### PR TITLE
feat(projects-editor): global drop zone with smart file routing

### DIFF
--- a/web/assets/css/project-editor.css
+++ b/web/assets/css/project-editor.css
@@ -472,3 +472,133 @@ body:has(.CodeMirror-fullscreen) .col-lg-8 {
     position: static !important;
   }
 }
+
+/* --- Global drop zone overlay (issue #117) --- */
+.global-dropzone {
+  position: fixed;
+  inset: 0;
+  z-index: 11000;
+  background: rgba(15, 23, 42, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  pointer-events: none;
+  animation: globalDropzoneFade 0.15s ease-out;
+}
+
+.global-dropzone.d-none {
+  display: none !important;
+}
+
+@keyframes globalDropzoneFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.global-dropzone__inner {
+  background: rgba(255, 255, 255, 0.98);
+  border: 3px dashed #4A90D9;
+  border-radius: 16px;
+  padding: 40px 48px;
+  max-width: 560px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+}
+
+.global-dropzone__icon {
+  font-size: 4rem;
+  color: #4A90D9;
+  margin-bottom: 16px;
+  display: block;
+}
+
+.global-dropzone__title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 18px;
+}
+
+.global-dropzone__routes {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px 0;
+  text-align: left;
+  display: inline-block;
+}
+
+.global-dropzone__routes li {
+  padding: 6px 0;
+  color: #374151;
+  font-size: 0.95rem;
+}
+
+.global-dropzone__hint {
+  margin-top: 8px;
+}
+
+/* Progress toast for drop activity */
+.drop-progress {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 360px;
+  max-width: calc(100vw - 40px);
+  max-height: 60vh;
+  background: #1f2937;
+  color: #f3f4f6;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  z-index: 11050;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.drop-progress.d-none {
+  display: none !important;
+}
+
+.drop-progress__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.25);
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.drop-progress__body {
+  padding: 6px 12px 12px;
+  overflow-y: auto;
+  font-size: 0.85rem;
+}
+
+.drop-progress__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.drop-progress__row:last-child {
+  border-bottom: none;
+}
+
+.drop-progress__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drop-progress__status {
+  flex-shrink: 0;
+  font-size: 0.8rem;
+}

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -454,6 +454,8 @@
     easyMDE.codemirror.on('change', scheduleAutoSave);
     setupFloatingToolbar(easyMDE);
     setupImageAutocomplete(easyMDE);
+    // Expose for external integrations (e.g. global drop zone — issue #117)
+    window.easyMDE = easyMDE;
   }
 
   // --- Floating toolbar on text selection ---
@@ -1314,6 +1316,289 @@
       el.addEventListener('change', scheduleAutoSave);
     }
   });
+
+  // --- Global drop zone (issue #117) ---
+  // Smart routing: images -> uploadImages(), README.md -> editor content,
+  // license files -> upload + add link, everything else -> uploadFiles().
+  const ALLOWED_FILE_EXTS = new Set([
+    'py', 'cpp', 'h', 'ino', 'md', 'txt', 'pdf',
+    'stl', 'obj', 'gcode', '3mf', 'step', 'stp', 'dxf', 'dwg', 'svg',
+    'json', 'xml', 'yaml', 'yml', 'csv', 'toml',
+    'zip', 'tar', 'gz', '7z', 'rar',
+    'scad', 'kicad_pcb', 'kicad_sch', 'brd', 'sch',
+    'f3d', 'fcstd',
+  ]);
+  const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg']);
+
+  function getExt(name) {
+    const i = (name || '').lastIndexOf('.');
+    return i === -1 ? '' : name.substring(i + 1).toLowerCase();
+  }
+
+  function isImageFile(file) {
+    if (file.type && file.type.startsWith('image/')) return true;
+    return IMAGE_EXTS.has(getExt(file.name));
+  }
+
+  function isReadmeFile(file) {
+    return (file.name || '').toLowerCase() === 'readme.md';
+  }
+
+  function isLicenseFile(file) {
+    const n = (file.name || '').toLowerCase();
+    return n === 'license' || n === 'license.md' || n === 'license.txt'
+      || n === 'licence' || n === 'licence.md' || n === 'licence.txt';
+  }
+
+  function isAcceptedFile(file) {
+    if (isImageFile(file)) return true;
+    const ext = getExt(file.name);
+    if (ALLOWED_FILE_EXTS.has(ext)) return true;
+    // LICENSE without extension
+    const bare = (file.name || '').toLowerCase();
+    if (bare === 'license' || bare === 'licence') return true;
+    return false;
+  }
+
+  // Drop progress toast
+  const dropProgressEl = document.getElementById('drop-progress');
+  const dropProgressBody = dropProgressEl && dropProgressEl.querySelector('.drop-progress__body');
+  const dropProgressTitle = dropProgressEl && dropProgressEl.querySelector('.drop-progress__title');
+  const dropProgressClose = document.getElementById('drop-progress-close');
+  if (dropProgressClose) dropProgressClose.addEventListener('click', () => dropProgressEl.classList.add('d-none'));
+
+  function showProgress() {
+    if (!dropProgressEl) return;
+    dropProgressBody.innerHTML = '';
+    dropProgressTitle.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Processing files...';
+    dropProgressEl.classList.remove('d-none');
+  }
+  function addProgressLine(name, status) {
+    if (!dropProgressBody) return null;
+    const row = document.createElement('div');
+    row.className = 'drop-progress__row';
+    row.innerHTML = '<span class="drop-progress__name"></span><span class="drop-progress__status"></span>';
+    row.querySelector('.drop-progress__name').textContent = name;
+    row.querySelector('.drop-progress__status').innerHTML = status || '<i class="fas fa-spinner fa-spin"></i>';
+    dropProgressBody.appendChild(row);
+    return row;
+  }
+  function updateProgressLine(row, html) {
+    if (!row) return;
+    row.querySelector('.drop-progress__status').innerHTML = html;
+  }
+  function finishProgress(summary) {
+    if (!dropProgressEl) return;
+    dropProgressTitle.innerHTML = '<i class="fas fa-check-circle text-success me-1"></i> ' + summary;
+    setTimeout(() => { dropProgressEl.classList.add('d-none'); }, 4000);
+  }
+
+  // Upload a single file via the files API and return the response JSON.
+  async function uploadSingleFile(file) {
+    const form = new FormData();
+    form.append('file', file);
+    const resp = await apiFetch(API + '/api/projects/' + currentProject.id + '/files', {
+      method: 'POST', credentials: 'include', body: form,
+    });
+    if (!resp.ok) {
+      let detail = 'upload failed';
+      try { const j = await resp.json(); detail = j.detail || detail; } catch (e) {}
+      throw new Error(detail);
+    }
+    return resp.json();
+  }
+
+  // Upload a single image via the images API.
+  async function uploadSingleImage(file) {
+    const form = new FormData();
+    form.append('file', file);
+    const resp = await apiFetch(API + '/api/projects/' + currentProject.id + '/images', {
+      method: 'POST', credentials: 'include', body: form,
+    });
+    if (!resp.ok) {
+      let detail = 'upload failed';
+      try { const j = await resp.json(); detail = j.detail || detail; } catch (e) {}
+      throw new Error(detail);
+    }
+    return resp.json();
+  }
+
+  async function readFileAsText(file) {
+    return new Promise((resolve, reject) => {
+      const r = new FileReader();
+      r.onload = () => resolve(r.result);
+      r.onerror = () => reject(r.error);
+      r.readAsText(file);
+    });
+  }
+
+  async function handleReadmeDrop(file, row) {
+    const text = await readFileAsText(file);
+    const current = getEditorValue() || '';
+    if (current.trim().length > 50) {
+      if (!confirm('Replace existing editor content with ' + file.name + '? Current content is ' + current.length + ' characters.')) {
+        updateProgressLine(row, '<span class="text-muted">skipped</span>');
+        return false;
+      }
+    }
+    setEditorValue(text);
+    updateProgressLine(row, '<span class="text-success"><i class="fas fa-check"></i> loaded into editor</span>');
+    return true;
+  }
+
+  async function handleLicenseDrop(file, row) {
+    // Upload as a regular file, then add a link pointing to its download URL.
+    const uploaded = await uploadSingleFile(file);
+    try {
+      const downloadUrl = API + '/api/projects/' + currentProject.id + '/files/' + uploaded.id + '/download';
+      await apiFetch(API + '/api/projects/' + currentProject.id + '/links', {
+        method: 'POST', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'License', url: downloadUrl, link_type: 'documentation' }),
+      });
+    } catch (e) { /* link add failed — file still uploaded */ }
+    updateProgressLine(row, '<span class="text-success"><i class="fas fa-check"></i> uploaded &amp; linked</span>');
+  }
+
+  async function processDroppedFiles(fileList) {
+    const files = Array.from(fileList || []);
+    if (files.length === 0) return;
+
+    // Ensure project exists before uploading.
+    if (!currentProject) {
+      await saveProject();
+      if (!currentProject) {
+        alert('Please add a title and save before dropping files.');
+        return;
+      }
+    }
+
+    showProgress();
+
+    // Filter unsupported files up-front with a warning row.
+    const accepted = [];
+    for (const f of files) {
+      if (!isAcceptedFile(f)) {
+        const r = addProgressLine(f.name, '<span class="text-warning"><i class="fas fa-exclamation-triangle"></i> unsupported type</span>');
+        continue;
+      }
+      accepted.push(f);
+    }
+
+    let imageCount = 0;
+    let fileCount = 0;
+    let readmeCount = 0;
+    let licenseCount = 0;
+    let errorCount = 0;
+    let needsImageReload = false;
+    let needsFileReload = false;
+    let needsLinksReload = false;
+
+    for (const file of accepted) {
+      const row = addProgressLine(file.name, '<i class="fas fa-spinner fa-spin"></i>');
+      try {
+        if (isReadmeFile(file)) {
+          const ok = await handleReadmeDrop(file, row);
+          if (ok) readmeCount++;
+        } else if (isLicenseFile(file)) {
+          await handleLicenseDrop(file, row);
+          licenseCount++;
+          needsFileReload = true;
+          needsLinksReload = true;
+        } else if (isImageFile(file)) {
+          await uploadSingleImage(file);
+          updateProgressLine(row, '<span class="text-success"><i class="fas fa-check"></i> added to gallery</span>');
+          imageCount++;
+          needsImageReload = true;
+        } else {
+          await uploadSingleFile(file);
+          updateProgressLine(row, '<span class="text-success"><i class="fas fa-check"></i> uploaded</span>');
+          fileCount++;
+          needsFileReload = true;
+        }
+      } catch (e) {
+        updateProgressLine(row, '<span class="text-danger"><i class="fas fa-times"></i> ' + (e.message || 'failed') + '</span>');
+        errorCount++;
+      }
+    }
+
+    if (needsImageReload) loadImages();
+    if (needsFileReload) loadFiles();
+    if (needsLinksReload) loadLinks();
+
+    scheduleAutoSave();
+
+    const parts = [];
+    if (imageCount) parts.push(imageCount + ' image' + (imageCount === 1 ? '' : 's'));
+    if (fileCount) parts.push(fileCount + ' file' + (fileCount === 1 ? '' : 's'));
+    if (readmeCount) parts.push('README');
+    if (licenseCount) parts.push('license');
+    let summary = parts.length ? 'Added ' + parts.join(', ') : 'Done';
+    if (errorCount) summary += ' (' + errorCount + ' failed)';
+    finishProgress(summary);
+  }
+
+  // Set up global drag overlay using a counter pattern.
+  (function setupGlobalDropzone() {
+    const overlay = document.getElementById('global-dropzone');
+    if (!overlay) return;
+    let dragDepth = 0;
+
+    function hasFiles(e) {
+      if (!e.dataTransfer) return false;
+      const types = e.dataTransfer.types;
+      if (!types) return false;
+      for (let i = 0; i < types.length; i++) {
+        if (types[i] === 'Files' || types[i] === 'application/x-moz-file') return true;
+      }
+      return false;
+    }
+
+    document.addEventListener('dragenter', (e) => {
+      if (!hasFiles(e)) return;
+      dragDepth++;
+      overlay.classList.remove('d-none');
+      overlay.classList.add('is-active');
+    });
+
+    document.addEventListener('dragover', (e) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+    });
+
+    document.addEventListener('dragleave', (e) => {
+      if (!hasFiles(e)) return;
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) {
+        overlay.classList.add('d-none');
+        overlay.classList.remove('is-active');
+      }
+    });
+
+    document.addEventListener('drop', (e) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      dragDepth = 0;
+      overlay.classList.add('d-none');
+      overlay.classList.remove('is-active');
+      // Don't intercept drops on the sidebar dropzones — they handle their own files.
+      const target = e.target;
+      if (target && (target.closest('#file-dropzone') || target.closest('#image-dropzone'))) {
+        return;
+      }
+      const files = e.dataTransfer && e.dataTransfer.files;
+      if (files && files.length) processDroppedFiles(files);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !overlay.classList.contains('d-none')) {
+        dragDepth = 0;
+        overlay.classList.add('d-none');
+        overlay.classList.remove('is-active');
+      }
+    });
+  })();
 
   // --- Init ---
   async function init() {

--- a/web/projects/editor.html
+++ b/web/projects/editor.html
@@ -9,6 +9,30 @@ description: Create or edit a project
 <link rel="stylesheet" href="/assets/css/image-viewer.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
 
+<!-- Global drag-and-drop overlay (issue #117) -->
+<div id="global-dropzone" class="global-dropzone d-none" aria-hidden="true">
+  <div class="global-dropzone__inner">
+    <i class="fas fa-cloud-upload-alt global-dropzone__icon"></i>
+    <h2 class="global-dropzone__title">Drop files to add them to your project</h2>
+    <ul class="global-dropzone__routes">
+      <li><i class="fas fa-image text-info me-2"></i><strong>Images</strong> &rarr; uploaded to the gallery</li>
+      <li><i class="fas fa-file-alt text-success me-2"></i><strong>README.md</strong> &rarr; loaded into the content editor</li>
+      <li><i class="fas fa-balance-scale text-warning me-2"></i><strong>LICENSE</strong> &rarr; uploaded and linked under Related Links</li>
+      <li><i class="fas fa-paperclip text-secondary me-2"></i><strong>Other files</strong> &rarr; added to Files &amp; Models</li>
+    </ul>
+    <p class="global-dropzone__hint text-muted small mb-0">Release the mouse to drop. Press Esc to cancel.</p>
+  </div>
+</div>
+
+<!-- Drop progress toast -->
+<div id="drop-progress" class="drop-progress d-none" aria-live="polite">
+  <div class="drop-progress__header">
+    <span class="drop-progress__title"><i class="fas fa-spinner fa-spin me-1"></i> Processing files...</span>
+    <button type="button" class="btn-close btn-close-white btn-sm" id="drop-progress-close" aria-label="Close"></button>
+  </div>
+  <div class="drop-progress__body"></div>
+</div>
+
 <div class="container-fluid py-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <div>


### PR DESCRIPTION
## Summary

Adds a full-page drag-and-drop overlay to the project editor (`/projects/editor.html`) with smart routing per file type.

- **Images** (png/jpg/jpeg/gif/webp/svg) -> gallery upload
- **README.md** (case-insensitive) -> replaces EasyMDE content (confirms if existing content >50 chars)
- **LICENSE / license.md / license.txt** -> uploaded as a file AND added to Related Links as `link_type: documentation`, title `"License"`
- **All other accepted types** (see `ALLOWED_FILE_EXTENSIONS` in `storage.py`) -> uploaded as project files
- Unsupported types are flagged in the progress toast and skipped

## Implementation notes

- Counter-based `dragenter`/`dragleave` listeners on `document` to avoid flicker over children
- Only triggers when the drag actually carries files (checks `DataTransfer.types`)
- Sidebar `#file-dropzone` / `#image-dropzone` still work as before — overlay defers to them if drop lands inside
- Per-file progress toast (bottom-right) with success/error/skip
- `Esc` cancels the overlay
- Calls existing `scheduleAutoSave()` at the end
- `easyMDE` is now also exposed on `window.easyMDE` for external integrations
- CSS lives in `web/assets/css/project-editor.css` (semi-transparent backdrop, dashed border, big icon, route legend)

Frontend-only — no backend changes.

Closes #117

## Test plan

- [ ] Open `/projects/editor.html?id=<id>` while logged in
- [ ] Drag a folder containing a README.md, LICENSE, an image and a .py file onto the page
- [ ] Verify overlay appears full-page with the route legend
- [ ] After drop: README loads into editor, image lands in gallery, .py in Files, license appears both in Files and as a "License" link
- [ ] Drag an unsupported file type (e.g. .exe) — should show as "unsupported type"
- [ ] Drag a second README into a project with >50 chars — should prompt to confirm replacement
- [ ] Press Esc mid-drag — overlay hides
- [ ] Sidebar dropzones still work (drag onto `#file-dropzone` and `#image-dropzone`)
- [ ] Note: full functional testing requires the projects-api running

Co-Authored-By: Claude <noreply@anthropic.com>