### PR TITLE
Replace groups tip with specific idea category links

### DIFF
--- a/web/_includes/nibsy-widget.html
+++ b/web/_includes/nibsy-widget.html
@@ -716,7 +716,7 @@
     videos:  ["Grab some popcorn!", "Lots of videos to watch!", "See builds come to life!"],
     search:  ["Looking for something?", "I can help you find things!", "Let's find it together!"],
     about:   ["That's Kev! He made me!", "Learn about KevsRobots!", "The story behind the site!"],
-    groups:  ["Explore by category!", "Find topics you love!", "Discover new areas!"],
+    groups:  ["Great ideas in here!", "Find your next project!", "So much inspiration!"],
     gear:    ["Checking out the gear?", "Great tools for makers!", "Find the right equipment!"],
     other:   ["Exploring, are we?", "Nice find!", "Happy browsing!"]
   };
@@ -743,7 +743,14 @@
     { text: 'Need some robot inspiration?', html: 'Need some robot inspiration? <a href="/robots/">Get ideas</a>', duration: 5000 },
     { text: 'Have you seen the courses?', html: 'Have you seen the courses? <a href="/learn/">Take a look</a>', duration: 5000 },
     { text: 'Want to see what I can build?', html: 'Want to see what I can build? <a href="/all_videos">Watch a video</a>', duration: 5000 },
-    { text: 'Explore by category!', html: 'Explore by category! <a href="/groups/">Browse groups</a>', duration: 5000 }
+    { text: 'Interested in Arduino?', html: 'Interested in Arduino? <a href="/groups/arduino.html">Arduino ideas</a>', duration: 5000 },
+    { text: 'Love MicroPython?', html: 'Love MicroPython? <a href="/groups/micropython.html">MicroPython ideas</a>', duration: 5000 },
+    { text: 'Raspberry Pi projects!', html: 'Raspberry Pi projects! <a href="/groups/raspberrypi.html">Take a look</a>', duration: 5000 },
+    { text: 'Want to build a robot?', html: 'Want to build a robot? <a href="/groups/robots.html">Robot ideas</a>', duration: 5000 },
+    { text: 'Into 3D printing?', html: 'Into 3D printing? <a href="/groups/3dprinting.html">3D printing ideas</a>', duration: 5000 },
+    { text: 'Explore electronics!', html: 'Explore electronics! <a href="/groups/electronics.html">Electronics ideas</a>', duration: 5000 },
+    { text: 'Robot arms are cool!', html: 'Robot arms are cool! <a href="/groups/robotarms.html">Robot arm ideas</a>', duration: 5000 },
+    { text: 'Try some AI projects!', html: 'Try some AI projects! <a href="/groups/ai.html">AI ideas</a>', duration: 5000 }
   ];
 
   let lastTipIndex = -1;


### PR DESCRIPTION
## Summary
- Replaces the single generic "Browse groups" nav tip with 8 specific idea tips
- Links to: Arduino, MicroPython, Raspberry Pi, Robots, 3D Printing, Electronics, Robot Arms, AI
- Updates groups page context greeting to be idea-focused

## Test plan
- [ ] Cycle through tips with > button — should see Arduino, MicroPython, etc.
- [ ] Click a link — should go to the correct group page
- [ ] No more "Browse groups" tip should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)