### PR TITLE
Update idea tips to use /ideas/ paths, add Lego

### DIFF
--- a/web/_includes/nibsy-widget.html
+++ b/web/_includes/nibsy-widget.html
@@ -743,14 +743,15 @@
     { text: 'Need some robot inspiration?', html: 'Need some robot inspiration? <a href="/robots/">Get ideas</a>', duration: 5000 },
     { text: 'Have you seen the courses?', html: 'Have you seen the courses? <a href="/learn/">Take a look</a>', duration: 5000 },
     { text: 'Want to see what I can build?', html: 'Want to see what I can build? <a href="/all_videos">Watch a video</a>', duration: 5000 },
-    { text: 'Interested in Arduino?', html: 'Interested in Arduino? <a href="/groups/arduino.html">Arduino ideas</a>', duration: 5000 },
-    { text: 'Love MicroPython?', html: 'Love MicroPython? <a href="/groups/micropython.html">MicroPython ideas</a>', duration: 5000 },
-    { text: 'Raspberry Pi projects!', html: 'Raspberry Pi projects! <a href="/groups/raspberrypi.html">Take a look</a>', duration: 5000 },
-    { text: 'Want to build a robot?', html: 'Want to build a robot? <a href="/groups/robots.html">Robot ideas</a>', duration: 5000 },
-    { text: 'Into 3D printing?', html: 'Into 3D printing? <a href="/groups/3dprinting.html">3D printing ideas</a>', duration: 5000 },
-    { text: 'Explore electronics!', html: 'Explore electronics! <a href="/groups/electronics.html">Electronics ideas</a>', duration: 5000 },
-    { text: 'Robot arms are cool!', html: 'Robot arms are cool! <a href="/groups/robotarms.html">Robot arm ideas</a>', duration: 5000 },
-    { text: 'Try some AI projects!', html: 'Try some AI projects! <a href="/groups/ai.html">AI ideas</a>', duration: 5000 }
+    { text: 'Interested in Arduino?', html: 'Interested in Arduino? <a href="/ideas/arduino.html">Arduino ideas</a>', duration: 5000 },
+    { text: 'Love MicroPython?', html: 'Love MicroPython? <a href="/ideas/micropython.html">MicroPython ideas</a>', duration: 5000 },
+    { text: 'Raspberry Pi projects!', html: 'Raspberry Pi projects! <a href="/ideas/raspberrypi.html">Take a look</a>', duration: 5000 },
+    { text: 'Want to build a robot?', html: 'Want to build a robot? <a href="/ideas/robots.html">Robot ideas</a>', duration: 5000 },
+    { text: 'Into 3D printing?', html: 'Into 3D printing? <a href="/ideas/3dprinting.html">3D printing ideas</a>', duration: 5000 },
+    { text: 'Explore electronics!', html: 'Explore electronics! <a href="/ideas/electronics.html">Electronics ideas</a>', duration: 5000 },
+    { text: 'Robot arms are cool!', html: 'Robot arms are cool! <a href="/ideas/robotarms.html">Robot arm ideas</a>', duration: 5000 },
+    { text: 'Love Lego?', html: 'Love Lego? <a href="/ideas/lego.html">Lego ideas</a>', duration: 5000 },
+    { text: 'Try some AI projects!', html: 'Try some AI projects! <a href="/ideas/ai.html">AI ideas</a>', duration: 5000 }
   ];
 
   let lastTipIndex = -1;


### PR DESCRIPTION
## Summary
- Changes all idea category tip links from `/groups/` to `/ideas/`
- Adds a "Love Lego?" tip linking to `/ideas/lego.html`

## Test plan
- [ ] Cycle through tips — idea links should point to /ideas/ not /groups/
- [ ] Lego tip should appear in rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)