### PR TITLE
feat(projects-api): parts catalog Phase 1 backend (#121)

### DIFF
--- a/stacks/projects-api/docs/parts-api.md
+++ b/stacks/projects-api/docs/parts-api.md
@@ -1,0 +1,278 @@
+# Parts catalog API
+
+Phase 1 (issue #121) endpoints. Mounted under `/api/parts`. All mutation
+endpoints (POST/PUT/restore) require a logged-in user **and** an account
+that is at least 14 days old. Read endpoints are public.
+
+Auth: send the Chatter JWT either via the `access_token` cookie
+(domain `.kevsrobots.com`, value `Bearer <jwt>`) or an
+`Authorization: Bearer <jwt>` header.
+
+The 14-day gate looks the username up against Chatter's `/api/me`
+endpoint and caches the result in-process for 1 hour. If Chatter is
+unreachable or omits `account_created_at`, the gate fails closed with
+HTTP 403 `"Account age cannot be verified"`.
+
+---
+
+## GET `/api/parts`
+
+Substring search across `name`, `sku`, `mpn`, and any registered alias.
+
+### Query params
+
+| name  | type   | default | description                                        |
+| ----- | ------ | ------- | -------------------------------------------------- |
+| `q`   | string | _none_  | search term. Empty / omitted returns popular parts |
+| `limit` | int  | `10`    | 1 – 50                                             |
+
+### Response — `200 OK`
+
+```json
+[
+  {
+    "id": 12,
+    "slug": "sg90-micro-servo",
+    "name": "SG90 Micro Servo",
+    "sku": "SG90",
+    "status": "draft",
+    "usage_count": 4,
+    "primary_supplier_url": "https://thepihut.com/products/sg90-micro-servo"
+  }
+]
+```
+
+`primary_supplier_url` is the first registered supplier for the part, or
+`null` if none.
+
+---
+
+## POST `/api/parts`
+
+Create a new draft part. Auto-slugifies the name (with `-2`, `-3` etc.
+suffixes on collision) and writes an initial revision with
+`change_summary = "Initial draft"`.
+
+### Request body
+
+```json
+{
+  "name": "SG90 Micro Servo",
+  "sku": "SG90",
+  "mpn": null,
+  "description_md": null,
+  "image_url": null,
+  "supplier_url": "https://thepihut.com/products/sg90-micro-servo",
+  "supplier_name": "ThePiHut",
+  "tags": ["servo", "rc"]
+}
+```
+
+Only `name` is required. `supplier_url` is optional; if provided, a single
+`PartSupplier` row is created with `supplier_name` (optional).
+
+### Response — `201 Created`
+
+Returns a [PartDetail](#partdetail-shape). See `GET /api/parts/{slug}`.
+
+### Errors
+
+* `401 Unauthorized` — no / invalid JWT.
+* `403 Forbidden` — account younger than 14 days, or account age can't be
+  verified (Chatter down / no `account_created_at` field).
+* `422 Unprocessable Entity` — validation error (name too short, etc.).
+
+---
+
+## GET `/api/parts/{slug}`
+
+Returns the full part incl. suppliers and the 10 most recent revisions.
+
+### Response — `200 OK` — PartDetail shape
+
+```json
+{
+  "id": 12,
+  "slug": "sg90-micro-servo",
+  "name": "SG90 Micro Servo",
+  "sku": "SG90",
+  "mpn": null,
+  "description_md": "Plastic-geared hobby servo …",
+  "image_url": "https://…/sg90.jpg",
+  "tags": ["servo", "rc"],
+  "status": "draft",
+  "created_by": "kev",
+  "created_at": "2026-05-15T11:22:33",
+  "updated_at": "2026-05-15T11:22:33",
+  "current_revision_id": 87,
+  "usage_count": 4,
+  "suppliers": [
+    {
+      "id": 31,
+      "name": "ThePiHut",
+      "url": "https://thepihut.com/products/sg90-micro-servo",
+      "last_checked_at": null,
+      "last_status": null
+    }
+  ],
+  "recent_revisions": [
+    {
+      "id": 87,
+      "author": "kev",
+      "created_at": "2026-05-15T11:22:33",
+      "change_summary": "Fix supplier URL"
+    }
+  ]
+}
+```
+
+Timestamps are naive UTC ISO-8601 (no timezone suffix).
+
+### Errors
+
+* `404 Not Found` — slug doesn't exist.
+
+---
+
+## PUT `/api/parts/{slug}`
+
+Write a new revision. The server diffs the request against the current
+part state; if **no field actually changes**, returns `400 Bad Request`
+with detail `"No fields changed"`. Otherwise:
+
+* Writes a new `PartRevision` snapshot.
+* Updates `parts.current_revision_id` and the part's editable fields.
+* If `suppliers` is provided, replaces the supplier list en-bloc.
+
+### Request body
+
+```json
+{
+  "name": "SG90 Micro Servo (9g)",
+  "sku": "SG90",
+  "mpn": null,
+  "description_md": "Updated description …",
+  "image_url": null,
+  "tags": ["servo", "rc", "9g"],
+  "suppliers": [
+    { "name": "ThePiHut", "url": "https://thepihut.com/products/sg90-micro-servo" },
+    { "name": "AliExpress", "url": "https://aliexpress.com/item/…" }
+  ],
+  "change_summary": "Add second supplier and update spec"
+}
+```
+
+All editable fields are optional **except** `change_summary` (1 – 200
+chars). Omitting a field means "leave it alone". Omitting `suppliers`
+means "leave supplier list alone"; passing `[]` means "remove all
+suppliers".
+
+### Response — `200 OK`
+
+Returns the updated [PartDetail](#partdetail-shape).
+
+### Errors
+
+* `400 Bad Request` — diff is empty (no fields changed).
+* `401 / 403` — see POST.
+* `404 Not Found` — slug doesn't exist.
+
+---
+
+## GET `/api/parts/{slug}/revisions`
+
+Paginated revision list.
+
+### Query params
+
+| name     | type | default | description |
+| -------- | ---- | ------- | ----------- |
+| `limit`  | int  | `20`    | 1 – 100     |
+| `offset` | int  | `0`     | ≥ 0         |
+
+### Response — `200 OK`
+
+```json
+[
+  {
+    "id": 87,
+    "author": "kev",
+    "created_at": "2026-05-15T11:22:33",
+    "change_summary": "Fix supplier URL"
+  }
+]
+```
+
+---
+
+## GET `/api/parts/{slug}/revisions/{rev_id}`
+
+Returns a single revision snapshot. Useful for the "diff vs current"
+view on the history page.
+
+### Response — `200 OK`
+
+```json
+{
+  "id": 87,
+  "author": "kev",
+  "created_at": "2026-05-15T11:22:33",
+  "change_summary": "Fix supplier URL",
+  "name": "SG90 Micro Servo",
+  "sku": "SG90",
+  "mpn": null,
+  "description_md": "Plastic-geared hobby servo …",
+  "image_url": null,
+  "tags": ["servo", "rc"],
+  "suppliers": [
+    { "name": "ThePiHut", "url": "https://thepihut.com/products/sg90-micro-servo" }
+  ]
+}
+```
+
+---
+
+## POST `/api/parts/{slug}/revisions/{rev_id}/restore`
+
+Writes a **new** revision whose snapshot equals `rev_id`. History stays
+linear (the old revision is not deleted). The new revision's
+`change_summary` is `"Restored from revision #<rev_id>"`.
+
+### Response — `200 OK`
+
+Returns the resulting [PartDetail](#partdetail-shape) (now pointing at
+the newly-written revision).
+
+### Errors
+
+* `401 / 403` — same as POST.
+* `404 Not Found` — slug or rev_id doesn't exist.
+
+---
+
+## BOM integration
+
+`BOMItemCreate` / `BOMItemResponse` now include an optional `part_id`
+(nullable int). When set on a BOM row, `parts.usage_count` is kept in
+sync as `COUNT(DISTINCT project_id) FROM project_bom_items WHERE
+part_id = ?`. The free-form fields (`name`, `quantity`, `unit`,
+`unit_cost`, `supplier_url`) still work and remain authoritative — the
+frontend should populate them from the chosen part for display, but the
+catalog row is the source of truth for future revisions.
+
+### Example BOM body
+
+```json
+{
+  "name": "SG90 Micro Servo",
+  "quantity": 4,
+  "unit": "qty",
+  "unit_cost": 2.50,
+  "supplier_url": "https://thepihut.com/products/sg90-micro-servo",
+  "sort_order": 0,
+  "part_id": 12
+}
+```
+
+If `part_id` points at a non-existent catalog row, the server silently
+sets it to `null` rather than rejecting the BOM mutation.

--- a/stacks/projects-api/projects_api/auth.py
+++ b/stacks/projects-api/projects_api/auth.py
@@ -1,13 +1,35 @@
-"""Auth middleware — verifies Chatter JWT tokens."""
+"""Auth middleware — verifies Chatter JWT tokens.
+
+Also exposes a 14-day account-age gate used by the parts catalog
+(issue #121). The JWT only carries the `sub` claim today, so we fall back
+to looking up the user's account creation date from Chatter and caching
+it in-process for 1 hour. The lookup is hidden behind a single coroutine
+so tests can monkeypatch it without spinning up an HTTP mock.
+"""
 
 from __future__ import annotations
 
+import logging
+import time
+from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import Cookie, Header, HTTPException, status
+import httpx
+from fastapi import Cookie, Depends, Header, HTTPException, status
 from jose import JWTError, jwt
 
 from .config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# In-process cache: username -> (account_created_at | None, expires_epoch).
+# A `None` value is cached too (briefly) so a Chatter outage doesn't melt
+# us under retries; the cache TTL is short enough for stale entries to be
+# self-healing.
+_ACCOUNT_AGE_CACHE: dict[str, tuple[Optional[datetime], float]] = {}
+_ACCOUNT_AGE_TTL_SECONDS = 3600  # 1 hour
+_ACCOUNT_AGE_NEGATIVE_TTL_SECONDS = 60  # cache lookup failures briefly
+MIN_ACCOUNT_AGE_DAYS = 14
 
 
 def get_current_user(
@@ -63,3 +85,105 @@ def get_optional_user(
         return get_current_user(access_token, authorization)
     except HTTPException:
         return None
+
+
+def _extract_token(access_token: Optional[str], authorization: Optional[str]) -> Optional[str]:
+    if access_token and access_token.startswith("Bearer "):
+        return access_token[7:]
+    if authorization and authorization.startswith("Bearer "):
+        return authorization[7:]
+    return None
+
+
+def _parse_iso8601(value: str) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp from Chatter. Returns naive UTC."""
+    try:
+        # Accept trailing "Z" which fromisoformat() doesn't grok pre-3.11.
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+    except (TypeError, ValueError):
+        return None
+
+
+async def fetch_account_created_at(username: str, token: str) -> Optional[datetime]:
+    """Ask Chatter when this account was created.
+
+    Returns a naive UTC datetime, or None if the field couldn't be
+    determined (network error, missing field, etc.). Caches both
+    successful and failed lookups in-process for a short TTL.
+
+    Tests monkeypatch this function — keep the signature stable.
+    """
+    now = time.time()
+    cached = _ACCOUNT_AGE_CACHE.get(username)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+
+    settings = get_settings()
+    url = f"{settings.chatter_base_url.rstrip('/')}/api/me"
+    created: Optional[datetime] = None
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as http:
+            resp = await http.get(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                raw = data.get("account_created_at") or data.get("created_at")
+                if isinstance(raw, str):
+                    created = _parse_iso8601(raw)
+                elif isinstance(raw, (int, float)):
+                    created = datetime.utcfromtimestamp(raw)
+    except Exception as exc:  # network / parsing — fail closed below
+        logger.warning("Chatter account-age lookup failed for %s: %s", username, exc)
+
+    ttl = _ACCOUNT_AGE_TTL_SECONDS if created is not None else _ACCOUNT_AGE_NEGATIVE_TTL_SECONDS
+    _ACCOUNT_AGE_CACHE[username] = (created, now + ttl)
+    return created
+
+
+def _clear_account_age_cache() -> None:
+    """Test helper: drop the in-process cache."""
+    _ACCOUNT_AGE_CACHE.clear()
+
+
+async def get_current_user_aged(
+    access_token: Optional[str] = Cookie(default=None),
+    authorization: Optional[str] = Header(default=None),
+) -> str:
+    """Like ``get_current_user`` but also enforces a 14-day account-age gate.
+
+    Used by parts-catalog mutation endpoints (POST/PUT/restore). On any
+    lookup failure we fail closed — better to ask the user to come back
+    later than to let a brand-new account spam-edit the wiki.
+    """
+    username = get_current_user(access_token=access_token, authorization=authorization)
+    token = _extract_token(access_token, authorization)
+    if token is None:
+        # get_current_user would have raised already, but be defensive.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    created_at = await fetch_account_created_at(username, token)
+    if created_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Account age cannot be verified",
+        )
+
+    now = datetime.utcnow()
+    age_days = (now - created_at).total_seconds() / 86400.0
+    if age_days < MIN_ACCOUNT_AGE_DAYS:
+        remaining = max(0, MIN_ACCOUNT_AGE_DAYS - int(age_days))
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Account must be at least {MIN_ACCOUNT_AGE_DAYS} days old to edit the parts catalog. Come back in {remaining} day(s).",
+        )
+    return username

--- a/stacks/projects-api/projects_api/config.py
+++ b/stacks/projects-api/projects_api/config.py
@@ -30,6 +30,10 @@ class Settings(BaseSettings):
     jwt_secret: str = "changeme"
     jwt_algorithm: str = "HS256"
 
+    # Base URL for the Chatter auth service. Used by the parts catalog
+    # account-age gate to look up `account_created_at` from `/api/me`.
+    chatter_base_url: str = "https://chatter.kevsrobots.com"
+
     # NAS storage
     nas_host: str = "192.168.1.79"
     nas_username: Optional[str] = None

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -10,7 +10,17 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
 from .db import create_all, repair_stale_fks
-from .routers import bom, files, health, images, journal, links, moderation, projects
+from .routers import (
+    bom,
+    files,
+    health,
+    images,
+    journal,
+    links,
+    moderation,
+    parts,
+    projects,
+)
 
 
 @asynccontextmanager
@@ -43,6 +53,7 @@ def create_app() -> FastAPI:
     app.include_router(links.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
+    app.include_router(parts.router)
     return app
 
 

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -6,10 +6,12 @@ from datetime import datetime
 from typing import Any, Optional
 
 from sqlalchemy import (
+    ARRAY,
     Boolean,
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -22,6 +24,9 @@ from sqlalchemy.types import JSON
 from .db import Base
 
 JsonType = JSONB().with_variant(JSON(), "sqlite")
+
+# Tags array: native text[] on Postgres, JSON list on SQLite (for tests).
+TagsType = ARRAY(String).with_variant(JSON(), "sqlite")
 
 
 class Project(Base):
@@ -87,6 +92,13 @@ class ProjectBOMItem(Base):
     unit_cost: Mapped[Optional[float]] = mapped_column(Float)
     supplier_url: Mapped[Optional[str]] = mapped_column(Text)
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Optional link to a part in the shared parts catalog. When set, the
+    # part's data is the source of truth and the free-form fields above are
+    # kept for back-compat / display. Set to NULL on part delete so rows
+    # survive parts catalog churn.
+    part_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("parts.id", ondelete="SET NULL"), nullable=True, index=True
+    )
 
 
 class ProjectLink(Base):
@@ -164,3 +176,104 @@ class ProjectJournalImage(Base):
     uploaded_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )
+
+
+# --- Parts catalog (issue #121, Phase 1) ---------------------------------
+#
+# A shared, wiki-style catalog of reusable components. BOM rows may link to
+# a `Part` so that supplier URLs / specs / images are looked up once and
+# reused across projects.
+#
+# Schema decisions for v1:
+#   * `current_revision_id` is a nullable FK to break the circular dep with
+#     `part_revisions`. It's set after the first revision row is written.
+#   * `usage_count` is a denormalised cache of distinct projects using the
+#     part. We update it in the same transaction as BOM mutations (see
+#     `routers/bom.py`). A Phase-2 cron will recompute it from
+#     `SELECT COUNT(DISTINCT project_id) FROM project_bom_items WHERE part_id=?`
+#     to repair any drift.
+#   * `status` is a free string for now — `draft`/`verified`/`under_review`.
+#     The `merged_into:<id>` value comes in Phase 3 (merge proposals).
+
+
+class Part(Base):
+    __tablename__ = "parts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    slug: Mapped[str] = mapped_column(String(120), nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    sku: Mapped[Optional[str]] = mapped_column(String(100), index=True)
+    mpn: Mapped[Optional[str]] = mapped_column(String(100), index=True)
+    description_md: Mapped[Optional[str]] = mapped_column(Text)
+    image_url: Mapped[Optional[str]] = mapped_column(Text)
+    tags: Mapped[Optional[list]] = mapped_column(TagsType)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="draft")
+    created_by: Mapped[str] = mapped_column(String(100), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    # FK is added without `use_alter` because we never INSERT a part with a
+    # known revision id — the revision row is written first, then we patch
+    # this column.
+    current_revision_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("part_revisions.id", ondelete="SET NULL", use_alter=True, name="fk_parts_current_revision"),
+        nullable=True,
+    )
+    usage_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+
+
+class PartAlias(Base):
+    __tablename__ = "part_aliases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part_id: Mapped[int] = mapped_column(
+        ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    alias: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    __table_args__ = (
+        # Functional index for case-insensitive search. Postgres respects it
+        # for queries against `func.lower(alias)`; SQLite ignores the func
+        # expression and falls back to a sequential scan (fine for tests).
+        Index("ix_part_aliases_lower_alias", func.lower(alias)),
+    )
+
+
+class PartSupplier(Base):
+    __tablename__ = "part_suppliers"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part_id: Mapped[int] = mapped_column(
+        ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    supplier_name: Mapped[Optional[str]] = mapped_column(String(120))
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    last_checked_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    last_status: Mapped[Optional[str]] = mapped_column(String(30))
+
+
+class PartRevision(Base):
+    __tablename__ = "part_revisions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part_id: Mapped[int] = mapped_column(
+        ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    author: Mapped[str] = mapped_column(String(100), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    change_summary: Mapped[str] = mapped_column(String(200), nullable=False)
+    # Snapshot of the editable fields at the time of the revision.
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    sku: Mapped[Optional[str]] = mapped_column(String(100))
+    mpn: Mapped[Optional[str]] = mapped_column(String(100))
+    description_md: Mapped[Optional[str]] = mapped_column(Text)
+    image_url: Mapped[Optional[str]] = mapped_column(Text)
+    tags: Mapped[Optional[list]] = mapped_column(TagsType)
+    # Suppliers are denormalised into the revision row as JSON so we don't
+    # need a sibling table per revision. Each entry: {name, url}.
+    suppliers_json: Mapped[Optional[list]] = mapped_column(JsonType)

--- a/stacks/projects-api/projects_api/routers/bom.py
+++ b/stacks/projects-api/projects_api/routers/bom.py
@@ -1,14 +1,24 @@
-"""Bill of Materials endpoints."""
+"""Bill of Materials endpoints.
+
+When BOM rows are mutated, we keep ``parts.usage_count`` in sync. The
+count tracks *distinct projects* that reference each part — adding a
+second BOM row for the same part in the same project must NOT bump the
+counter, and removing it must NOT decrement past the last row that
+references it. The helpers below encode that rule using a fresh count
+query inside the same transaction as the mutation.
+"""
 
 from __future__ import annotations
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user
 from ..db import get_session
-from ..models import Project, ProjectBOMItem
+from ..models import Part, Project, ProjectBOMItem
 from ..schemas import BOMItemCreate, BOMItemResponse
 
 router = APIRouter(prefix="/api/projects/{project_id}/bom", tags=["bom"])
@@ -21,6 +31,23 @@ async def _check_owner(session: AsyncSession, project_id: int, user: str) -> Pro
     if project.author_username != user:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not the project owner")
     return project
+
+
+async def _refresh_usage_count(session: AsyncSession, part_id: int) -> None:
+    """Recompute ``parts.usage_count`` as COUNT(DISTINCT project_id).
+
+    Cheap (single index lookup) and avoids tricky "is this the only row
+    for this part in this project?" bookkeeping. Clamped to >= 0.
+    """
+    part = await session.get(Part, part_id)
+    if part is None:
+        return
+    count = await session.scalar(
+        select(func.count(func.distinct(ProjectBOMItem.project_id))).where(
+            ProjectBOMItem.part_id == part_id
+        )
+    )
+    part.usage_count = max(0, int(count or 0))
 
 
 @router.get("", response_model=list[BOMItemResponse])
@@ -46,8 +73,21 @@ async def add_bom_item(
     session: AsyncSession = Depends(get_session),
 ) -> BOMItemResponse:
     await _check_owner(session, project_id, user)
-    item = ProjectBOMItem(project_id=project_id, **body.model_dump())
+    payload = body.model_dump()
+    part_id: Optional[int] = payload.get("part_id")
+    if part_id is not None:
+        # Validate the part exists; if not, drop the link rather than 400.
+        # (BOM creation shouldn't blow up because the catalog row was
+        # deleted out from under us.)
+        existing = await session.get(Part, part_id)
+        if existing is None:
+            payload["part_id"] = None
+            part_id = None
+    item = ProjectBOMItem(project_id=project_id, **payload)
     session.add(item)
+    await session.flush()
+    if part_id is not None:
+        await _refresh_usage_count(session, part_id)
     await session.commit()
     await session.refresh(item)
     return BOMItemResponse.model_validate(item, from_attributes=True)
@@ -65,8 +105,22 @@ async def update_bom_item(
     item = await session.get(ProjectBOMItem, item_id)
     if item is None or item.project_id != project_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="BOM item not found")
-    for field, value in body.model_dump().items():
+    old_part_id = item.part_id
+    payload = body.model_dump()
+    new_part_id: Optional[int] = payload.get("part_id")
+    if new_part_id is not None:
+        existing = await session.get(Part, new_part_id)
+        if existing is None:
+            payload["part_id"] = None
+            new_part_id = None
+    for field, value in payload.items():
         setattr(item, field, value)
+    await session.flush()
+    if old_part_id != new_part_id:
+        if old_part_id is not None:
+            await _refresh_usage_count(session, old_part_id)
+        if new_part_id is not None:
+            await _refresh_usage_count(session, new_part_id)
     await session.commit()
     await session.refresh(item)
     return BOMItemResponse.model_validate(item, from_attributes=True)
@@ -83,5 +137,9 @@ async def delete_bom_item(
     item = await session.get(ProjectBOMItem, item_id)
     if item is None or item.project_id != project_id:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="BOM item not found")
+    old_part_id = item.part_id
     await session.delete(item)
+    await session.flush()
+    if old_part_id is not None:
+        await _refresh_usage_count(session, old_part_id)
     await session.commit()

--- a/stacks/projects-api/projects_api/routers/parts.py
+++ b/stacks/projects-api/projects_api/routers/parts.py
@@ -1,0 +1,540 @@
+"""Parts catalog endpoints (issue #121, Phase 1 MVP).
+
+This router implements:
+
+* ``GET    /api/parts``                 — fuzzy search across name + aliases
+                                          + sku + mpn.
+* ``POST   /api/parts``                 — create a draft part (14-day gated).
+* ``GET    /api/parts/{slug}``          — full part incl. suppliers + last
+                                          10 revisions.
+* ``PUT    /api/parts/{slug}``          — write a new revision (14-day
+                                          gated). Rejects if no field
+                                          actually changed.
+* ``GET    /api/parts/{slug}/revisions``— paginated revision list.
+* ``POST   /api/parts/{slug}/revisions/{rev_id}/restore`` — non-destructive
+                                          restore (writes a new revision
+                                          whose snapshot equals rev_id).
+
+Account-age gate
+----------------
+Mutating endpoints depend on :func:`get_current_user_aged` which calls
+:func:`fetch_account_created_at` against Chatter's ``/api/me``. If Chatter
+is unreachable or omits the ``account_created_at`` field, the gate fails
+closed (HTTP 403 "Account age cannot be verified"). Tests monkeypatch
+``fetch_account_created_at`` directly.
+
+Usage-count semantics
+---------------------
+``parts.usage_count`` is a denormalised cache of *distinct projects* that
+reference the part. It's maintained transactionally in
+``routers/bom.py`` as BOM rows are inserted / updated / deleted. If it
+ever drifts (e.g. due to a manual DB poke), a Phase-2 cron will recompute
+it from ``SELECT COUNT(DISTINCT project_id) FROM project_bom_items WHERE
+part_id=?``.
+
+Search v1
+---------
+We use ``lower()``-substring matching against ``parts.name``,
+``parts.sku``, ``parts.mpn`` and ``part_aliases.alias``. This is fine for
+the small corpus we'll have in Phase 1. When the catalog grows we'll swap
+this for ``pg_trgm`` (or a dedicated search index) without changing the
+API contract.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import delete, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import get_current_user_aged
+from ..db import get_session
+from ..models import Part, PartAlias, PartRevision, PartSupplier
+from ..schemas import (
+    PartCreate,
+    PartDetail,
+    PartRevisionDetail,
+    PartRevisionSummary,
+    PartSearchResult,
+    PartSupplierInput,
+    PartSupplierResponse,
+    PartUpdate,
+)
+
+router = APIRouter(prefix="/api/parts", tags=["parts"])
+
+
+# --- helpers ------------------------------------------------------------
+
+
+_SLUG_BAD_CHARS = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(name: str) -> str:
+    base = _SLUG_BAD_CHARS.sub("-", name.lower()).strip("-")
+    # Cap at 80 chars; the DB column is 120 so disambig suffixes have room.
+    return (base[:80] or "part").rstrip("-")
+
+
+async def _unique_slug(session: AsyncSession, base: str) -> str:
+    """Append -2, -3, ... until the slug is unique."""
+    candidate = base
+    suffix = 2
+    while True:
+        existing = await session.scalar(select(Part.id).where(Part.slug == candidate))
+        if existing is None:
+            return candidate
+        candidate = f"{base}-{suffix}"
+        suffix += 1
+
+
+def _now_naive_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _load_suppliers(session: AsyncSession, part_id: int) -> list[PartSupplier]:
+    return list(
+        (
+            await session.scalars(
+                select(PartSupplier)
+                .where(PartSupplier.part_id == part_id)
+                .order_by(PartSupplier.id)
+            )
+        ).all()
+    )
+
+
+def _supplier_response(s: PartSupplier) -> PartSupplierResponse:
+    return PartSupplierResponse(
+        id=s.id,
+        name=s.supplier_name,
+        url=s.url,
+        last_checked_at=s.last_checked_at,
+        last_status=s.last_status,
+    )
+
+
+def _suppliers_to_json(suppliers: list[PartSupplier]) -> list[dict]:
+    return [{"name": s.supplier_name, "url": s.url} for s in suppliers]
+
+
+async def _recompute_usage_count(session: AsyncSession, part_id: int) -> int:
+    """Recompute usage_count as ``COUNT(DISTINCT project_id)`` of BOM rows.
+
+    Cheaper alternative used by the BOM mutation hooks (in ``bom.py``).
+    Exposed here for the rare case the cache needs to be refreshed.
+    """
+    from ..models import ProjectBOMItem
+
+    count = await session.scalar(
+        select(func.count(func.distinct(ProjectBOMItem.project_id))).where(
+            ProjectBOMItem.part_id == part_id
+        )
+    )
+    return int(count or 0)
+
+
+async def _part_detail(session: AsyncSession, part: Part) -> PartDetail:
+    suppliers = await _load_suppliers(session, part.id)
+    revs = (
+        await session.scalars(
+            select(PartRevision)
+            .where(PartRevision.part_id == part.id)
+            .order_by(PartRevision.created_at.desc(), PartRevision.id.desc())
+            .limit(10)
+        )
+    ).all()
+    return PartDetail(
+        id=part.id,
+        slug=part.slug,
+        name=part.name,
+        sku=part.sku,
+        mpn=part.mpn,
+        description_md=part.description_md,
+        image_url=part.image_url,
+        tags=list(part.tags or []),
+        status=part.status,
+        created_by=part.created_by,
+        created_at=part.created_at,
+        updated_at=part.updated_at,
+        current_revision_id=part.current_revision_id,
+        usage_count=part.usage_count,
+        suppliers=[_supplier_response(s) for s in suppliers],
+        recent_revisions=[
+            PartRevisionSummary(
+                id=r.id,
+                author=r.author,
+                created_at=r.created_at,
+                change_summary=r.change_summary,
+            )
+            for r in revs
+        ],
+    )
+
+
+async def _primary_supplier_url(session: AsyncSession, part_id: int) -> Optional[str]:
+    row = await session.scalar(
+        select(PartSupplier.url)
+        .where(PartSupplier.part_id == part_id)
+        .order_by(PartSupplier.id)
+        .limit(1)
+    )
+    return row
+
+
+# --- endpoints ----------------------------------------------------------
+
+
+@router.get("", response_model=list[PartSearchResult])
+async def search_parts(
+    q: Optional[str] = Query(None, max_length=200),
+    limit: int = Query(10, ge=1, le=50),
+    session: AsyncSession = Depends(get_session),
+) -> list[PartSearchResult]:
+    """Substring search across name / sku / mpn / aliases.
+
+    Empty or whitespace-only ``q`` returns the most-used parts so the
+    BOM-editor autosuggest can show something useful on focus.
+    """
+    if not q or not q.strip():
+        parts = (
+            await session.scalars(
+                select(Part).order_by(Part.usage_count.desc(), Part.name.asc()).limit(limit)
+            )
+        ).all()
+    else:
+        needle = f"%{q.strip().lower()}%"
+        # Match against name/sku/mpn directly, plus any alias that matches.
+        alias_part_ids_subq = (
+            select(PartAlias.part_id)
+            .where(func.lower(PartAlias.alias).like(needle))
+        )
+        parts = (
+            await session.scalars(
+                select(Part)
+                .where(
+                    or_(
+                        func.lower(Part.name).like(needle),
+                        func.lower(func.coalesce(Part.sku, "")).like(needle),
+                        func.lower(func.coalesce(Part.mpn, "")).like(needle),
+                        Part.id.in_(alias_part_ids_subq),
+                    )
+                )
+                .order_by(Part.usage_count.desc(), Part.name.asc())
+                .limit(limit)
+            )
+        ).all()
+
+    results: list[PartSearchResult] = []
+    for p in parts:
+        results.append(
+            PartSearchResult(
+                id=p.id,
+                slug=p.slug,
+                name=p.name,
+                sku=p.sku,
+                status=p.status,
+                usage_count=p.usage_count,
+                primary_supplier_url=await _primary_supplier_url(session, p.id),
+            )
+        )
+    return results
+
+
+@router.post("", response_model=PartDetail, status_code=201)
+async def create_part(
+    body: PartCreate,
+    user: str = Depends(get_current_user_aged),
+    session: AsyncSession = Depends(get_session),
+) -> PartDetail:
+    slug = await _unique_slug(session, _slugify(body.name))
+    now = _now_naive_utc()
+    tags = [t.strip() for t in body.tags if t and t.strip()]
+    part = Part(
+        slug=slug,
+        name=body.name,
+        sku=body.sku or None,
+        mpn=body.mpn or None,
+        description_md=body.description_md,
+        image_url=body.image_url,
+        tags=tags,
+        status="draft",
+        created_by=user,
+        created_at=now,
+        updated_at=now,
+        usage_count=0,
+    )
+    session.add(part)
+    await session.flush()
+
+    suppliers: list[PartSupplier] = []
+    if body.supplier_url:
+        sup = PartSupplier(
+            part_id=part.id,
+            supplier_name=body.supplier_name,
+            url=body.supplier_url,
+        )
+        session.add(sup)
+        await session.flush()
+        suppliers.append(sup)
+
+    rev = PartRevision(
+        part_id=part.id,
+        author=user,
+        change_summary="Initial draft",
+        name=part.name,
+        sku=part.sku,
+        mpn=part.mpn,
+        description_md=part.description_md,
+        image_url=part.image_url,
+        tags=list(tags),
+        suppliers_json=_suppliers_to_json(suppliers),
+        created_at=now,
+    )
+    session.add(rev)
+    await session.flush()
+    part.current_revision_id = rev.id
+
+    await session.commit()
+    await session.refresh(part)
+    return await _part_detail(session, part)
+
+
+async def _get_part_by_slug(session: AsyncSession, slug: str) -> Part:
+    part = await session.scalar(select(Part).where(Part.slug == slug))
+    if part is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Part not found")
+    return part
+
+
+@router.get("/{slug}", response_model=PartDetail)
+async def get_part(
+    slug: str,
+    session: AsyncSession = Depends(get_session),
+) -> PartDetail:
+    part = await _get_part_by_slug(session, slug)
+    return await _part_detail(session, part)
+
+
+def _normalize_tags(tags: Optional[list[str]]) -> list[str]:
+    if not tags:
+        return []
+    return [t.strip() for t in tags if t and t.strip()]
+
+
+def _supplier_signature(suppliers: list[dict]) -> list[tuple]:
+    """Hashable view of suppliers for change detection (order matters)."""
+    return [(s.get("name"), s.get("url")) for s in suppliers]
+
+
+@router.put("/{slug}", response_model=PartDetail)
+async def update_part(
+    slug: str,
+    body: PartUpdate,
+    user: str = Depends(get_current_user_aged),
+    session: AsyncSession = Depends(get_session),
+) -> PartDetail:
+    part = await _get_part_by_slug(session, slug)
+
+    # Resolve the *next* state for each editable field. None on the body
+    # means "no change requested for this field".
+    next_name = body.name if body.name is not None else part.name
+    next_sku = body.sku if body.sku is not None else part.sku
+    next_mpn = body.mpn if body.mpn is not None else part.mpn
+    next_desc = body.description_md if body.description_md is not None else part.description_md
+    next_image = body.image_url if body.image_url is not None else part.image_url
+    next_tags = _normalize_tags(body.tags) if body.tags is not None else list(part.tags or [])
+
+    current_suppliers = await _load_suppliers(session, part.id)
+    current_supplier_json = _suppliers_to_json(current_suppliers)
+    if body.suppliers is not None:
+        next_supplier_json = [
+            {"name": (s.name or None), "url": s.url} for s in body.suppliers
+        ]
+    else:
+        next_supplier_json = current_supplier_json
+
+    # Diff vs current — reject if nothing actually changed.
+    changed = (
+        next_name != part.name
+        or next_sku != part.sku
+        or next_mpn != part.mpn
+        or next_desc != part.description_md
+        or next_image != part.image_url
+        or list(next_tags) != list(part.tags or [])
+        or _supplier_signature(next_supplier_json) != _supplier_signature(current_supplier_json)
+    )
+    if not changed:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="No fields changed",
+        )
+
+    now = _now_naive_utc()
+    # Write the revision first so we have an id to point `current_revision_id` at.
+    rev = PartRevision(
+        part_id=part.id,
+        author=user,
+        change_summary=body.change_summary,
+        name=next_name,
+        sku=next_sku,
+        mpn=next_mpn,
+        description_md=next_desc,
+        image_url=next_image,
+        tags=list(next_tags),
+        suppliers_json=next_supplier_json,
+        created_at=now,
+    )
+    session.add(rev)
+    await session.flush()
+
+    # Apply to the part itself.
+    part.name = next_name
+    part.sku = next_sku
+    part.mpn = next_mpn
+    part.description_md = next_desc
+    part.image_url = next_image
+    part.tags = list(next_tags)
+    part.current_revision_id = rev.id
+    part.updated_at = now
+
+    # Replace suppliers en-bloc (simplest correct behaviour for v1).
+    if body.suppliers is not None:
+        await session.execute(
+            delete(PartSupplier).where(PartSupplier.part_id == part.id)
+        )
+        for entry in next_supplier_json:
+            session.add(
+                PartSupplier(
+                    part_id=part.id,
+                    supplier_name=entry.get("name"),
+                    url=entry.get("url"),
+                )
+            )
+
+    await session.commit()
+    await session.refresh(part)
+    return await _part_detail(session, part)
+
+
+@router.get("/{slug}/revisions", response_model=list[PartRevisionSummary])
+async def list_revisions(
+    slug: str,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> list[PartRevisionSummary]:
+    part = await _get_part_by_slug(session, slug)
+    revs = (
+        await session.scalars(
+            select(PartRevision)
+            .where(PartRevision.part_id == part.id)
+            .order_by(PartRevision.created_at.desc(), PartRevision.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+    ).all()
+    return [
+        PartRevisionSummary(
+            id=r.id,
+            author=r.author,
+            created_at=r.created_at,
+            change_summary=r.change_summary,
+        )
+        for r in revs
+    ]
+
+
+@router.get("/{slug}/revisions/{rev_id}", response_model=PartRevisionDetail)
+async def get_revision(
+    slug: str,
+    rev_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> PartRevisionDetail:
+    part = await _get_part_by_slug(session, slug)
+    rev = await session.get(PartRevision, rev_id)
+    if rev is None or rev.part_id != part.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Revision not found")
+    suppliers_raw = rev.suppliers_json or []
+    suppliers = [
+        PartSupplierInput(name=s.get("name"), url=s.get("url", ""))
+        for s in suppliers_raw
+        if s.get("url")
+    ]
+    return PartRevisionDetail(
+        id=rev.id,
+        author=rev.author,
+        created_at=rev.created_at,
+        change_summary=rev.change_summary,
+        name=rev.name,
+        sku=rev.sku,
+        mpn=rev.mpn,
+        description_md=rev.description_md,
+        image_url=rev.image_url,
+        tags=list(rev.tags or []),
+        suppliers=suppliers,
+    )
+
+
+@router.post("/{slug}/revisions/{rev_id}/restore", response_model=PartDetail)
+async def restore_revision(
+    slug: str,
+    rev_id: int,
+    user: str = Depends(get_current_user_aged),
+    session: AsyncSession = Depends(get_session),
+) -> PartDetail:
+    """Non-destructive restore: write a NEW revision whose snapshot
+    equals ``rev_id``. History stays linear."""
+    part = await _get_part_by_slug(session, slug)
+    source = await session.get(PartRevision, rev_id)
+    if source is None or source.part_id != part.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Revision not found")
+
+    now = _now_naive_utc()
+    suppliers_json = list(source.suppliers_json or [])
+    new_rev = PartRevision(
+        part_id=part.id,
+        author=user,
+        change_summary=f"Restored from revision #{source.id}",
+        name=source.name,
+        sku=source.sku,
+        mpn=source.mpn,
+        description_md=source.description_md,
+        image_url=source.image_url,
+        tags=list(source.tags or []),
+        suppliers_json=suppliers_json,
+        created_at=now,
+    )
+    session.add(new_rev)
+    await session.flush()
+
+    part.name = source.name
+    part.sku = source.sku
+    part.mpn = source.mpn
+    part.description_md = source.description_md
+    part.image_url = source.image_url
+    part.tags = list(source.tags or [])
+    part.current_revision_id = new_rev.id
+    part.updated_at = now
+
+    await session.execute(
+        delete(PartSupplier).where(PartSupplier.part_id == part.id)
+    )
+    for entry in suppliers_json:
+        if not entry.get("url"):
+            continue
+        session.add(
+            PartSupplier(
+                part_id=part.id,
+                supplier_name=entry.get("name"),
+                url=entry.get("url"),
+            )
+        )
+
+    await session.commit()
+    await session.refresh(part)
+    return await _part_detail(session, part)

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -66,6 +66,7 @@ class BOMItemCreate(BaseModel):
     unit_cost: Optional[float] = None
     supplier_url: Optional[str] = None
     sort_order: int = 0
+    part_id: Optional[int] = None
 
 
 class BOMItemResponse(BaseModel):
@@ -76,6 +77,7 @@ class BOMItemResponse(BaseModel):
     unit_cost: Optional[float]
     supplier_url: Optional[str]
     sort_order: int
+    part_id: Optional[int] = None
 
 
 class LinkCreate(BaseModel):
@@ -156,3 +158,91 @@ class BlockedProjectResponse(BaseModel):
     is_blocked: bool
     moderation_note: Optional[str]
     created_at: datetime
+
+
+# --- Parts catalog (issue #121) ---
+
+
+class PartSupplierInput(BaseModel):
+    name: Optional[str] = Field(None, max_length=120)
+    url: str = Field(..., max_length=2000)
+
+
+class PartSupplierResponse(BaseModel):
+    id: int
+    name: Optional[str] = None
+    url: str
+    last_checked_at: Optional[datetime] = None
+    last_status: Optional[str] = None
+
+
+class PartCreate(BaseModel):
+    name: str = Field(..., min_length=2, max_length=200)
+    sku: Optional[str] = Field(None, max_length=100)
+    mpn: Optional[str] = Field(None, max_length=100)
+    description_md: Optional[str] = None
+    image_url: Optional[str] = Field(None, max_length=2000)
+    supplier_url: Optional[str] = Field(None, max_length=2000)
+    supplier_name: Optional[str] = Field(None, max_length=120)
+    tags: list[str] = Field(default_factory=list)
+
+
+class PartUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=2, max_length=200)
+    sku: Optional[str] = Field(None, max_length=100)
+    mpn: Optional[str] = Field(None, max_length=100)
+    description_md: Optional[str] = None
+    image_url: Optional[str] = Field(None, max_length=2000)
+    tags: Optional[list[str]] = None
+    suppliers: Optional[list[PartSupplierInput]] = None
+    change_summary: str = Field(..., min_length=1, max_length=200)
+
+
+class PartSearchResult(BaseModel):
+    id: int
+    slug: str
+    name: str
+    sku: Optional[str] = None
+    status: str
+    usage_count: int
+    primary_supplier_url: Optional[str] = None
+
+
+class PartRevisionSummary(BaseModel):
+    id: int
+    author: str
+    created_at: datetime
+    change_summary: str
+
+
+class PartRevisionDetail(BaseModel):
+    id: int
+    author: str
+    created_at: datetime
+    change_summary: str
+    name: str
+    sku: Optional[str] = None
+    mpn: Optional[str] = None
+    description_md: Optional[str] = None
+    image_url: Optional[str] = None
+    tags: list[str] = Field(default_factory=list)
+    suppliers: list[PartSupplierInput] = Field(default_factory=list)
+
+
+class PartDetail(BaseModel):
+    id: int
+    slug: str
+    name: str
+    sku: Optional[str] = None
+    mpn: Optional[str] = None
+    description_md: Optional[str] = None
+    image_url: Optional[str] = None
+    tags: list[str] = Field(default_factory=list)
+    status: str
+    created_by: str
+    created_at: datetime
+    updated_at: datetime
+    current_revision_id: Optional[int] = None
+    usage_count: int
+    suppliers: list[PartSupplierResponse] = Field(default_factory=list)
+    recent_revisions: list[PartRevisionSummary] = Field(default_factory=list)

--- a/stacks/projects-api/tests/test_parts.py
+++ b/stacks/projects-api/tests/test_parts.py
@@ -1,0 +1,328 @@
+"""Tests for the parts catalog (issue #121).
+
+The 14-day account-age gate is exercised by monkeypatching
+``projects_api.auth.fetch_account_created_at``. The default fixture
+returns a "5 years ago" timestamp so most tests don't have to think
+about it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture(autouse=True)
+def _old_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    """By default, pretend every account is 5 years old."""
+    from projects_api import auth as auth_module
+
+    async def _fake_age(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=365 * 5)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _fake_age)
+    auth_module._clear_account_age_cache()
+
+
+# --- create / get / search ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_part_writes_initial_revision(client) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/parts",
+        json={
+            "name": "SG90 Micro Servo",
+            "sku": "SG90",
+            "supplier_url": "https://example.com/sg90",
+            "supplier_name": "ThePiHut",
+            "tags": ["servo", "rc"],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["slug"] == "sg90-micro-servo"
+    assert data["name"] == "SG90 Micro Servo"
+    assert data["sku"] == "SG90"
+    assert data["created_by"] == "testuser"
+    assert data["status"] == "draft"
+    assert data["usage_count"] == 0
+    assert data["current_revision_id"] is not None
+    assert len(data["suppliers"]) == 1
+    assert data["suppliers"][0]["url"] == "https://example.com/sg90"
+    assert len(data["recent_revisions"]) == 1
+    assert data["recent_revisions"][0]["change_summary"] == "Initial draft"
+    assert sorted(data["tags"]) == ["rc", "servo"]
+
+
+@pytest.mark.asyncio
+async def test_slug_disambiguation(client) -> None:
+    headers = make_auth_header()
+    r1 = await client.post("/api/parts", json={"name": "Widget"}, headers=headers)
+    r2 = await client.post("/api/parts", json={"name": "Widget"}, headers=headers)
+    assert r1.json()["slug"] == "widget"
+    assert r2.json()["slug"] == "widget-2"
+
+
+@pytest.mark.asyncio
+async def test_search_matches_name_sku_and_mpn(client, session) -> None:
+    headers = make_auth_header()
+    await client.post(
+        "/api/parts",
+        json={"name": "SG90 Micro Servo", "sku": "SG90", "mpn": "TIANKONGRC-SG90"},
+        headers=headers,
+    )
+    await client.post(
+        "/api/parts",
+        json={"name": "Raspberry Pi Pico", "sku": "RP2040-PICO"},
+        headers=headers,
+    )
+
+    # By name
+    r = await client.get("/api/parts", params={"q": "servo"})
+    assert r.status_code == 200
+    assert any("Servo" in p["name"] for p in r.json())
+
+    # By sku
+    r = await client.get("/api/parts", params={"q": "rp2040"})
+    assert any(p["sku"] == "RP2040-PICO" for p in r.json())
+
+    # By mpn
+    r = await client.get("/api/parts", params={"q": "tiankongrc"})
+    assert any(p["name"] == "SG90 Micro Servo" for p in r.json())
+
+
+@pytest.mark.asyncio
+async def test_search_matches_alias(client, session) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/parts",
+        json={"name": "SG90 Micro Servo"},
+        headers=headers,
+    )
+    part_id = resp.json()["id"]
+    # Insert an alias directly — the public API for aliases lands in Phase 3.
+    from projects_api.models import PartAlias
+
+    session.add(PartAlias(part_id=part_id, alias="9g servo"))
+    await session.commit()
+
+    r = await client.get("/api/parts", params={"q": "9g"})
+    assert r.status_code == 200
+    assert any(p["id"] == part_id for p in r.json())
+
+
+# --- update / revisions / restore --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_creates_new_revision_and_bumps_current(client) -> None:
+    headers = make_auth_header()
+    create = await client.post(
+        "/api/parts",
+        json={"name": "Widget", "sku": "W1"},
+        headers=headers,
+    )
+    slug = create.json()["slug"]
+    original_rev = create.json()["current_revision_id"]
+
+    upd = await client.put(
+        f"/api/parts/{slug}",
+        json={
+            "description_md": "Now with documentation",
+            "change_summary": "Add description",
+        },
+        headers=headers,
+    )
+    assert upd.status_code == 200, upd.text
+    new_rev = upd.json()["current_revision_id"]
+    assert new_rev != original_rev
+    assert upd.json()["description_md"] == "Now with documentation"
+    # Two revisions present.
+    revs = await client.get(f"/api/parts/{slug}/revisions")
+    assert len(revs.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_update_with_no_change_is_400(client) -> None:
+    headers = make_auth_header()
+    create = await client.post(
+        "/api/parts",
+        json={"name": "Widget", "sku": "W1"},
+        headers=headers,
+    )
+    slug = create.json()["slug"]
+    # Same data + just a change_summary.
+    resp = await client.put(
+        f"/api/parts/{slug}",
+        json={"name": "Widget", "sku": "W1", "change_summary": "noop"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "no fields changed" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_restore_creates_new_revision_non_destructive(client) -> None:
+    headers = make_auth_header()
+    create = await client.post(
+        "/api/parts",
+        json={"name": "Widget", "description_md": "v1"},
+        headers=headers,
+    )
+    slug = create.json()["slug"]
+    rev1 = create.json()["current_revision_id"]
+
+    # Edit to v2.
+    await client.put(
+        f"/api/parts/{slug}",
+        json={"description_md": "v2", "change_summary": "to v2"},
+        headers=headers,
+    )
+
+    # Restore rev1.
+    restore = await client.post(
+        f"/api/parts/{slug}/revisions/{rev1}/restore",
+        headers=headers,
+    )
+    assert restore.status_code == 200, restore.text
+    restored = restore.json()
+    # New revision id != rev1 (history is linear, restore is non-destructive).
+    assert restored["current_revision_id"] != rev1
+    assert restored["description_md"] == "v1"
+
+    revs = await client.get(f"/api/parts/{slug}/revisions")
+    revs_list = revs.json()
+    # rev1 + v2 edit + restore = 3 revisions
+    assert len(revs_list) == 3
+    # Latest revision change_summary mentions the restore.
+    assert revs_list[0]["change_summary"] == f"Restored from revision #{rev1}"
+
+
+# --- account-age gate --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_account_age_gate_blocks_young_accounts(client, monkeypatch) -> None:
+    from projects_api import auth as auth_module
+
+    async def _young(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=3)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _young)
+    auth_module._clear_account_age_cache()
+
+    resp = await client.post(
+        "/api/parts",
+        json={"name": "Too new"},
+        headers=make_auth_header(),
+    )
+    assert resp.status_code == 403
+    assert "14 days" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_account_age_gate_fails_closed_on_lookup_failure(client, monkeypatch) -> None:
+    from projects_api import auth as auth_module
+
+    async def _failed(username: str, token: str) -> Optional[datetime]:
+        return None
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _failed)
+    auth_module._clear_account_age_cache()
+
+    resp = await client.post(
+        "/api/parts",
+        json={"name": "Anything"},
+        headers=make_auth_header(),
+    )
+    assert resp.status_code == 403
+    assert "verified" in resp.json()["detail"].lower()
+
+
+# --- BOM <-> usage_count ----------------------------------------------
+
+
+async def _create_project(client) -> int:
+    headers = make_auth_header()
+    resp = await client.post("/api/projects", json={"title": "Usage Count Test"}, headers=headers)
+    return resp.json()["id"]
+
+
+async def _create_part(client, name: str) -> dict:
+    headers = make_auth_header()
+    resp = await client.post("/api/parts", json={"name": name}, headers=headers)
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_bom_part_link_bumps_usage_count(client) -> None:
+    project_id = await _create_project(client)
+    part = await _create_part(client, "Pi Pico")
+    headers = make_auth_header()
+
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={"name": "Pi Pico", "quantity": 1, "part_id": part["id"]},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["part_id"] == part["id"]
+
+    detail = await client.get(f"/api/parts/{part['slug']}")
+    assert detail.json()["usage_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_bom_part_switch_moves_usage_count(client) -> None:
+    project_id = await _create_project(client)
+    part_a = await _create_part(client, "Part A")
+    part_b = await _create_part(client, "Part B")
+    headers = make_auth_header()
+
+    create = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={"name": "Part A", "quantity": 1, "part_id": part_a["id"]},
+        headers=headers,
+    )
+    item_id = create.json()["id"]
+
+    a_detail = await client.get(f"/api/parts/{part_a['slug']}")
+    assert a_detail.json()["usage_count"] == 1
+
+    # Switch this BOM row from Part A → Part B.
+    await client.put(
+        f"/api/projects/{project_id}/bom/{item_id}",
+        json={"name": "Part B", "quantity": 1, "part_id": part_b["id"]},
+        headers=headers,
+    )
+
+    a_after = await client.get(f"/api/parts/{part_a['slug']}")
+    b_after = await client.get(f"/api/parts/{part_b['slug']}")
+    assert a_after.json()["usage_count"] == 0
+    assert b_after.json()["usage_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_usage_count_counts_distinct_projects(client) -> None:
+    """Two BOM rows for the same part within a single project = 1, not 2."""
+    project_id = await _create_project(client)
+    part = await _create_part(client, "Servo")
+    headers = make_auth_header()
+
+    for _ in range(2):
+        resp = await client.post(
+            f"/api/projects/{project_id}/bom",
+            json={"name": "Servo", "quantity": 1, "part_id": part["id"]},
+            headers=headers,
+        )
+        assert resp.status_code == 201
+
+    detail = await client.get(f"/api/parts/{part['slug']}")
+    assert detail.json()["usage_count"] == 1


### PR DESCRIPTION
Implements backend half of #121.

## Summary

- Adds the shared parts-catalog schema (`parts`, `part_aliases`, `part_suppliers`, `part_revisions`) plus a nullable `part_id` FK on `project_bom_items`.
- New `/api/parts/*` router: search, create, get, update (writes a new revision), revisions list/detail, and non-destructive restore.
- 14-day account-age gate on POST/PUT/restore. Option (b) from the issue: projects-api looks up `account_created_at` from Chatter's `/api/me` on demand and caches it in-process for 1 hour. **Fails closed** (403 "Account age cannot be verified") on any lookup failure or missing field — better safe than spammable.
- `parts.usage_count` reflects **distinct projects** that reference the part. It's recomputed transactionally as `COUNT(DISTINCT project_id) FROM project_bom_items WHERE part_id=?` inside every BOM create/update/delete that touches `part_id`. This keeps the rule "two BOM rows in the same project don't double-count" trivially correct, and a Phase-2 cron can resync it if it ever drifts.
- Frontend contract written to `stacks/projects-api/docs/parts-api.md` for the frontend agent.

## Design notes / decisions

- **PUT diff semantics**: `change_summary` is required; everything else is optional. Omitting a field means "leave it alone". If the resulting diff has zero changes the endpoint returns `400 Bad Request` ("No fields changed") — matches the issue's "rejects if no change" requirement. `suppliers` is replaced en-bloc when present (simplest correct v1).
- **Restore**: writes a NEW revision whose snapshot equals the named one. History stays linear; nothing is deleted. `change_summary` is auto-filled as `"Restored from revision #N"`.
- **Search v1**: lowercased substring match against `name` / `sku` / `mpn` / aliases. Adequate for the small corpus we'll have in Phase 1 — module docstring flags this as the swap-point for `pg_trgm` later.
- **Status field**: stored as a free string for now (`draft` / `verified` / `under_review`). The `merged_into:<id>` value lands in Phase 3 as planned.
- **Slug collisions**: append `-2`, `-3`, ... walking the table once per attempt. Cheap for our scale.
- **BOM back-compat**: existing free-form `name` / `quantity` / `unit` / `unit_cost` / `supplier_url` still work. `part_id` is purely additive. If `part_id` points at a deleted catalog row the server silently sets it to `null` rather than rejecting the BOM mutation.
- **Auth seam**: `auth.fetch_account_created_at(username, token)` is the single async function tests monkeypatch — no HTTP mock needed.

## Test plan

- [x] `python3 -m pytest tests/test_parts.py` — 12 new tests, all green
- [x] Full suite (`python3 -m pytest`) — 46 passed, 0 regressions
- Coverage: search across name/sku/mpn/alias, create-with-initial-revision, slug disambiguation, update writes new revision + bumps `current_revision_id`, no-op update returns 400, restore is non-destructive, age gate blocks <14d accounts, age gate fails closed on lookup failure, BOM `part_id` increments usage, switching `part_id` decrements old/increments new, two BOM rows in one project count as 1.

## Out of scope (Phase 2 / 3, per issue)

Talk pages, link-health checker, auto-verify lifecycle, reports, merge proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)