### PR TITLE
Nibsy API: scaffold FastAPI recommendation microservice

### DIFF
--- a/stacks/nibsy-api/.dockerignore
+++ b/stacks/nibsy-api/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+venv
+.env
+tests
+*.db
+*.sqlite
+*.sqlite3
+.git
+.gitignore
+README.md

--- a/stacks/nibsy-api/.gitignore
+++ b/stacks/nibsy-api/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+.env
+*.db
+*.sqlite
+*.sqlite3

--- a/stacks/nibsy-api/Dockerfile
+++ b/stacks/nibsy-api/Dockerfile
@@ -1,0 +1,24 @@
+# Mirrors search_app/dockerfile shape; uvicorn on port 8200 per #70.
+FROM python:3.12.1-slim
+
+WORKDIR /usr/src/app
+
+# Build deps for asyncpg + general C extensions. curl is needed for HEALTHCHECK.
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    gcc \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PORT=8200
+EXPOSE 8200
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://127.0.0.1:8200/health || exit 1
+
+CMD ["uvicorn", "nibsy_api.main:app", "--host", "0.0.0.0", "--port", "8200"]

--- a/stacks/nibsy-api/README.md
+++ b/stacks/nibsy-api/README.md
@@ -1,0 +1,98 @@
+# Nibsy API
+
+FastAPI microservice that powers the Nibsy recommendation widget on
+[kevsrobots.com](https://kevsrobots.com). It owns the content catalogue
+(courses, posts, videos, robots, reviews, glossary), the click/impression
+log, and the precomputed top-N recommendations table read by the widget.
+
+This PR scaffolds the foundation (issue #66) and adds the
+`nibsy_recommendations` table from #73a so the generator/reader can land
+in follow-up PRs without a schema migration.
+
+## Layout
+
+```
+stacks/nibsy-api/
+├── nibsy_api/        # FastAPI app
+├── tests/            # pytest + aiosqlite + fixtures
+├── Dockerfile        # python:3.12.1-slim, uvicorn on 8200
+├── docker-compose.yml
+└── requirements.txt
+```
+
+## Running locally
+
+```bash
+cd stacks/nibsy-api
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+export NIBSY_DATA_DIR="$(pwd)/../../web/_data"
+uvicorn nibsy_api.main:app --reload --port 8200
+```
+
+Then hit `http://127.0.0.1:8200/health`.
+
+To force an ingest run:
+
+```bash
+curl -X POST http://127.0.0.1:8200/api/admin/ingest
+```
+
+## Running tests
+
+```bash
+cd stacks/nibsy-api
+pip install -r requirements.txt
+pytest
+```
+
+Tests use `aiosqlite` (in-memory) and the bundled `tests/fixtures/_data/`
+sample YAML — no Postgres or production data needed.
+
+## Building the Docker image
+
+```bash
+cd stacks/nibsy-api
+docker build -t nibsy-api-local .
+```
+
+Or with compose (also brings up a local Postgres on host port 5434):
+
+```bash
+docker compose up --build
+```
+
+## Endpoints
+
+| Path | Status | Notes |
+|---|---|---|
+| `GET /health` | implemented | Returns `{status, content_count, recommendation_count}` |
+| `POST /api/admin/ingest` | implemented | Triggers a re-ingest from `NIBSY_DATA_DIR` |
+| `GET /api/recommendations` | 501 stub | Reader for `nibsy_recommendations` — lands in #67 |
+| `GET /api/trending` | 501 stub | #67 / #72 |
+| `GET /api/related/{content_id}` | 501 stub | #67 |
+| `POST /api/track/click` | 501 stub | #68 |
+| `POST /api/track/impression` | 501 stub | #68 |
+
+## Roadmap
+
+| Issue | Status | Summary |
+|---|---|---|
+| #66 | done (this PR) | FastAPI scaffold, schema, ingest, /health, admin ingest |
+| #67 | open | Recommendation read endpoints (`/recommendations`, `/related`, `/trending`) |
+| #68 | open | Click & impression tracking endpoints |
+| #69 | open | Production ingest pipeline / scheduled refresh |
+| #70 | open | Production deployment (docker-stack, swarm, port 8200) |
+| #71 | open | Widget integration on kevsrobots.com pages |
+| #72 | open | Trending-by-popularity algorithm |
+| #73 | open | Precomputed recommendations system (umbrella) |
+| #73a | partial (this PR) | Table added; generator + reader land next |
+| #73b | open | AI categorisation / smarter signals |
+
+## Conventions
+
+Mirrors `search_app/` where applicable:
+* Python 3.12 base image
+* `curl -f /health` healthcheck
+* No Alembic — `Base.metadata.create_all` on startup
+* Image pushed to `192.168.2.1:5000/nibsy-api:latest` (left to #70)

--- a/stacks/nibsy-api/docker-compose.yml
+++ b/stacks/nibsy-api/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+# Local development convenience only.
+# Production deployment (#70) ships its own docker-stack.yml with the
+# 192.168.2.1:5000/nibsy-api:latest image — that is NOT included here.
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: nibsy
+      POSTGRES_PASSWORD: nibsy
+      POSTGRES_DB: nibsy
+    ports:
+      - "5434:5432"
+    volumes:
+      - nibsy_pg_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  nibsy-api:
+    build: .
+    depends_on:
+      - postgres
+    ports:
+      - "8200:8200"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://nibsy:nibsy@postgres:5432/nibsy
+      NIBSY_DATA_DIR: /usr/src/app/_data
+      PORT: 8200
+    volumes:
+      - .:/usr/src/app
+      - ../../web/_data:/usr/src/app/_data:ro
+    restart: unless-stopped
+
+volumes:
+  nibsy_pg_data:

--- a/stacks/nibsy-api/nibsy_api/__init__.py
+++ b/stacks/nibsy-api/nibsy_api/__init__.py
@@ -1,0 +1,3 @@
+"""Nibsy API — FastAPI recommendation microservice for kevsrobots.com."""
+
+__version__ = "0.1.0"

--- a/stacks/nibsy-api/nibsy_api/config.py
+++ b/stacks/nibsy-api/nibsy_api/config.py
@@ -1,0 +1,43 @@
+"""Application configuration via pydantic-settings.
+
+Reads from environment variables and an optional `.env` file. Defaults are
+suitable for local development against the docker-compose Postgres.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # SQLAlchemy async URL. Falls back to local aiosqlite for cheap dev/test.
+    # Production (see #70) will override to asyncpg against 192.168.2.1:5433.
+    database_url: str = "sqlite+aiosqlite:///./nibsy.db"
+
+    # Path to a directory containing the YAML data files. If set and the
+    # `nibsy_content` table is empty on startup, ingestion runs automatically.
+    nibsy_data_dir: Optional[Path] = None
+
+    # Service port — #70 standardises on 8200.
+    port: int = 8200
+
+
+def get_settings() -> Settings:
+    """Return a fresh Settings instance.
+
+    Kept as a callable so tests can monkeypatch the environment before
+    instantiating, and so FastAPI dependency overrides work cleanly.
+    """
+
+    return Settings()

--- a/stacks/nibsy-api/nibsy_api/db.py
+++ b/stacks/nibsy-api/nibsy_api/db.py
@@ -1,0 +1,82 @@
+"""Async SQLAlchemy engine, session factory, and declarative Base.
+
+Peer services in this repo use sync SQLAlchemy (see `pagecount/`), but the
+Nibsy API is greenfield so we adopt the async stack from the outset to keep
+the FastAPI handlers non-blocking.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+from .config import get_settings
+
+
+class Base(DeclarativeBase):
+    """Declarative base for all ORM models."""
+
+
+_engine: AsyncEngine | None = None
+_sessionmaker: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine() -> AsyncEngine:
+    """Lazily build and cache the global async engine."""
+
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        _engine = create_async_engine(settings.database_url, future=True)
+    return _engine
+
+
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    """Lazily build and cache the global async sessionmaker."""
+
+    global _sessionmaker
+    if _sessionmaker is None:
+        _sessionmaker = async_sessionmaker(
+            bind=get_engine(),
+            expire_on_commit=False,
+            class_=AsyncSession,
+        )
+    return _sessionmaker
+
+
+def reset_engine() -> None:
+    """Drop the cached engine/sessionmaker.
+
+    Used by tests to swap database URLs between fixtures.
+    """
+
+    global _engine, _sessionmaker
+    _engine = None
+    _sessionmaker = None
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency yielding an `AsyncSession` per request."""
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        yield session
+
+
+async def create_all() -> None:
+    """Create every registered table. Mirrors peer services that skip Alembic."""
+
+    # Importing models registers them on Base.metadata. The import is local
+    # to avoid a circular dependency at module load time.
+    from . import models  # noqa: F401
+
+    engine = get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/stacks/nibsy-api/nibsy_api/ingest.py
+++ b/stacks/nibsy-api/nibsy_api/ingest.py
@@ -1,0 +1,381 @@
+"""YAML data ingestion.
+
+Reads the canonical YAML files under `web/_data/` (or a fixtures directory in
+tests) and upserts them into `nibsy_content`. Each YAML file has its own
+quirks — see the per-file handlers below — but the output schema is uniform.
+
+Upsert key is `nibsy_content.url`. Rows are compared field-by-field; identical
+rows are counted as "unchanged" so we can prove idempotency.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import NibsyContent
+from .schemas import IngestStats
+
+logger = logging.getLogger(__name__)
+
+
+# --- Normalisation helpers -------------------------------------------------
+
+
+def _slugify(text: str) -> str:
+    """Turn arbitrary text into a stable URL slug."""
+
+    text = text.strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
+
+def _parse_date(value: Any) -> Optional[datetime]:
+    """Best-effort coercion of a YAML date/string into a datetime."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day)
+    if isinstance(value, str):
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%Y-%m-%dT%H:%M:%S"):
+            try:
+                return datetime.strptime(value, fmt)
+            except ValueError:
+                continue
+    return None
+
+
+def _load_yaml(path: Path) -> Any:
+    """Read a YAML file, returning `None` if missing."""
+
+    if not path.exists():
+        logger.info("ingest: %s not found — skipping", path.name)
+        return None
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+# --- Per-file row builders -------------------------------------------------
+
+
+def _rows_from_courses(data: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for entry in data or []:
+        link = entry.get("link")
+        name = entry.get("name")
+        if not link or not name:
+            continue
+        rows.append(
+            {
+                "content_type": "course",
+                "title": name,
+                "url": link,
+                "description": entry.get("description"),
+                "tags": entry.get("groups") or [],
+                "date_published": _parse_date(entry.get("date_published")),
+                "content_metadata": {
+                    "author": entry.get("author"),
+                    "cover": entry.get("cover"),
+                    "duration": entry.get("duration"),
+                },
+            }
+        )
+    return rows
+
+
+def _rows_from_posts(data: Any) -> list[dict[str, Any]]:
+    # posts.yaml is dict-wrapped: {posts: [...]} — issue body missed this.
+    if isinstance(data, dict):
+        items = data.get("posts") or []
+    else:
+        items = data or []
+    rows: list[dict[str, Any]] = []
+    for entry in items:
+        url = entry.get("url")
+        title = entry.get("title")
+        if not url or not title:
+            continue
+        rows.append(
+            {
+                "content_type": "post",
+                "title": title,
+                "url": url,
+                "description": None,
+                "tags": [],
+                "date_published": _parse_date(entry.get("date")),
+                "content_metadata": {},
+            }
+        )
+    return rows
+
+
+def _rows_from_youtube(data: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for entry in data or []:
+        video_id = entry.get("video_id")
+        title = entry.get("title")
+        if not video_id or not title:
+            continue
+        # youtube.yml has no native URL — synthesise one for the upsert key.
+        url = f"https://youtube.com/watch?v={video_id}"
+        rows.append(
+            {
+                "content_type": "video",
+                "title": title,
+                "url": url,
+                "description": None,
+                "tags": [t for t in (entry.get("type"), entry.get("strategy")) if t],
+                "date_published": _parse_date(entry.get("published")),
+                "content_metadata": {
+                    "video_id": video_id,
+                    "type": entry.get("type"),
+                    "strategy": entry.get("strategy"),
+                },
+            }
+        )
+    return rows
+
+
+def _rows_from_robots(data: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for entry in data or []:
+        link = entry.get("link")
+        name = entry.get("name")
+        if not link or not name:
+            continue
+        rows.append(
+            {
+                "content_type": "robot",
+                "title": name,
+                "url": link,
+                "description": entry.get("description"),
+                "tags": [],
+                "date_published": _parse_date(entry.get("date")),
+                "content_metadata": {
+                    "cover": entry.get("cover"),
+                    "hero": entry.get("hero"),
+                },
+            }
+        )
+    return rows
+
+
+def _rows_from_reviews(data: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for entry in data or []:
+        title = entry.get("title")
+        excerpt = entry.get("excerpt")
+        link = entry.get("link")
+        # Skip placeholder rows per brief: `excerpt: null` or `title: title`.
+        if excerpt is None or title == "title" or not link or not title:
+            continue
+        rows.append(
+            {
+                "content_type": "review",
+                "title": title,
+                "url": link,
+                "description": excerpt,
+                "tags": [],
+                "date_published": _parse_date(entry.get("date")),
+                "content_metadata": {
+                    "author": entry.get("author"),
+                    "cover": entry.get("cover"),
+                    "rating": entry.get("rating"),
+                    "transparency": entry.get("transparency"),
+                },
+            }
+        )
+    return rows
+
+
+def _rows_from_glossary(data: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for entry in data or []:
+        term = entry.get("term")
+        if not term:
+            continue
+        # `link` is external — synthesise a site-relative URL from the term
+        # slug so the upsert key is stable across edits.
+        url = f"/glossary/{_slugify(term)}"
+        rows.append(
+            {
+                "content_type": "glossary",
+                "title": term,
+                "url": url,
+                "description": entry.get("definition") or entry.get("full"),
+                "tags": [],
+                "date_published": None,
+                "content_metadata": {
+                    "full": entry.get("full"),
+                    "external_link": entry.get("link"),
+                    "course": entry.get("course"),
+                    "article": entry.get("article"),
+                },
+            }
+        )
+    return rows
+
+
+# --- Upsert --------------------------------------------------------------
+
+
+_TRACKED_FIELDS = (
+    "content_type",
+    "title",
+    "description",
+    "tags",
+    "date_published",
+    "content_metadata",
+)
+
+
+async def _upsert_row(
+    session: AsyncSession, row: dict[str, Any], stats: IngestStats
+) -> Optional[NibsyContent]:
+    """Insert/update a single row keyed by `url`. Returns the persisted row."""
+
+    existing = await session.scalar(
+        select(NibsyContent).where(NibsyContent.url == row["url"])
+    )
+    if existing is None:
+        obj = NibsyContent(**row)
+        session.add(obj)
+        stats.added += 1
+        return obj
+
+    changed = False
+    for field in _TRACKED_FIELDS:
+        new_value = row.get(field)
+        if field == "content_metadata":
+            # Merge rather than replace so per-file augmentations (e.g.
+            # popular_videos.yaml stats merged into youtube rows) survive
+            # subsequent re-ingests of the primary file.
+            existing_meta = dict(getattr(existing, field) or {})
+            incoming_meta = dict(new_value or {})
+            merged = {**existing_meta, **incoming_meta}
+            if merged != existing_meta:
+                setattr(existing, field, merged)
+                changed = True
+            continue
+        if getattr(existing, field) != new_value:
+            setattr(existing, field, new_value)
+            changed = True
+    if changed:
+        existing.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        stats.updated += 1
+    else:
+        stats.unchanged += 1
+    return existing
+
+
+async def _merge_popular_videos(
+    data: Iterable[dict[str, Any]], session: AsyncSession, stats: IngestStats
+) -> None:
+    """Merge popular-video stats into existing video rows.
+
+    Per brief: do NOT create new content rows. Look up by synthesised
+    YouTube URL and merge `{views, popular}` into `metadata`.
+    """
+
+    for entry in data or []:
+        video_id = entry.get("Content")
+        if not video_id:
+            continue
+        url = f"https://youtube.com/watch?v={video_id}"
+        existing = await session.scalar(
+            select(NibsyContent).where(NibsyContent.url == url)
+        )
+        if existing is None:
+            # No matching video — skip rather than invent a content row.
+            stats.skipped += 1
+            continue
+        before = dict(existing.content_metadata or {})
+        meta = dict(before)
+        meta["views"] = entry.get("Views")
+        meta["views_str"] = entry.get("views_str")
+        meta["popular"] = bool(entry.get("popular"))
+        if meta == before:
+            stats.unchanged += 1
+            continue
+        existing.content_metadata = meta
+        existing.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        stats.updated += 1
+
+
+# --- Public entrypoint ---------------------------------------------------
+
+
+_FILE_HANDLERS: dict[str, Any] = {
+    "courses.yml": _rows_from_courses,
+    "posts.yaml": _rows_from_posts,
+    "youtube.yml": _rows_from_youtube,
+    "robots.yml": _rows_from_robots,
+    "reviews.yml": _rows_from_reviews,
+    "glossary.yml": _rows_from_glossary,
+}
+
+
+async def ingest_from_data_dir(
+    path: Path, session: AsyncSession
+) -> IngestStats:
+    """Read all known YAML files in `path`, upsert into `nibsy_content`.
+
+    `popular_videos.yaml` is handled separately: it merges into existing
+    video rows rather than creating its own content rows.
+    """
+
+    stats = IngestStats()
+    path = Path(path)
+
+    if not path.exists() or not path.is_dir():
+        stats.errors += 1
+        stats.error_details.append(f"data dir not found: {path}")
+        return stats
+
+    # Pass 1 — the row-producing files.
+    for filename, handler in _FILE_HANDLERS.items():
+        file_path = path / filename
+        try:
+            data = _load_yaml(file_path)
+        except yaml.YAMLError as exc:  # malformed YAML
+            stats.errors += 1
+            stats.error_details.append(f"{filename}: {exc}")
+            continue
+        if data is None:
+            continue
+        stats.files_processed.append(filename)
+        rows = handler(data)
+        for row in rows:
+            try:
+                await _upsert_row(session, row, stats)
+            except Exception as exc:  # noqa: BLE001 — log + continue
+                stats.errors += 1
+                stats.error_details.append(f"{filename} {row.get('url')}: {exc}")
+
+    # Flush so popular_videos merging sees freshly-inserted youtube rows.
+    await session.flush()
+
+    # Pass 2 — popular_videos.yaml merges metadata only.
+    pop_path = path / "popular_videos.yaml"
+    try:
+        pop_data = _load_yaml(pop_path)
+    except yaml.YAMLError as exc:
+        stats.errors += 1
+        stats.error_details.append(f"popular_videos.yaml: {exc}")
+        pop_data = None
+    if pop_data is not None:
+        stats.files_processed.append("popular_videos.yaml")
+        await _merge_popular_videos(pop_data, session, stats)
+
+    await session.commit()
+    return stats

--- a/stacks/nibsy-api/nibsy_api/main.py
+++ b/stacks/nibsy-api/nibsy_api/main.py
@@ -1,0 +1,64 @@
+"""FastAPI application entrypoint.
+
+Builds the app, wires routers, and runs an auto-ingest on startup if the
+content table is empty and `NIBSY_DATA_DIR` is configured.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from fastapi import FastAPI
+from sqlalchemy import func, select
+
+from .config import get_settings
+from .db import create_all, get_sessionmaker
+from .ingest import ingest_from_data_dir
+from .models import NibsyContent
+from .routers import admin, health, stubs
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Create tables and optionally run a first-time ingest."""
+
+    await create_all()
+
+    settings = get_settings()
+    data_dir = settings.nibsy_data_dir
+    if data_dir is not None and data_dir.exists() and data_dir.is_dir():
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            count = await session.scalar(select(func.count()).select_from(NibsyContent))
+            if not count:
+                logger.info("nibsy_content is empty — running startup ingest from %s", data_dir)
+                stats = await ingest_from_data_dir(data_dir, session)
+                logger.info("startup ingest finished: %s", stats.model_dump())
+            else:
+                logger.info("nibsy_content already has %s rows — skipping startup ingest", count)
+    else:
+        logger.info("NIBSY_DATA_DIR not configured or missing — skipping startup ingest")
+
+    yield
+
+
+def create_app() -> FastAPI:
+    """Application factory."""
+
+    app = FastAPI(
+        title="Nibsy API",
+        description="Recommendation microservice for kevsrobots.com",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.include_router(health.router)
+    app.include_router(admin.router)
+    app.include_router(stubs.router)
+    return app
+
+
+app = create_app()

--- a/stacks/nibsy-api/nibsy_api/models.py
+++ b/stacks/nibsy-api/nibsy_api/models.py
@@ -1,0 +1,119 @@
+"""SQLAlchemy models for the Nibsy API.
+
+Schema covers issue #66 (content, clicks, impressions) and adds the
+precomputed recommendations table from #73a so we land both at once and
+avoid a follow-up migration.
+
+The Postgres-flavoured columns (`ARRAY`, `JSONB`) fall back to portable
+SQLite-friendly types when the engine is SQLite. This lets the pytest
+suite run on `aiosqlite` without a real Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+from .db import Base
+
+
+# Use JSONB on Postgres, plain JSON elsewhere (SQLite for tests).
+JsonType = JSONB().with_variant(JSON(), "sqlite")
+# Use Postgres TEXT[] on Postgres, JSON-encoded list on SQLite.
+TagsType = ARRAY(Text).with_variant(JSON(), "sqlite")
+
+
+class NibsyContent(Base):
+    """A piece of content (course, post, video, robot, review, glossary term)."""
+
+    __tablename__ = "nibsy_content"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    content_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    # URL is the natural upsert key — UNIQUE so `INSERT ... ON CONFLICT` keys cleanly.
+    url: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    tags: Mapped[Optional[list[str]]] = mapped_column(TagsType)
+    date_published: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    content_metadata: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        "metadata", JsonType
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+
+class NibsyClick(Base):
+    """A click on a recommended item (populated by #68's tracking endpoint)."""
+
+    __tablename__ = "nibsy_clicks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    content_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("nibsy_content.id", ondelete="SET NULL")
+    )
+    content_url: Mapped[str] = mapped_column(Text, nullable=False)
+    source_page: Mapped[str] = mapped_column(Text, nullable=False)
+    session_id: Mapped[Optional[str]] = mapped_column(String(100))
+    ip_address: Mapped[Optional[str]] = mapped_column(String(45))
+    user_agent: Mapped[Optional[str]] = mapped_column(Text)
+    clicked_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+
+class NibsyImpression(Base):
+    """An impression of a recommendation card (populated by #68)."""
+
+    __tablename__ = "nibsy_impressions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    content_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("nibsy_content.id", ondelete="SET NULL")
+    )
+    source_page: Mapped[str] = mapped_column(Text, nullable=False)
+    session_id: Mapped[Optional[str]] = mapped_column(String(100))
+    shown_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+
+class NibsyRecommendation(Base):
+    """Precomputed top-N recommendations per source URL (#73a).
+
+    The generator job (#73a/#73b) populates this offline; the read path
+    (#67) reads from it. Neither is in scope for this PR — only the table
+    lands here so the next PRs can write/read without a migration.
+    """
+
+    __tablename__ = "nibsy_recommendations"
+
+    # The page being read — primary key so upserts replace in place.
+    source_url: Mapped[str] = mapped_column(Text, primary_key=True)
+    # Ordered array of {content_id, url, title, type, reason}
+    recommendations: Mapped[list[dict[str, Any]]] = mapped_column(
+        JsonType, nullable=False
+    )
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    # Bump when the algorithm changes so consumers can invalidate caches.
+    generator_version: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="v0"
+    )

--- a/stacks/nibsy-api/nibsy_api/routers/__init__.py
+++ b/stacks/nibsy-api/nibsy_api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI routers for the Nibsy API."""

--- a/stacks/nibsy-api/nibsy_api/routers/admin.py
+++ b/stacks/nibsy-api/nibsy_api/routers/admin.py
@@ -1,0 +1,34 @@
+"""Administrative endpoints (manual ingest trigger)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import get_settings
+from ..db import get_session
+from ..ingest import ingest_from_data_dir
+from ..schemas import IngestStats
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+@router.post("/ingest", response_model=IngestStats)
+async def trigger_ingest(
+    session: AsyncSession = Depends(get_session),
+) -> IngestStats:
+    """Trigger a manual ingestion from `NIBSY_DATA_DIR`.
+
+    The startup hook also runs ingestion automatically when the content
+    table is empty; this endpoint is for re-runs after the YAML changes.
+    Production deployment (#69) will eventually replace this with a
+    scheduled job.
+    """
+
+    settings = get_settings()
+    if settings.nibsy_data_dir is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="NIBSY_DATA_DIR is not configured",
+        )
+    return await ingest_from_data_dir(settings.nibsy_data_dir, session)

--- a/stacks/nibsy-api/nibsy_api/routers/health.py
+++ b/stacks/nibsy-api/nibsy_api/routers/health.py
@@ -1,0 +1,33 @@
+"""Health-check router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_session
+from ..models import NibsyContent, NibsyRecommendation
+from ..schemas import HealthResponse
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health(session: AsyncSession = Depends(get_session)) -> HealthResponse:
+    """Liveness/readiness probe.
+
+    Returns the row counts of the two tables we actually care about so the
+    Docker healthcheck and any external monitor can tell the service has a
+    populated database, not just that it can serve a 200.
+    """
+
+    content_count = await session.scalar(select(func.count()).select_from(NibsyContent))
+    recommendation_count = await session.scalar(
+        select(func.count()).select_from(NibsyRecommendation)
+    )
+    return HealthResponse(
+        status="ok",
+        content_count=int(content_count or 0),
+        recommendation_count=int(recommendation_count or 0),
+    )

--- a/stacks/nibsy-api/nibsy_api/routers/stubs.py
+++ b/stacks/nibsy-api/nibsy_api/routers/stubs.py
@@ -1,0 +1,56 @@
+"""501 stubs for endpoints deferred to follow-up PRs.
+
+Each route returns HTTP 501 Not Implemented and points to the GitHub issue
+that will land it. Returning 501 (rather than letting FastAPI 404) means
+the widget integration (#71) gets a clear signal during early integration.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+router = APIRouter(prefix="/api", tags=["stubs"])
+
+
+def _not_implemented(issue: str) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=f"Not implemented — see {issue}",
+    )
+
+
+@router.get("/recommendations")
+async def get_recommendations() -> None:
+    """Read precomputed recs out of `nibsy_recommendations` (see #67 / #73a)."""
+
+    # The table exists (added in this PR for #73a) but the read path itself
+    # lands in #67, and the generator that populates it lands in #73a/#73b.
+    _not_implemented("#67 / #73a")
+
+
+@router.get("/trending")
+async def get_trending() -> None:
+    """Trending-by-clicks endpoint — see #67 / #72."""
+
+    _not_implemented("#67 / #72")
+
+
+@router.get("/related/{content_id}")
+async def get_related(content_id: int) -> None:
+    """Related items for a given content row — see #67."""
+
+    _not_implemented("#67")
+
+
+@router.post("/track/click")
+async def track_click() -> None:
+    """Click-tracking ingress — see #68."""
+
+    _not_implemented("#68")
+
+
+@router.post("/track/impression")
+async def track_impression() -> None:
+    """Impression-tracking ingress — see #68."""
+
+    _not_implemented("#68")

--- a/stacks/nibsy-api/nibsy_api/schemas.py
+++ b/stacks/nibsy-api/nibsy_api/schemas.py
@@ -1,0 +1,25 @@
+"""Pydantic response models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    """Payload returned by `GET /health`."""
+
+    status: str = "ok"
+    content_count: int = 0
+    recommendation_count: int = 0
+
+
+class IngestStats(BaseModel):
+    """Outcome of an ingestion run."""
+
+    added: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    skipped: int = 0
+    errors: int = 0
+    files_processed: list[str] = Field(default_factory=list)
+    error_details: list[str] = Field(default_factory=list)

--- a/stacks/nibsy-api/pytest.ini
+++ b/stacks/nibsy-api/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/stacks/nibsy-api/requirements.txt
+++ b/stacks/nibsy-api/requirements.txt
@@ -1,0 +1,12 @@
+fastapi
+uvicorn[standard]
+sqlalchemy[asyncio]
+asyncpg
+aiosqlite
+pydantic
+pydantic-settings
+pyyaml
+python-dotenv
+httpx
+pytest
+pytest-asyncio

--- a/stacks/nibsy-api/tests/conftest.py
+++ b/stacks/nibsy-api/tests/conftest.py
@@ -1,0 +1,104 @@
+"""Shared pytest fixtures.
+
+Each test gets a fresh in-memory aiosqlite database so they cannot leak
+state into each other. We monkeypatch the settings before constructing the
+engine, then build the FastAPI app and override `get_session` to use the
+test sessionmaker.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+# Make `nibsy_api` importable when pytest is invoked from this directory.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+FIXTURES_DIR = ROOT / "tests" / "fixtures" / "_data"
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point every test at the fixtures dir and an isolated DB URL."""
+
+    monkeypatch.setenv("NIBSY_DATA_DIR", str(FIXTURES_DIR))
+    # Unique in-memory DB per worker; the fixture below overrides the engine.
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+
+@pytest_asyncio.fixture
+async def engine():
+    """Fresh in-memory engine per test."""
+
+    eng = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", future=True
+    )
+    # Import after env is set so any module-level config picks it up.
+    from nibsy_api import db as db_module
+    from nibsy_api import models  # noqa: F401 — registers tables on Base.metadata
+
+    async with eng.begin() as conn:
+        await conn.run_sync(db_module.Base.metadata.create_all)
+
+    yield eng
+
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def sessionmaker_(engine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@pytest_asyncio.fixture
+async def session(sessionmaker_) -> AsyncIterator[AsyncSession]:
+    async with sessionmaker_() as s:
+        yield s
+
+
+@pytest_asyncio.fixture
+async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
+    """ASGI test client with `get_session` and `create_all` overridden."""
+
+    from nibsy_api import db as db_module
+    from nibsy_api.main import create_app
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with sessionmaker_() as s:
+            yield s
+
+    async def _noop_create_all() -> None:
+        # Tables are already created by the `engine` fixture.
+        return None
+
+    # Patch create_all so lifespan doesn't try to talk to the global engine.
+    original_create_all = db_module.create_all
+    db_module.create_all = _noop_create_all
+    # Patch the sessionmaker the lifespan uses so startup ingest writes to
+    # the same in-memory DB our overridden dependency reads from.
+    original_get_sessionmaker = db_module.get_sessionmaker
+    db_module.get_sessionmaker = lambda: sessionmaker_
+
+    app = create_app()
+    app.dependency_overrides[db_module.get_session] = _override_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # Trigger lifespan startup so the auto-ingest fires.
+        async with app.router.lifespan_context(app):
+            yield ac
+
+    db_module.create_all = original_create_all
+    db_module.get_sessionmaker = original_get_sessionmaker

--- a/stacks/nibsy-api/tests/fixtures/_data/courses.yml
+++ b/stacks/nibsy-api/tests/fixtures/_data/courses.yml
@@ -1,0 +1,28 @@
+- author: Kevin McAleer
+  cover: /learn/example/cover.jpg
+  date_published: 2025-01-01
+  description: An example fixture course used by the Nibsy API test suite.
+  duration: 1h 00m
+  groups:
+  - micropython
+  - testing
+  link: /learn/example/00_intro.html
+  name: Example Test Course
+- author: Kevin McAleer
+  cover: /learn/another/cover.jpg
+  date_published: 2024-06-15
+  description: A second fixture course.
+  duration: 0h 45m
+  groups:
+  - robotics
+  link: /learn/another/00_intro.html
+  name: Another Test Course
+- author: Kevin McAleer
+  cover: /learn/third/cover.jpg
+  date_published: 2023-11-30
+  description: A third fixture course.
+  duration: 2h 15m
+  groups:
+  - python
+  link: /learn/third/00_intro.html
+  name: Third Test Course

--- a/stacks/nibsy-api/tests/fixtures/_data/glossary.yml
+++ b/stacks/nibsy-api/tests/fixtures/_data/glossary.yml
@@ -1,0 +1,14 @@
+- term: test-term-one
+  definition: A first fixture glossary term.
+  full: "A longer description of the first fixture glossary term."
+  link: https://example.com/glossary/test-term-one
+  article: /resources/how_it_works/test-term-one
+- term: test-term-two
+  definition: A second fixture glossary term.
+  full: "A longer description of the second fixture glossary term."
+  link: https://example.com/glossary/test-term-two
+- term: test-term-three
+  definition: A third fixture glossary term.
+  full: "A longer description of the third fixture glossary term."
+  link: https://example.com/glossary/test-term-three
+  course: /learn/test-course

--- a/stacks/nibsy-api/tests/fixtures/_data/popular_videos.yaml
+++ b/stacks/nibsy-api/tests/fixtures/_data/popular_videos.yaml
@@ -1,0 +1,15 @@
+- Content: "TEST_VIDEO_ID_1"
+  Views: 12345
+  popular: True
+  title: "Example Test Video"
+  views_str: "12,345"
+- Content: "TEST_VIDEO_ID_2"
+  Views: 6789
+  popular: True
+  title: "Second Test Video"
+  views_str: "6,789"
+- Content: "TEST_VIDEO_ID_MISSING"
+  Views: 9999
+  popular: True
+  title: "This video should not match anything"
+  views_str: "9,999"

--- a/stacks/nibsy-api/tests/fixtures/_data/posts.yaml
+++ b/stacks/nibsy-api/tests/fixtures/_data/posts.yaml
@@ -1,0 +1,10 @@
+posts:
+- title: Example Test Post
+  url: /2025-01-01-example.md
+  date: 2025-01-01
+- title: Second Test Post
+  url: /2025-02-01-second.md
+  date: 2025-02-01
+- title: Third Test Post
+  url: /2025-03-01-third.md
+  date: 2025-03-01

--- a/stacks/nibsy-api/tests/fixtures/_data/reviews.yml
+++ b/stacks/nibsy-api/tests/fixtures/_data/reviews.yml
@@ -1,0 +1,27 @@
+- author: Kevin McAleer
+  cover: /assets/img/reviews/example.jpg
+  date: 2025-01-01
+  excerpt: A good example review for the test suite.
+  layout: review
+  link: https://example.com/products/example
+  rating: 4.5
+  title: Example Test Review
+  transparency:
+  - "\U0001F381"
+- author: Kevin McAleer
+  cover: /assets/img/reviews/placeholder.jpg
+  date: 2025-01-02
+  excerpt: null
+  layout: review
+  link: https://example.com/products/placeholder
+  rating: 0
+  title: title
+- author: Kevin McAleer
+  cover: /assets/img/reviews/second.jpg
+  date: 2025-02-01
+  excerpt: A second review that should ingest cleanly.
+  layout: review
+  link: https://example.com/products/second
+  rating: 4.0
+  title: Second Test Review
+  transparency:

--- a/stacks/nibsy-api/tests/fixtures/_data/robots.yml
+++ b/stacks/nibsy-api/tests/fixtures/_data/robots.yml
@@ -1,0 +1,18 @@
+- name: Example Test Robot
+  link: /projects/example-robot/
+  cover: /assets/img/projects/example-robot/cover.jpg
+  description: A fixture robot used by the Nibsy API test suite.
+  date: 2025/01/01
+  hero: /assets/img/projects/example-robot/hero.png
+- name: Second Test Robot
+  link: /projects/second-robot/
+  cover: /assets/img/projects/second-robot/cover.jpg
+  description: A second fixture robot.
+  date: 2024/06/15
+  hero: /assets/img/projects/second-robot/hero.png
+- name: Third Test Robot
+  link: /projects/third-robot/
+  cover: /assets/img/projects/third-robot/cover.jpg
+  description: A third fixture robot.
+  date: 2023/11/30
+  hero: /assets/img/projects/third-robot/hero.png

--- a/stacks/nibsy-api/tests/fixtures/_data/youtube.yml
+++ b/stacks/nibsy-api/tests/fixtures/_data/youtube.yml
@@ -1,0 +1,15 @@
+- published: 2025/01/15
+  title: "Example Test Video"
+  video_id: TEST_VIDEO_ID_1
+  type: video
+  strategy: hero
+- published: 2025/02/15
+  title: "Second Test Video"
+  video_id: TEST_VIDEO_ID_2
+  type: livestream
+  strategy: home
+- published: 2025/03/15
+  title: "Third Test Video"
+  video_id: TEST_VIDEO_ID_3
+  type: video
+  strategy: help

--- a/stacks/nibsy-api/tests/test_health.py
+++ b/stacks/nibsy-api/tests/test_health.py
@@ -1,0 +1,19 @@
+"""Health endpoint smoke tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_health_ok(client) -> None:
+    """`GET /health` returns 200 with the expected JSON shape."""
+
+    response = await client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "content_count" in body
+    assert "recommendation_count" in body
+    assert isinstance(body["content_count"], int)
+    assert isinstance(body["recommendation_count"], int)

--- a/stacks/nibsy-api/tests/test_ingest.py
+++ b/stacks/nibsy-api/tests/test_ingest.py
@@ -1,0 +1,107 @@
+"""Ingestion tests against the fixtures directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from nibsy_api.ingest import ingest_from_data_dir
+from nibsy_api.models import NibsyContent
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "_data"
+
+
+@pytest.mark.asyncio
+async def test_ingest_populates_content(session) -> None:
+    """A first ingest should add rows for every fixture entry."""
+
+    stats = await ingest_from_data_dir(FIXTURES, session)
+
+    assert stats.errors == 0, stats.error_details
+    # 3 courses + 3 posts + 3 youtube + 3 robots + 2 reviews (one is skipped) + 3 glossary = 17
+    assert stats.added == 17
+    assert stats.updated >= 2  # popular_videos merges into 2 of the 3 youtube rows
+
+    rows = (await session.scalars(select(NibsyContent))).all()
+    urls = {r.url for r in rows}
+
+    assert "/learn/example/00_intro.html" in urls
+    assert "/2025-01-01-example.md" in urls
+    assert "https://youtube.com/watch?v=TEST_VIDEO_ID_1" in urls
+    assert "/projects/example-robot/" in urls
+    assert "https://example.com/products/example" in urls
+    assert "/glossary/test-term-one" in urls
+
+
+@pytest.mark.asyncio
+async def test_ingest_idempotent(session) -> None:
+    """Re-running ingest with no source changes should report all unchanged."""
+
+    first = await ingest_from_data_dir(FIXTURES, session)
+    assert first.errors == 0
+
+    second = await ingest_from_data_dir(FIXTURES, session)
+    assert second.errors == 0
+    assert second.added == 0
+    # All youtube rows already have popular_videos metadata applied, so they
+    # come back as unchanged on the second pass too.
+    assert second.updated == 0
+    assert second.unchanged > 0
+
+
+@pytest.mark.asyncio
+async def test_popular_videos_merges_metadata(session) -> None:
+    """popular_videos.yaml updates existing video metadata, doesn't create rows."""
+
+    await ingest_from_data_dir(FIXTURES, session)
+
+    # The synthesised YouTube URL is the upsert key.
+    row = await session.scalar(
+        select(NibsyContent).where(
+            NibsyContent.url == "https://youtube.com/watch?v=TEST_VIDEO_ID_1"
+        )
+    )
+    assert row is not None
+    meta = row.content_metadata or {}
+    assert meta.get("views") == 12345
+    assert meta.get("popular") is True
+    assert meta.get("video_id") == "TEST_VIDEO_ID_1"
+
+    # The popular_videos.yaml entry with id TEST_VIDEO_ID_MISSING must NOT
+    # have spawned a new content row.
+    missing = await session.scalar(
+        select(NibsyContent).where(
+            NibsyContent.url == "https://youtube.com/watch?v=TEST_VIDEO_ID_MISSING"
+        )
+    )
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_reviews_placeholder_skipped(session) -> None:
+    """Reviews with `excerpt: null` or `title: title` should be skipped."""
+
+    await ingest_from_data_dir(FIXTURES, session)
+    placeholder = await session.scalar(
+        select(NibsyContent).where(
+            NibsyContent.url == "https://example.com/products/placeholder"
+        )
+    )
+    assert placeholder is None
+
+
+@pytest.mark.asyncio
+async def test_stubs_return_501(client) -> None:
+    """Unimplemented routes should return 501, not 404."""
+
+    for method, path in [
+        ("GET", "/api/recommendations"),
+        ("GET", "/api/trending"),
+        ("GET", "/api/related/1"),
+        ("POST", "/api/track/click"),
+        ("POST", "/api/track/impression"),
+    ]:
+        response = await client.request(method, path)
+        assert response.status_code == 501, f"{method} {path} returned {response.status_code}"


### PR DESCRIPTION
Closes #66. Also adds the `nibsy_recommendations` table schema for #74 so we land both at once and avoid a follow-up migration.

## What's in this PR

A new FastAPI microservice at `stacks/nibsy-api/` that will power the Nibsy recommendation widget. This PR is the **foundation only** — recommendation logic, tracking, deployment, and widget integration are all explicitly deferred to their own follow-up issues.

### Code
- FastAPI app with async SQLAlchemy 2.x + asyncpg, pydantic v2
- Four tables: `nibsy_content`, `nibsy_clicks`, `nibsy_impressions`, `nibsy_recommendations`
- Cross-platform models: Postgres `JSONB`/`TEXT[]` with SQLite `JSON` fallback for the test path
- Implemented endpoints: `GET /health`, `POST /api/admin/ingest`
- 501 stubs for `/api/recommendations`, `/trending`, `/related`, `/track/click`, `/track/impression` — comments in `routers/stubs.py` point to the follow-up issue for each
- YAML ingestion across all 7 `web/_data/` files with idempotent upserts keyed by URL

### Ingestion gotchas handled
- `posts.yaml` has a top-level `posts:` wrapper (not a flat list)
- `youtube.yml` has no native URL — synthesised from `video_id`
- `popular_videos.yaml` rows are merged into existing video metadata, not stored as duplicates
- `reviews.yml` rows with `excerpt: null` or `title: title` placeholders are skipped
- `glossary.yml` `link` is external — synthesised a site-relative URL for stable upsert key

### Tests
6 passing pytest cases against in-memory aiosqlite — no Postgres needed:
- `test_health_ok`
- `test_ingest_populates_content`
- `test_ingest_idempotent`
- `test_popular_videos_merges_metadata`
- `test_reviews_placeholder_skipped`
- `test_stubs_return_501`

### Docker
- `Dockerfile` mirrors `search_app/`'s pattern (python:3.12.1-slim, healthcheck via `curl -f /health`, uvicorn on **port 8200** per #70)
- `docker-compose.yml` brings up a local Postgres on host port 5434 to avoid clashing with the production DB at `:5433`

## How to test locally

```bash
cd stacks/nibsy-api
python3 -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt
pytest                        # 6 passing
uvicorn nibsy_api.main:app --reload --port 8200
curl http://127.0.0.1:8200/health
```

## What's deferred (and to which issue)

| Issue | What |
|---|---|
| #67 | Implement `/api/recommendations` (becomes a thin lookup against `nibsy_recommendations`) |
| #68 | Click + impression tracking endpoints |
| #69 | Production YAML ingest from live site assets |
| #70 | Docker deployment on the Pi cluster |
| #71 | Wire `nibsy-widget.html` to consume this API |
| #72 | Trending integration via Chatter analytics |
| #74 | Heuristic recommendations generator + 2-weekly scheduler |
| #75 | AI categorisation pass for richer page tags |
| #76 | Course pathway / next-course recommendations (pairs with #43) |

## Open questions before merging

1. **Pinned vs unpinned requirements** — I mirrored `search_app/`'s unpinned style. For production (#70) we may want pinned versions; happy to add `pip freeze` output if you'd prefer.
2. **Dockerfile casing** — used standard `Dockerfile`; `search_app/` uses lowercase `dockerfile`. Easy to rename if you want strict consistency across services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
