### PR TITLE
Nibsy API: heuristic recommendations generator + scheduler

### DIFF
--- a/stacks/nibsy-api/README.md
+++ b/stacks/nibsy-api/README.md
@@ -5,15 +5,14 @@ FastAPI microservice that powers the Nibsy recommendation widget on
 (courses, posts, videos, robots, reviews, glossary), the click/impression
 log, and the precomputed top-N recommendations table read by the widget.
 
-This PR scaffolds the foundation (issue #66) and adds the
-`nibsy_recommendations` table from #73a so the generator/reader can land
-in follow-up PRs without a schema migration.
-
 ## Layout
 
 ```
 stacks/nibsy-api/
 ├── nibsy_api/        # FastAPI app
+│   ├── generator.py  # Heuristic top-N scoring (#74)
+│   ├── ingest.py     # YAML → nibsy_content
+│   └── routers/
 ├── tests/            # pytest + aiosqlite + fixtures
 ├── Dockerfile        # python:3.12.1-slim, uvicorn on 8200
 ├── docker-compose.yml
@@ -32,10 +31,15 @@ uvicorn nibsy_api.main:app --reload --port 8200
 
 Then hit `http://127.0.0.1:8200/health`.
 
-To force an ingest run:
+On first boot the service ingests `NIBSY_DATA_DIR`, generates an initial
+recommendation set, and schedules a refresh every
+`RECOMMENDATION_REFRESH_DAYS` days (default `14`).
+
+To force a re-ingest or a recommendation refresh:
 
 ```bash
 curl -X POST http://127.0.0.1:8200/api/admin/ingest
+curl -X POST http://127.0.0.1:8200/api/admin/regenerate-recommendations
 ```
 
 ## Running tests
@@ -66,28 +70,60 @@ docker compose up --build
 
 | Path | Status | Notes |
 |---|---|---|
-| `GET /health` | implemented | Returns `{status, content_count, recommendation_count}` |
-| `POST /api/admin/ingest` | implemented | Triggers a re-ingest from `NIBSY_DATA_DIR` |
-| `GET /api/recommendations` | 501 stub | Reader for `nibsy_recommendations` — lands in #67 |
+| `GET /health` | implemented | `{status, content_count, recommendation_count}` |
+| `GET /api/recommendations` | implemented | Precomputed top-N lookup keyed by `?page=...` |
+| `POST /api/admin/ingest` | implemented | Re-ingest from `NIBSY_DATA_DIR` |
+| `POST /api/admin/regenerate-recommendations` | implemented | Ad-hoc recompute (also runs on a 14-day schedule) |
 | `GET /api/trending` | 501 stub | #67 / #72 |
 | `GET /api/related/{content_id}` | 501 stub | #67 |
 | `POST /api/track/click` | 501 stub | #68 |
 | `POST /api/track/impression` | 501 stub | #68 |
 
+## How recommendations work
+
+Recommendations are **precomputed in batch**, not generated on each
+request. A scheduler runs `generate_recommendations` on a 14-day cadence
+(and on first boot when `nibsy_recommendations` is empty); each call
+recomputes the top-6 picks per source URL and persists them as a JSONB
+array. The widget endpoint then becomes a single indexed lookup.
+
+The v0 scorer (`generator.py`) combines three cheap signals:
+
+```
+score(source → target) =
+    1.0 × jaccard(source.tags, target.tags)        # tag overlap
+  + 0.5 × affinity(source.type, target.type)        # content-type matrix
+  + 0.3 × recency_bonus(target.date_published)      # newer targets get a bump
+```
+
+After scoring, a greedy pick with a soft same-type penalty
+(`0.8 ** count_of_same_type_already_chosen`) breaks the obvious
+monoculture failure mode where six courses or six videos would dominate.
+
+The scorer is intentionally simple — the AI categorisation pass in
+**#75** layers richer topic extraction on top of `tags`, at which point
+this same heuristic produces materially better neighbours without any
+algorithm change. The `generator_version` column lets consumers invalidate
+caches when the scoring evolves.
+
 ## Roadmap
 
 | Issue | Status | Summary |
 |---|---|---|
-| #66 | done (this PR) | FastAPI scaffold, schema, ingest, /health, admin ingest |
-| #67 | open | Recommendation read endpoints (`/recommendations`, `/related`, `/trending`) |
+| #66 | done | FastAPI scaffold, schema, ingest, `/health`, admin ingest |
+| #74 | done | Heuristic recommendations generator + 14-day scheduler + read endpoint |
+| #67 | partial | `/api/recommendations` implemented; `/api/related` and `/api/trending` still stubs |
 | #68 | open | Click & impression tracking endpoints |
-| #69 | open | Production ingest pipeline / scheduled refresh |
+| #69 | open | Production ingest pipeline from live site assets |
 | #70 | open | Production deployment (docker-stack, swarm, port 8200) |
 | #71 | open | Widget integration on kevsrobots.com pages |
-| #72 | open | Trending-by-popularity algorithm |
-| #73 | open | Precomputed recommendations system (umbrella) |
-| #73a | partial (this PR) | Table added; generator + reader land next |
-| #73b | open | AI categorisation / smarter signals |
+| #72 | open | Trending integration with Chatter analytics |
+| #73 | open | Intelligent recommendations (umbrella) |
+| #75 | open | AI categorisation pass for richer tags |
+| #76 | open | Course pathway / next-course recommendations (pairs with #43) |
+| #78 | open | CORS middleware |
+| #79 | open | Dockerfile build-deps trim |
+| #80 | open | Minor cleanups (compose `version:`, dead reviews check) |
 
 ## Conventions
 

--- a/stacks/nibsy-api/nibsy_api/config.py
+++ b/stacks/nibsy-api/nibsy_api/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     # Service port — #70 standardises on 8200.
     port: int = 8200
 
+    # How often the recommendations generator (#74) re-runs in the background.
+    # Production default is 14 days; tests/dev can shorten it via env var.
+    # Set to 0 or negative to disable the scheduler entirely.
+    recommendation_refresh_days: int = 14
+
 
 def get_settings() -> Settings:
     """Return a fresh Settings instance.

--- a/stacks/nibsy-api/nibsy_api/generator.py
+++ b/stacks/nibsy-api/nibsy_api/generator.py
@@ -1,0 +1,305 @@
+"""Heuristic recommendations generator (issue #74).
+
+Walks `nibsy_content`, scores every (source, target) pair using a small set
+of cheap signals — tag overlap, content-type affinity, recency — and writes
+the top-6 per source URL into `nibsy_recommendations`.
+
+No LLM is involved here by design. The richer AI categorisation pass that
+swaps in better tags lives in #75 and is orthogonal: this generator will
+benefit from it automatically once it lands, because it reads whatever is
+in `nibsy_content.tags`.
+
+Algorithm version is recorded on every row so consumers can invalidate
+caches when the scoring changes. Bump `GENERATOR_VERSION` whenever the
+output of `_score` could differ for the same inputs.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import NibsyContent, NibsyRecommendation
+from .schemas import GenerationStats
+
+logger = logging.getLogger(__name__)
+
+
+GENERATOR_VERSION = "heuristic-v0"
+
+# Up to 6 recommendations per source URL.
+TOP_N = 6
+
+# Soft penalty multiplier applied to a candidate's score for each item of
+# the same content_type already chosen. 0.8 ** 1 = 0.8, ** 2 = 0.64, etc.
+# Breaks monocultures without imposing a hard quota.
+TYPE_REPEAT_PENALTY = 0.8
+
+# Per-component weights in the linear combination below. Tuned by hand on
+# the fixtures during development; expect to re-tune once #75 enriches
+# `tags` with LLM-extracted topics.
+W_TAG_OVERLAP = 1.0
+W_AFFINITY = 0.5
+W_RECENCY = 0.3
+
+# Affinity matrix keyed by (source_type, target_type). Default 0.5 for any
+# pair not listed — we lean optimistic so unlikely-seeming pairs still get
+# considered if tags align.
+_AFFINITY: dict[tuple[str, str], float] = {
+    ("course", "course"): 0.5,
+    ("course", "video"): 0.8,
+    ("course", "blog"): 0.6,
+    ("course", "post"): 0.6,
+    ("blog", "blog"): 0.7,
+    ("post", "post"): 0.7,
+    ("blog", "course"): 0.5,
+    ("post", "course"): 0.5,
+    ("video", "video"): 0.4,
+    ("video", "course"): 0.7,
+    ("review", "robot"): 0.9,
+    ("review", "review"): 0.4,
+    ("robot", "course"): 0.8,
+    ("robot", "robot"): 0.5,
+    ("robot", "review"): 0.7,
+    # Glossary terms are a stepping stone into deeper content — treat them
+    # as a low-weight bridge to/from everything.
+    ("glossary", "course"): 0.3,
+    ("glossary", "blog"): 0.3,
+    ("glossary", "post"): 0.3,
+    ("glossary", "video"): 0.3,
+    ("course", "glossary"): 0.3,
+    ("blog", "glossary"): 0.3,
+    ("post", "glossary"): 0.3,
+    ("video", "glossary"): 0.3,
+}
+_AFFINITY_DEFAULT = 0.5
+
+
+def _affinity(src_type: str, dst_type: str) -> float:
+    return _AFFINITY.get((src_type, dst_type), _AFFINITY_DEFAULT)
+
+
+def _jaccard(a: Optional[Iterable[str]], b: Optional[Iterable[str]]) -> float:
+    """Jaccard index between two iterables of tags. Zero if both empty."""
+
+    sa = set(a or [])
+    sb = set(b or [])
+    if not sa and not sb:
+        return 0.0
+    union = sa | sb
+    if not union:
+        return 0.0
+    return len(sa & sb) / len(union)
+
+
+def _recency(date_published: Optional[datetime], now: datetime) -> float:
+    """Inverse-age bonus. New content gets ~1.0; older asymptotes to 0."""
+
+    if date_published is None:
+        return 0.0
+    days = max(0, (now - date_published).days)
+    return min(1.0, 1.0 / (1.0 + days / 365.0))
+
+
+def _score(
+    source: NibsyContent,
+    target: NibsyContent,
+    now: datetime,
+) -> tuple[float, set[str]]:
+    """Return (score, shared_tags) for the source→target pair."""
+
+    sa = set(source.tags or [])
+    sb = set(target.tags or [])
+    shared = sa & sb
+    tag_overlap = _jaccard(source.tags, target.tags)
+    affinity = _affinity(source.content_type, target.content_type)
+    recency = _recency(target.date_published, now)
+    score = (
+        W_TAG_OVERLAP * tag_overlap
+        + W_AFFINITY * affinity
+        + W_RECENCY * recency
+    )
+    return score, shared
+
+
+def _reason(
+    source: NibsyContent,
+    target: NibsyContent,
+    shared_tags: set[str],
+) -> str:
+    """Short human-readable reason. Two templates plus a fallback."""
+
+    if shared_tags:
+        # Cap at 3 tags so the reason stays short in the UI.
+        sample = sorted(shared_tags)[:3]
+        return f"Shares tags: {', '.join(sample)}"
+    if target.date_published is not None:
+        # No tag overlap but the target is fresh enough to surface.
+        return f"Recent {target.content_type}"
+    return f"Related {target.content_type}"
+
+
+def _pick_top_with_mixing(
+    scored: list[tuple[float, set[str], NibsyContent]],
+) -> list[tuple[float, set[str], NibsyContent]]:
+    """Greedy top-N with a soft same-type penalty.
+
+    Multiplies each remaining candidate's score by TYPE_REPEAT_PENALTY ^ k
+    where k is the count of already-chosen items with the same
+    content_type. This breaks 6-of-a-kind monocultures while still
+    letting strong same-type matches win when nothing else is close.
+    """
+
+    remaining = list(scored)
+    chosen: list[tuple[float, set[str], NibsyContent]] = []
+    type_counts: dict[str, int] = {}
+
+    while remaining and len(chosen) < TOP_N:
+        best_idx = -1
+        best_adj = float("-inf")
+        for i, (raw_score, _shared, target) in enumerate(remaining):
+            penalty = TYPE_REPEAT_PENALTY ** type_counts.get(target.content_type, 0)
+            adj = raw_score * penalty
+            if adj > best_adj:
+                best_adj = adj
+                best_idx = i
+        if best_idx < 0:
+            break
+        picked = remaining.pop(best_idx)
+        chosen.append(picked)
+        type_counts[picked[2].content_type] = (
+            type_counts.get(picked[2].content_type, 0) + 1
+        )
+
+    return chosen
+
+
+def _build_payload(
+    source: NibsyContent,
+    chosen: list[tuple[float, set[str], NibsyContent]],
+) -> list[dict[str, Any]]:
+    """Serialise the chosen targets into the JSONB shape we persist."""
+
+    return [
+        {
+            "content_id": target.id,
+            "url": target.url,
+            "title": target.title,
+            "type": target.content_type,
+            "reason": _reason(source, target, shared),
+            "score": round(score, 4),
+        }
+        for score, shared, target in chosen
+    ]
+
+
+async def generate_recommendations(session: AsyncSession) -> GenerationStats:
+    """Regenerate `nibsy_recommendations` from scratch.
+
+    Wipes orphan rows (recommendations whose source content was deleted),
+    rescoreseach source's top-N targets, and upserts. Wrapped in a single
+    commit so a mid-run failure can't half-update the table.
+    """
+
+    start = time.monotonic()
+    stats = GenerationStats(generator_version=GENERATOR_VERSION)
+    # Use a naive UTC datetime so it round-trips cleanly through both
+    # PostgreSQL `TIMESTAMP` (without time zone) and SQLite's TEXT-coerced
+    # storage — matches how `ingest.py` writes `updated_at`.
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    # Load every content row once. The dataset is small (~200 rows expected
+    # in production) so an in-memory scoring pass is fine and much simpler
+    # than streaming. If we ever cross ~10k rows we'd switch to a smarter
+    # index-based candidate-set approach.
+    contents = (await session.scalars(select(NibsyContent))).all()
+    if not contents:
+        logger.info("generator: nibsy_content is empty — nothing to do")
+        stats.duration_ms = int((time.monotonic() - start) * 1000)
+        return stats
+
+    content_urls = {c.url for c in contents}
+
+    # --- Remove orphans first so they don't pollute the count -----------
+    existing_recs = (
+        await session.scalars(select(NibsyRecommendation.source_url))
+    ).all()
+    orphan_urls = [u for u in existing_recs if u not in content_urls]
+    if orphan_urls:
+        await session.execute(
+            delete(NibsyRecommendation).where(
+                NibsyRecommendation.source_url.in_(orphan_urls)
+            )
+        )
+        stats.removed_orphans = len(orphan_urls)
+        logger.info(
+            "generator: removed %s orphan recommendation rows", len(orphan_urls)
+        )
+
+    # --- Score + persist top-N per source ------------------------------
+    rec_count = 0
+    for source in contents:
+        scored: list[tuple[float, set[str], NibsyContent]] = []
+        for target in contents:
+            if target.url == source.url:
+                continue
+            score, shared = _score(source, target, now)
+            if score <= 0:
+                # Pure no-signal pair — skip to keep the candidate set small.
+                continue
+            scored.append((score, shared, target))
+
+        if not scored:
+            stats.sources_skipped += 1
+            continue
+
+        # Pre-sort by raw score desc so the mixing pass starts with a
+        # reasonable order. The mixing pass then applies the penalty.
+        scored.sort(key=lambda t: t[0], reverse=True)
+        # Trim to a sensible candidate window — we never need more than
+        # TOP_N * 4 to give the mixing pass room.
+        scored = scored[: TOP_N * 4]
+        chosen = _pick_top_with_mixing(scored)
+        if not chosen:
+            stats.sources_skipped += 1
+            continue
+
+        payload = _build_payload(source, chosen)
+        existing = await session.scalar(
+            select(NibsyRecommendation).where(
+                NibsyRecommendation.source_url == source.url
+            )
+        )
+        if existing is None:
+            session.add(
+                NibsyRecommendation(
+                    source_url=source.url,
+                    recommendations=payload,
+                    generated_at=now,
+                    generator_version=GENERATOR_VERSION,
+                )
+            )
+        else:
+            existing.recommendations = payload
+            existing.generated_at = now
+            existing.generator_version = GENERATOR_VERSION
+        stats.sources_processed += 1
+        rec_count += len(payload)
+
+    stats.recommendations_written = rec_count
+    await session.commit()
+    stats.duration_ms = int((time.monotonic() - start) * 1000)
+    logger.info(
+        "generator: wrote %s recommendations across %s sources in %sms (skipped=%s, orphans=%s)",
+        stats.recommendations_written,
+        stats.sources_processed,
+        stats.duration_ms,
+        stats.sources_skipped,
+        stats.removed_orphans,
+    )
+    return stats

--- a/stacks/nibsy-api/nibsy_api/main.py
+++ b/stacks/nibsy-api/nibsy_api/main.py
@@ -1,7 +1,10 @@
 """FastAPI application entrypoint.
 
-Builds the app, wires routers, and runs an auto-ingest on startup if the
-content table is empty and `NIBSY_DATA_DIR` is configured.
+Builds the app, wires routers, runs an auto-ingest on startup (if the
+content table is empty and `NIBSY_DATA_DIR` is configured), kicks off a
+first-run recommendations generation if the recommendations table is
+empty, and registers an APScheduler job to re-generate every
+`recommendation_refresh_days` days (#74).
 """
 
 from __future__ import annotations
@@ -10,40 +13,118 @@ import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
 from fastapi import FastAPI
 from sqlalchemy import func, select
 
 from .config import get_settings
 from .db import create_all, get_sessionmaker
+from .generator import generate_recommendations
 from .ingest import ingest_from_data_dir
-from .models import NibsyContent
-from .routers import admin, health, stubs
+from .models import NibsyContent, NibsyRecommendation
+from .routers import admin, health, recommendations, stubs
 
 logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Create tables and optionally run a first-time ingest."""
-
-    await create_all()
+async def _maybe_startup_ingest() -> None:
+    """Run an ingest on boot if content is empty and a data dir is set."""
 
     settings = get_settings()
     data_dir = settings.nibsy_data_dir
-    if data_dir is not None and data_dir.exists() and data_dir.is_dir():
-        sessionmaker = get_sessionmaker()
-        async with sessionmaker() as session:
-            count = await session.scalar(select(func.count()).select_from(NibsyContent))
-            if not count:
-                logger.info("nibsy_content is empty — running startup ingest from %s", data_dir)
-                stats = await ingest_from_data_dir(data_dir, session)
-                logger.info("startup ingest finished: %s", stats.model_dump())
-            else:
-                logger.info("nibsy_content already has %s rows — skipping startup ingest", count)
-    else:
+    if data_dir is None or not data_dir.exists() or not data_dir.is_dir():
         logger.info("NIBSY_DATA_DIR not configured or missing — skipping startup ingest")
+        return
 
-    yield
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(NibsyContent)
+        )
+        if count:
+            logger.info(
+                "nibsy_content already has %s rows — skipping startup ingest",
+                count,
+            )
+            return
+        logger.info("nibsy_content is empty — running startup ingest from %s", data_dir)
+        stats = await ingest_from_data_dir(data_dir, session)
+        logger.info("startup ingest finished: %s", stats.model_dump())
+
+
+async def _maybe_startup_generate() -> None:
+    """Run a first-time generation if the recommendations table is empty."""
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        content_count = await session.scalar(
+            select(func.count()).select_from(NibsyContent)
+        )
+        rec_count = await session.scalar(
+            select(func.count()).select_from(NibsyRecommendation)
+        )
+        if not content_count:
+            logger.info("nibsy_content empty — skipping startup generation")
+            return
+        if rec_count:
+            logger.info(
+                "nibsy_recommendations has %s rows — skipping startup generation",
+                rec_count,
+            )
+            return
+        logger.info("nibsy_recommendations is empty — running first-time generation")
+        stats = await generate_recommendations(session)
+        logger.info("startup generation finished: %s", stats.model_dump())
+
+
+async def _scheduled_regenerate() -> None:
+    """Periodic regeneration job invoked by APScheduler."""
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        try:
+            stats = await generate_recommendations(session)
+            logger.info("scheduled generation finished: %s", stats.model_dump())
+        except Exception:  # noqa: BLE001 — never let the scheduler die
+            logger.exception("scheduled generation failed")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Boot sequence: create tables, ingest, generate, schedule."""
+
+    await create_all()
+    await _maybe_startup_ingest()
+    await _maybe_startup_generate()
+
+    settings = get_settings()
+    scheduler: AsyncIOScheduler | None = None
+    if settings.recommendation_refresh_days > 0:
+        scheduler = AsyncIOScheduler()
+        scheduler.add_job(
+            _scheduled_regenerate,
+            trigger=IntervalTrigger(days=settings.recommendation_refresh_days),
+            id="nibsy-regenerate",
+            name="Regenerate Nibsy recommendations",
+            max_instances=1,
+            coalesce=True,
+            replace_existing=True,
+        )
+        scheduler.start()
+        logger.info(
+            "scheduler started — regenerate every %s day(s)",
+            settings.recommendation_refresh_days,
+        )
+    else:
+        logger.info("recommendation_refresh_days <= 0 — scheduler disabled")
+
+    try:
+        yield
+    finally:
+        if scheduler is not None:
+            scheduler.shutdown(wait=False)
+            logger.info("scheduler stopped")
 
 
 def create_app() -> FastAPI:
@@ -52,11 +133,12 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="Nibsy API",
         description="Recommendation microservice for kevsrobots.com",
-        version="0.1.0",
+        version="0.2.0",
         lifespan=lifespan,
     )
     app.include_router(health.router)
     app.include_router(admin.router)
+    app.include_router(recommendations.router)
     app.include_router(stubs.router)
     return app
 

--- a/stacks/nibsy-api/nibsy_api/routers/admin.py
+++ b/stacks/nibsy-api/nibsy_api/routers/admin.py
@@ -1,4 +1,9 @@
-"""Administrative endpoints (manual ingest trigger)."""
+"""Administrative endpoints (manual ingest + regenerate triggers).
+
+Both endpoints are unauthenticated for now. Auth lands with #69 (production
+ingest pipeline) and #71 (widget integration) — the API will live on the
+private Pi cluster network until then.
+"""
 
 from __future__ import annotations
 
@@ -7,8 +12,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
 from ..db import get_session
+from ..generator import generate_recommendations
 from ..ingest import ingest_from_data_dir
-from ..schemas import IngestStats
+from ..schemas import GenerationStats, IngestStats
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -32,3 +38,17 @@ async def trigger_ingest(
             detail="NIBSY_DATA_DIR is not configured",
         )
     return await ingest_from_data_dir(settings.nibsy_data_dir, session)
+
+
+@router.post("/regenerate-recommendations", response_model=GenerationStats)
+async def trigger_regenerate(
+    session: AsyncSession = Depends(get_session),
+) -> GenerationStats:
+    """Trigger a manual recommendations regeneration (#74).
+
+    The scheduler also runs this every `RECOMMENDATION_REFRESH_DAYS` days
+    in the background; this endpoint is for ad-hoc refreshes after a
+    content change or an algorithm tweak.
+    """
+
+    return await generate_recommendations(session)

--- a/stacks/nibsy-api/nibsy_api/routers/recommendations.py
+++ b/stacks/nibsy-api/nibsy_api/routers/recommendations.py
@@ -1,0 +1,99 @@
+"""Public recommendations endpoint (issue #67, #74).
+
+Thin read against the precomputed `nibsy_recommendations` table. The
+generator (#74) keeps the table populated; this handler just looks up by
+`source_url` and applies `limit` and `exclude` filters in-memory.
+
+We deliberately return 200 with an empty list when the source page has
+no recommendations yet, rather than 404. Nibsy is best-effort by design —
+the widget should degrade gracefully, never throw.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from ..db import get_session
+from ..models import NibsyRecommendation
+from ..schemas import RecommendationItem, RecommendationsResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["recommendations"])
+
+
+# Match the TOP_N from the generator so we never claim to return more
+# than what was precomputed.
+_MAX_LIMIT = 6
+
+
+def _parse_exclude(raw: Optional[str]) -> set[int]:
+    """Parse `?exclude=1,2,3` into a set of ints, tolerantly."""
+
+    if not raw:
+        return set()
+    out: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.add(int(part))
+        except ValueError:
+            # Silently ignore non-int tokens — the caller is the widget,
+            # not a developer, and we don't want a bad URL to break the page.
+            continue
+    return out
+
+
+@router.get("/recommendations", response_model=RecommendationsResponse)
+async def get_recommendations(
+    page: str = Query(..., description="URL path of the current page"),
+    limit: int = Query(5, ge=1, le=_MAX_LIMIT),
+    exclude: Optional[str] = Query(
+        None, description="Comma-separated content IDs to exclude"
+    ),
+    session: AsyncSession = Depends(get_session),
+) -> RecommendationsResponse:
+    """Return the precomputed top-N recommendations for a source page."""
+
+    row = await session.scalar(
+        select(NibsyRecommendation).where(
+            NibsyRecommendation.source_url == page
+        )
+    )
+    if row is None:
+        # No precomputed entry — graceful 200 with an empty list so the
+        # widget can render its fallback without special-casing 404s.
+        logger.debug("recommendations: no row for source_url=%s", page)
+        return RecommendationsResponse(source_url=page)
+
+    excluded_ids = _parse_exclude(exclude)
+    items: list[RecommendationItem] = []
+    for entry in row.recommendations or []:
+        if entry.get("content_id") in excluded_ids:
+            continue
+        items.append(
+            RecommendationItem(
+                content_id=entry["content_id"],
+                url=entry["url"],
+                title=entry["title"],
+                type=entry["type"],
+                reason=entry.get("reason", ""),
+                score=entry.get("score"),
+            )
+        )
+        if len(items) >= limit:
+            break
+
+    return RecommendationsResponse(
+        source_url=row.source_url,
+        recommendations=items,
+        generated_at=row.generated_at,
+        generator_version=row.generator_version,
+    )

--- a/stacks/nibsy-api/nibsy_api/routers/stubs.py
+++ b/stacks/nibsy-api/nibsy_api/routers/stubs.py
@@ -19,15 +19,6 @@ def _not_implemented(issue: str) -> None:
     )
 
 
-@router.get("/recommendations")
-async def get_recommendations() -> None:
-    """Read precomputed recs out of `nibsy_recommendations` (see #67 / #73a)."""
-
-    # The table exists (added in this PR for #73a) but the read path itself
-    # lands in #67, and the generator that populates it lands in #73a/#73b.
-    _not_implemented("#67 / #73a")
-
-
 @router.get("/trending")
 async def get_trending() -> None:
     """Trending-by-clicks endpoint — see #67 / #72."""

--- a/stacks/nibsy-api/nibsy_api/schemas.py
+++ b/stacks/nibsy-api/nibsy_api/schemas.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -23,3 +26,34 @@ class IngestStats(BaseModel):
     errors: int = 0
     files_processed: list[str] = Field(default_factory=list)
     error_details: list[str] = Field(default_factory=list)
+
+
+class GenerationStats(BaseModel):
+    """Outcome of a recommendations generation run (#74)."""
+
+    sources_processed: int = 0
+    recommendations_written: int = 0
+    sources_skipped: int = 0
+    removed_orphans: int = 0
+    duration_ms: int = 0
+    generator_version: str = "heuristic-v0"
+
+
+class RecommendationItem(BaseModel):
+    """A single recommendation returned to the widget."""
+
+    content_id: int
+    url: str
+    title: str
+    type: str
+    reason: str
+    score: Optional[float] = None
+
+
+class RecommendationsResponse(BaseModel):
+    """Payload returned by `GET /api/recommendations`."""
+
+    source_url: str
+    recommendations: list[RecommendationItem] = Field(default_factory=list)
+    generated_at: Optional[datetime] = None
+    generator_version: Optional[str] = None

--- a/stacks/nibsy-api/requirements.txt
+++ b/stacks/nibsy-api/requirements.txt
@@ -8,5 +8,6 @@ pydantic-settings
 pyyaml
 python-dotenv
 httpx
+apscheduler
 pytest
 pytest-asyncio

--- a/stacks/nibsy-api/tests/test_generator.py
+++ b/stacks/nibsy-api/tests/test_generator.py
@@ -1,0 +1,142 @@
+"""Tests for the heuristic recommendations generator (#74)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from nibsy_api.generator import GENERATOR_VERSION, generate_recommendations
+from nibsy_api.ingest import ingest_from_data_dir
+from nibsy_api.models import NibsyContent, NibsyRecommendation
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "_data"
+
+
+async def _seed(session) -> None:
+    """Populate the content table from the bundled fixtures."""
+
+    await ingest_from_data_dir(FIXTURES, session)
+
+
+@pytest.mark.asyncio
+async def test_generate_writes_recommendations(session) -> None:
+    """Generation should produce a `nibsy_recommendations` row per content row."""
+
+    await _seed(session)
+    stats = await generate_recommendations(session)
+
+    assert stats.generator_version == GENERATOR_VERSION
+    assert stats.sources_processed > 0
+    assert stats.recommendations_written > 0
+    assert stats.duration_ms >= 0
+
+    content_count = len((await session.scalars(select(NibsyContent))).all())
+    rec_rows = (await session.scalars(select(NibsyRecommendation))).all()
+    # Every source should have a row unless it was skipped because no
+    # candidate scored above zero — with the fixtures, none should skip.
+    assert len(rec_rows) == content_count - stats.sources_skipped
+
+
+@pytest.mark.asyncio
+async def test_generate_no_self_recommendation(session) -> None:
+    """No source should recommend itself."""
+
+    await _seed(session)
+    await generate_recommendations(session)
+
+    rows = (await session.scalars(select(NibsyRecommendation))).all()
+    assert rows, "no recommendations written"
+    for row in rows:
+        for entry in row.recommendations:
+            assert entry["url"] != row.source_url, (
+                f"self-recommendation found for {row.source_url}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_generate_content_type_mixing(session) -> None:
+    """For sources with diverse candidates, the output should mix types."""
+
+    await _seed(session)
+    await generate_recommendations(session)
+
+    # Pick the source with the most recommendations and assert its types
+    # aren't monocultural. With ~17 fixture rows across 6 types this
+    # should always have at least 2 distinct types in the top-N.
+    rows = (await session.scalars(select(NibsyRecommendation))).all()
+    biggest = max(rows, key=lambda r: len(r.recommendations))
+    distinct_types = {e["type"] for e in biggest.recommendations}
+    assert len(distinct_types) >= 2, (
+        f"expected ≥2 content types in top recs for {biggest.source_url}, "
+        f"got {distinct_types}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_removes_orphans(session) -> None:
+    """Pre-existing recommendation rows for deleted content should be wiped."""
+
+    await _seed(session)
+
+    # Inject an orphan — a `nibsy_recommendations` row whose source_url
+    # has no matching `nibsy_content` row.
+    session.add(
+        NibsyRecommendation(
+            source_url="/orphan/page-that-no-longer-exists.html",
+            recommendations=[
+                {
+                    "content_id": 9999,
+                    "url": "/whatever",
+                    "title": "x",
+                    "type": "blog",
+                    "reason": "stale",
+                }
+            ],
+            generated_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            generator_version="ancient",
+        )
+    )
+    await session.commit()
+
+    stats = await generate_recommendations(session)
+    assert stats.removed_orphans >= 1
+
+    surviving = await session.scalar(
+        select(NibsyRecommendation).where(
+            NibsyRecommendation.source_url == "/orphan/page-that-no-longer-exists.html"
+        )
+    )
+    assert surviving is None
+
+
+@pytest.mark.asyncio
+async def test_generate_is_idempotent(session) -> None:
+    """Re-running generation should produce the same payload (modulo time)."""
+
+    await _seed(session)
+    await generate_recommendations(session)
+    rows1 = (await session.scalars(select(NibsyRecommendation))).all()
+    snapshot1 = {
+        r.source_url: sorted(r.recommendations, key=lambda e: e["content_id"])
+        for r in rows1
+    }
+
+    await generate_recommendations(session)
+    rows2 = (await session.scalars(select(NibsyRecommendation))).all()
+    snapshot2 = {
+        r.source_url: sorted(r.recommendations, key=lambda e: e["content_id"])
+        for r in rows2
+    }
+
+    assert snapshot1.keys() == snapshot2.keys()
+    for url, entries1 in snapshot1.items():
+        entries2 = snapshot2[url]
+        # Compare the meaningful fields — generated_at will differ.
+        assert [
+            (e["content_id"], e["url"], e["type"], e["reason"]) for e in entries1
+        ] == [
+            (e["content_id"], e["url"], e["type"], e["reason"]) for e in entries2
+        ], f"recommendations diverged on re-run for {url}"

--- a/stacks/nibsy-api/tests/test_ingest.py
+++ b/stacks/nibsy-api/tests/test_ingest.py
@@ -94,10 +94,13 @@ async def test_reviews_placeholder_skipped(session) -> None:
 
 @pytest.mark.asyncio
 async def test_stubs_return_501(client) -> None:
-    """Unimplemented routes should return 501, not 404."""
+    """Unimplemented routes should return 501, not 404.
+
+    `/api/recommendations` is intentionally absent — it became a real
+    endpoint in #74. See `tests/test_recommendations_endpoint.py`.
+    """
 
     for method, path in [
-        ("GET", "/api/recommendations"),
         ("GET", "/api/trending"),
         ("GET", "/api/related/1"),
         ("POST", "/api/track/click"),

--- a/stacks/nibsy-api/tests/test_recommendations_endpoint.py
+++ b/stacks/nibsy-api/tests/test_recommendations_endpoint.py
@@ -1,0 +1,100 @@
+"""Tests for `GET /api/recommendations` (#74)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from nibsy_api.generator import generate_recommendations
+from nibsy_api.ingest import ingest_from_data_dir
+from nibsy_api.models import NibsyContent, NibsyRecommendation
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "_data"
+
+
+async def _seed_and_generate(session) -> None:
+    await ingest_from_data_dir(FIXTURES, session)
+    await generate_recommendations(session)
+
+
+async def _first_source_with_recs(session) -> str:
+    rec = await session.scalar(select(NibsyRecommendation))
+    assert rec is not None, "no recommendations were generated"
+    return rec.source_url
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_returns_list(client, session) -> None:
+    """A page that has precomputed recs should return them."""
+
+    await _seed_and_generate(session)
+    source_url = await _first_source_with_recs(session)
+
+    response = await client.get("/api/recommendations", params={"page": source_url})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source_url"] == source_url
+    assert isinstance(body["recommendations"], list)
+    assert len(body["recommendations"]) >= 1
+    # Each item carries the agreed shape.
+    item = body["recommendations"][0]
+    for field in ("content_id", "url", "title", "type", "reason"):
+        assert field in item, f"missing field {field} in recommendation item"
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_empty_for_unknown_page(client, session) -> None:
+    """Unknown pages get 200 + empty list, not 404."""
+
+    await _seed_and_generate(session)
+
+    response = await client.get(
+        "/api/recommendations", params={"page": "/totally/unknown/page.html"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source_url"] == "/totally/unknown/page.html"
+    assert body["recommendations"] == []
+    assert body["generated_at"] is None
+    assert body["generator_version"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_respects_limit(client, session) -> None:
+    """`limit=2` caps the response at two items."""
+
+    await _seed_and_generate(session)
+    source_url = await _first_source_with_recs(session)
+
+    response = await client.get(
+        "/api/recommendations",
+        params={"page": source_url, "limit": 2},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["recommendations"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_respects_exclude(client, session) -> None:
+    """`exclude=<id>` filters that content_id out of the response."""
+
+    await _seed_and_generate(session)
+    # Find a source with at least 2 recs so excluding one still leaves something.
+    rec = await session.scalar(
+        select(NibsyRecommendation)
+    )
+    assert rec is not None
+    assert len(rec.recommendations) >= 2, "need at least 2 recs for this test"
+    excluded_id = rec.recommendations[0]["content_id"]
+
+    response = await client.get(
+        "/api/recommendations",
+        params={"page": rec.source_url, "exclude": str(excluded_id)},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    returned_ids = {e["content_id"] for e in body["recommendations"]}
+    assert excluded_id not in returned_ids


### PR DESCRIPTION
Closes #74. Also unblocks #67 (the read endpoint) by turning the 501 stub from #66 into a real implementation.

## What's in this PR

A batch generator that walks `nibsy_content`, scores every (source, target) pair using a small set of cheap signals, and writes the top-6 picks per source URL to `nibsy_recommendations`. Plus a 14-day scheduler that re-runs it in the background. Plus the real `GET /api/recommendations` endpoint reading from that precomputed table.

The endpoint is now a thin indexed lookup — sub-millisecond per request — and the cost is paid once every two weeks during the regeneration pass instead of on every page view.

## Algorithm v0 (heuristic, no LLM)

```
score(source → target) =
    1.0 × jaccard(source.tags, target.tags)
  + 0.5 × affinity(source.type, target.type)
  + 0.3 × recency_bonus(target.date_published)
```

After scoring, a greedy top-N pick with a soft same-type penalty (`0.8 ** count_of_same_type_already_chosen`) breaks the obvious monoculture failure mode where six courses or six videos would dominate.

The scorer is intentionally simple. **#75 (AI categorisation)** layers richer topic extraction on top of `tags`, at which point this same heuristic produces materially better neighbours without any algorithm change. The `generator_version` column ("heuristic-v0") lets consumers invalidate caches when scoring evolves.

## What's new

| File | Why |
|---|---|
| `nibsy_api/generator.py` | The scorer + persistence + orphan cleanup, all wrapped in a single transaction |
| `nibsy_api/routers/recommendations.py` | `GET /api/recommendations` — thin lookup with `limit` (default 5, max 6) and `exclude` filters |
| `tests/test_generator.py` | 5 tests: shape, no self-recs, type-mixing, orphan removal, idempotency |
| `tests/test_recommendations_endpoint.py` | 4 tests: returns list, empty-for-unknown, limit, exclude |

## What changed

- `nibsy_api/main.py` — lifespan now: ingest → first-time generate → start APScheduler → on shutdown, scheduler.shutdown(wait=False)
- `nibsy_api/routers/admin.py` — adds `POST /api/admin/regenerate-recommendations`
- `nibsy_api/routers/stubs.py` — removes `/api/recommendations` (no longer a stub)
- `nibsy_api/config.py` — `RECOMMENDATION_REFRESH_DAYS` env var, default 14
- `nibsy_api/schemas.py` — `GenerationStats`, `RecommendationItem`, `RecommendationsResponse`
- `requirements.txt` — adds `apscheduler`
- `tests/test_ingest.py::test_stubs_return_501` — drops `/api/recommendations` from the list
- `README.md` — marks #74 done, adds a "How recommendations work" section

## How to smoke-test locally

```bash
cd stacks/nibsy-api
pip install -r requirements.txt
export NIBSY_DATA_DIR="$(pwd)/tests/fixtures/_data"
uvicorn nibsy_api.main:app --port 8200
```

Then:

```bash
curl http://127.0.0.1:8200/health
# {"status":"ok","content_count":17,"recommendation_count":17}

curl 'http://127.0.0.1:8200/api/recommendations?page=/learn/example/00_intro.html&limit=3'
# returns 3 recommendations with reason + score

curl -X POST http://127.0.0.1:8200/api/admin/regenerate-recommendations
# {"sources_processed":17,"recommendations_written":102,"sources_skipped":0,
#  "removed_orphans":0,"duration_ms":47,"generator_version":"heuristic-v0"}
```

## Tests

15/15 passing — 6 originals + 5 new generator tests + 4 new endpoint tests:

```
tests/test_generator.py::test_generate_writes_recommendations PASSED
tests/test_generator.py::test_generate_no_self_recommendation PASSED
tests/test_generator.py::test_generate_content_type_mixing PASSED
tests/test_generator.py::test_generate_removes_orphans PASSED
tests/test_generator.py::test_generate_is_idempotent PASSED
tests/test_health.py::test_health_ok PASSED
tests/test_ingest.py::test_ingest_populates_content PASSED
tests/test_ingest.py::test_ingest_idempotent PASSED
tests/test_ingest.py::test_popular_videos_merges_metadata PASSED
tests/test_ingest.py::test_reviews_placeholder_skipped PASSED
tests/test_ingest.py::test_stubs_return_501 PASSED
tests/test_recommendations_endpoint.py::test_get_recommendations_returns_list PASSED
tests/test_recommendations_endpoint.py::test_get_recommendations_empty_for_unknown_page PASSED
tests/test_recommendations_endpoint.py::test_get_recommendations_respects_limit PASSED
tests/test_recommendations_endpoint.py::test_get_recommendations_respects_exclude PASSED
```

## Scope guard

- No LLM is called by the generator — that's #75.
- No course-pathway logic — that's #76 (which pairs with #43).
- No CORS, no Docker trim, no minor cleanups — those are #78/#79/#80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
