### PR TITLE
feat(parts): frontend for parts catalog Phase 1 MVP

### DIFF
--- a/web/assets/css/project-editor.css
+++ b/web/assets/css/project-editor.css
@@ -625,3 +625,132 @@ body:has(.CodeMirror-fullscreen) .col-lg-8 {
   flex-shrink: 0;
   font-size: 0.8rem;
 }
+
+/* Parts catalog autosuggest dropdown — mirrors .image-autocomplete-popup */
+.parts-autocomplete {
+  position: fixed;
+  z-index: 10000;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-height: 320px;
+  overflow-y: auto;
+  min-width: 280px;
+  padding: 4px;
+  font-size: 0.875rem;
+}
+
+.parts-autocomplete-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  line-height: 1.3;
+}
+
+.parts-autocomplete-item:hover,
+.parts-autocomplete-item.active {
+  background: #e8f4fd;
+}
+
+.parts-autocomplete-item .parts-ac-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.parts-autocomplete-item .parts-ac-name {
+  font-weight: 600;
+  color: #222;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.parts-autocomplete-item .parts-ac-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: #6c757d;
+  margin-top: 2px;
+}
+
+.parts-autocomplete-item .parts-ac-sku {
+  font-family: SFMono-Regular, Menlo, monospace;
+  color: #6c757d;
+}
+
+.parts-autocomplete-item .parts-ac-usage {
+  background: #e9ecef;
+  color: #495057;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+}
+
+.parts-autocomplete-item .parts-ac-verified {
+  background: #d1e7dd;
+  color: #0f5132;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.parts-autocomplete-item .parts-ac-verified i {
+  margin-right: 2px;
+}
+
+.parts-autocomplete-empty {
+  padding: 8px 10px;
+  font-size: 0.8rem;
+  color: #6c757d;
+  font-style: italic;
+}
+
+.parts-autocomplete-add {
+  border-top: 1px solid #eee;
+  margin-top: 4px;
+  padding-top: 6px;
+  color: #4A90D9;
+  font-weight: 500;
+}
+
+.parts-autocomplete-add:hover,
+.parts-autocomplete-add.active {
+  background: #f0f7ff;
+}
+
+/* Linked-part pill shown on BOM rows whose part_id is set */
+.bom-part-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  padding: 1px 8px;
+  border-radius: 10px;
+  background: #e8f4fd;
+  color: #4A90D9;
+  font-size: 0.7rem;
+  text-decoration: none;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.bom-part-pill:hover {
+  background: #d3eafc;
+  color: #2b6db5;
+  text-decoration: none;
+}
+
+.bom-supplier-hint {
+  display: block;
+  font-size: 0.7rem;
+  color: #6c757d;
+  margin-top: 2px;
+  font-style: italic;
+}

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -1352,22 +1352,47 @@
     loadBOM();
   });
 
+  function escapeHtmlAttr(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
   async function loadBOM() {
     if (!currentProject) return;
     const resp = await apiFetch(API + '/api/projects/' + currentProject.id + '/bom', { credentials: 'include' });
     const items = await resp.json();
     const tbody = document.getElementById('bom-body');
-    tbody.innerHTML = items.map(item => `
-      <tr data-bom-id="${item.id}">
-        <td><input value="${item.name}" data-field="name" onchange="updateBOM(${item.id}, this)"></td>
+    tbody.innerHTML = items.map(item => {
+      const linked = item.part_id && item.part_slug;
+      const partPill = linked
+        ? `<a class="bom-part-pill" href="/parts/view.html?slug=${encodeURIComponent(item.part_slug)}" title="Linked to parts catalog" target="_blank"><i class="fas fa-link"></i> /parts/${escapeHtmlAttr(item.part_slug)}</a>`
+        : (item.part_id ? `<span class="bom-part-pill" title="Linked to parts catalog"><i class="fas fa-link"></i> part #${item.part_id}</span>` : '');
+      const supplierHint = item.part_id
+        ? `<small class="bom-supplier-hint">from parts catalog</small>` : '';
+      const supplierReadonly = item.part_id ? ' readonly' : '';
+      return `
+      <tr data-bom-id="${item.id}" data-part-id="${item.part_id || ''}" data-part-slug="${escapeHtmlAttr(item.part_slug || '')}">
+        <td class="bom-part-cell" style="position:relative">
+          <input class="bom-part-input" value="${escapeHtmlAttr(item.name)}" data-field="name" autocomplete="off" placeholder="Type to search parts catalog..." onchange="updateBOM(${item.id}, this)">
+          ${partPill}
+        </td>
         <td><input type="number" value="${item.quantity}" data-field="quantity" style="width:50px" onchange="updateBOM(${item.id}, this)"></td>
-        <td><input value="${item.unit}" data-field="unit" style="width:50px" onchange="updateBOM(${item.id}, this)"></td>
+        <td><input value="${escapeHtmlAttr(item.unit)}" data-field="unit" style="width:50px" onchange="updateBOM(${item.id}, this)"></td>
         <td><input type="number" step="0.01" value="${item.unit_cost || 0}" data-field="unit_cost" style="width:70px" onchange="updateBOM(${item.id}, this)"></td>
-        <td><input value="${item.supplier_url || ''}" data-field="supplier_url" onchange="updateBOM(${item.id}, this)"></td>
+        <td>
+          <input value="${escapeHtmlAttr(item.supplier_url || '')}" data-field="supplier_url"${supplierReadonly} onchange="updateBOM(${item.id}, this)">
+          ${supplierHint}
+        </td>
         <td><button class="btn btn-sm text-danger" onclick="deleteBOM(${item.id})"><i class="fas fa-times"></i></button></td>
-      </tr>
-    `).join('');
+      </tr>`;
+    }).join('');
     updateBOMTotal(items);
+    // Wire up the parts autosuggest on every Part-name input
+    tbody.querySelectorAll('.bom-part-input').forEach(setupPartsAutosuggest);
   }
 
   function updateBOMTotal(items) {
@@ -1380,16 +1405,35 @@
     const data = {};
     row.querySelectorAll('input').forEach(inp => {
       const field = inp.dataset.field;
+      if (!field) return;
       let val = inp.value;
       if (field === 'quantity') val = parseInt(val) || 1;
       else if (field === 'unit_cost') val = parseFloat(val) || 0;
       data[field] = val;
     });
-    await apiFetch(API + '/api/projects/' + currentProject.id + '/bom/' + itemId, {
-      method: 'PUT', credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+    const partId = row.dataset.partId;
+    if (partId) data.part_id = parseInt(partId);
+    let resp;
+    try {
+      resp = await apiFetch(API + '/api/projects/' + currentProject.id + '/bom/' + itemId, {
+        method: 'PUT', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+    } catch (e) { loadBOM(); return; }
+    // If an older backend rejects the new part_id field, retry without it so
+    // the user's edit still saves. Treat 4xx as "field rejected"; 5xx is a
+    // real server error and we just let it fall through.
+    if (!resp.ok && partId && resp.status >= 400 && resp.status < 500) {
+      delete data.part_id;
+      try {
+        await apiFetch(API + '/api/projects/' + currentProject.id + '/bom/' + itemId, {
+          method: 'PUT', credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        });
+      } catch (_) {}
+    }
     loadBOM();
   };
 
@@ -1399,6 +1443,367 @@
     });
     loadBOM();
   };
+
+  // --- Parts catalog autosuggest ---
+  // Single shared dropdown reused across all Part-name inputs in the BOM table.
+  let partsPopup = null;
+  let partsActiveInput = null;
+  let partsActiveIdx = 0;
+  let partsResults = [];
+  let partsDebounceTimer = null;
+  let partsAbort = null;
+
+  function ensurePartsPopup() {
+    if (partsPopup) return partsPopup;
+    partsPopup = document.createElement('div');
+    partsPopup.className = 'parts-autocomplete';
+    partsPopup.style.display = 'none';
+    document.body.appendChild(partsPopup);
+    // Re-position on scroll so it tracks the input
+    window.addEventListener('scroll', () => {
+      if (partsPopup.style.display !== 'none' && partsActiveInput) positionPartsPopup(partsActiveInput);
+    }, true);
+    return partsPopup;
+  }
+
+  function positionPartsPopup(input) {
+    const rect = input.getBoundingClientRect();
+    partsPopup.style.left = rect.left + 'px';
+    partsPopup.style.top = (rect.bottom + 2) + 'px';
+    partsPopup.style.minWidth = Math.max(280, rect.width) + 'px';
+  }
+
+  function hidePartsPopup() {
+    if (partsPopup) partsPopup.style.display = 'none';
+    partsActiveInput = null;
+    partsResults = [];
+    partsActiveIdx = 0;
+  }
+
+  function renderPartsPopup(query) {
+    const popup = ensurePartsPopup();
+    const addRowHtml = `
+      <div class="parts-autocomplete-item parts-autocomplete-add" data-action="add">
+        <span><i class="fas fa-plus me-1"></i> Add as new part&hellip;${query ? ' &ldquo;' + escapeHtmlAttr(query) + '&rdquo;' : ''}</span>
+      </div>`;
+    if (!partsResults || partsResults.length === 0) {
+      popup.innerHTML = `<div class="parts-autocomplete-empty">No matches yet. Keep typing or add a new part below.</div>${addRowHtml}`;
+    } else {
+      popup.innerHTML = partsResults.map((p, i) => `
+        <div class="parts-autocomplete-item ${i === partsActiveIdx ? 'active' : ''}" data-idx="${i}">
+          <div class="parts-ac-main">
+            <div class="parts-ac-name">${escapeHtmlAttr(p.name)}</div>
+            <div class="parts-ac-meta">
+              ${p.sku ? `<span class="parts-ac-sku">${escapeHtmlAttr(p.sku)}</span>` : ''}
+              ${typeof p.usage_count === 'number' ? `<span class="parts-ac-usage" title="Used in ${p.usage_count} projects">${p.usage_count} use${p.usage_count === 1 ? '' : 's'}</span>` : ''}
+              ${p.status === 'verified' ? `<span class="parts-ac-verified"><i class="fas fa-check-circle"></i>verified</span>` : ''}
+            </div>
+          </div>
+        </div>`).join('') + addRowHtml;
+    }
+    popup.querySelectorAll('.parts-autocomplete-item').forEach(el => {
+      el.addEventListener('mousedown', e => {
+        e.preventDefault();
+        if (el.dataset.action === 'add') {
+          openAddPartModal(query, partsActiveInput);
+        } else {
+          selectPartsResult(parseInt(el.dataset.idx, 10));
+        }
+      });
+    });
+  }
+
+  async function fetchPartsSearch(query) {
+    if (partsAbort) partsAbort.abort();
+    partsAbort = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+    try {
+      const resp = await apiFetch(
+        API + '/api/parts?q=' + encodeURIComponent(query) + '&limit=10',
+        partsAbort ? { signal: partsAbort.signal } : {}
+      );
+      if (!resp.ok) {
+        // Backend may not be live yet — fail soft, just show "add new"
+        partsResults = [];
+        renderPartsPopup(query);
+        return;
+      }
+      partsResults = await resp.json();
+      if (!Array.isArray(partsResults)) partsResults = [];
+      partsActiveIdx = 0;
+      renderPartsPopup(query);
+    } catch (e) {
+      // network/abort errors are expected — keep popup usable
+      if (e && e.name === 'AbortError') return;
+      partsResults = [];
+      renderPartsPopup(query);
+    }
+  }
+
+  function selectPartsResult(idx) {
+    if (!partsActiveInput) return;
+    const part = partsResults[idx];
+    if (!part) return;
+    const row = partsActiveInput.closest('tr');
+    if (!row) return;
+    const itemId = row.dataset.bomId;
+    row.dataset.partId = part.id;
+    row.dataset.partSlug = part.slug || '';
+    // Write the chosen part's display name back into the input
+    partsActiveInput.value = part.name || '';
+    // Auto-fill supplier URL if the part has one
+    const supplierInput = row.querySelector('input[data-field="supplier_url"]');
+    if (supplierInput && part.primary_supplier_url) supplierInput.value = part.primary_supplier_url;
+    hidePartsPopup();
+    // Persist the link via updateBOM (which now picks up dataset.partId)
+    if (itemId && supplierInput) window.updateBOM(parseInt(itemId, 10), supplierInput);
+    else if (itemId) window.updateBOM(parseInt(itemId, 10), partsActiveInput);
+  }
+
+  function setupPartsAutosuggest(input) {
+    input.addEventListener('input', () => {
+      const q = input.value.trim();
+      partsActiveInput = input;
+      // Clear any previously linked part_id since the user is typing freely
+      const row = input.closest('tr');
+      if (row) {
+        row.dataset.partId = '';
+        row.dataset.partSlug = '';
+        const pill = row.querySelector('.bom-part-pill');
+        if (pill) pill.remove();
+      }
+      if (q.length < 2) {
+        hidePartsPopup();
+        return;
+      }
+      ensurePartsPopup();
+      positionPartsPopup(input);
+      partsPopup.style.display = 'block';
+      if (partsDebounceTimer) clearTimeout(partsDebounceTimer);
+      partsDebounceTimer = setTimeout(() => fetchPartsSearch(q), 250);
+    });
+
+    input.addEventListener('focus', () => {
+      if (input.value.trim().length >= 2) {
+        partsActiveInput = input;
+        ensurePartsPopup();
+        positionPartsPopup(input);
+        partsPopup.style.display = 'block';
+        renderPartsPopup(input.value.trim());
+        fetchPartsSearch(input.value.trim());
+      }
+    });
+
+    input.addEventListener('blur', () => {
+      // Delay so a click on the popup can register first
+      setTimeout(() => {
+        if (partsPopup && !partsPopup.matches(':hover')) hidePartsPopup();
+      }, 200);
+    });
+
+    input.addEventListener('keydown', (e) => {
+      if (!partsPopup || partsPopup.style.display === 'none') return;
+      const total = partsResults.length + 1; // +1 for the "add new" row
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        partsActiveIdx = (partsActiveIdx + 1) % total;
+        renderPartsPopup(input.value.trim());
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        partsActiveIdx = (partsActiveIdx - 1 + total) % total;
+        renderPartsPopup(input.value.trim());
+      } else if (e.key === 'Enter') {
+        if (partsActiveIdx === partsResults.length) {
+          e.preventDefault();
+          openAddPartModal(input.value.trim(), input);
+        } else if (partsResults[partsActiveIdx]) {
+          e.preventDefault();
+          selectPartsResult(partsActiveIdx);
+        }
+      } else if (e.key === 'Escape') {
+        hidePartsPopup();
+      }
+    });
+  }
+
+  // --- "Add new part" modal ---
+  function ensureAddPartModal() {
+    let modal = document.getElementById('add-part-modal');
+    if (modal) return modal;
+    modal = document.createElement('div');
+    modal.id = 'add-part-modal';
+    modal.className = 'modal fade';
+    modal.tabIndex = -1;
+    modal.setAttribute('aria-hidden', 'true');
+    modal.innerHTML = `
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title"><i class="fas fa-plus-circle me-2 text-primary"></i>Add new part</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div id="add-part-error" class="alert alert-warning d-none small mb-2"></div>
+            <div class="mb-2">
+              <label class="form-label small text-muted">Part name <span class="text-danger">*</span></label>
+              <input type="text" id="add-part-name" class="form-control form-control-sm" placeholder="e.g. SG90 micro servo" maxlength="200">
+            </div>
+            <div class="row g-2 mb-2">
+              <div class="col-6">
+                <label class="form-label small text-muted">SKU</label>
+                <input type="text" id="add-part-sku" class="form-control form-control-sm" placeholder="optional">
+              </div>
+              <div class="col-6">
+                <label class="form-label small text-muted">MPN</label>
+                <input type="text" id="add-part-mpn" class="form-control form-control-sm" placeholder="optional">
+              </div>
+            </div>
+            <div class="mb-2">
+              <label class="form-label small text-muted">Supplier URL</label>
+              <input type="url" id="add-part-supplier" class="form-control form-control-sm" placeholder="https://...">
+            </div>
+            <div class="mb-2">
+              <label class="form-label small text-muted">Tags (comma-separated)</label>
+              <input type="text" id="add-part-tags" class="form-control form-control-sm" placeholder="e.g. servo, motor">
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-sm btn-primary" id="add-part-save">Create part</button>
+          </div>
+        </div>
+      </div>`;
+    document.body.appendChild(modal);
+    document.getElementById('add-part-save').addEventListener('click', submitAddPart);
+    return modal;
+  }
+
+  let addPartTargetInput = null;
+  function openAddPartModal(prefillName, targetInput) {
+    ensureAddPartModal();
+    addPartTargetInput = targetInput || null;
+    document.getElementById('add-part-name').value = prefillName || '';
+    document.getElementById('add-part-sku').value = '';
+    document.getElementById('add-part-mpn').value = '';
+    document.getElementById('add-part-supplier').value = '';
+    document.getElementById('add-part-tags').value = '';
+    const errEl = document.getElementById('add-part-error');
+    errEl.classList.add('d-none');
+    errEl.textContent = '';
+    hidePartsPopup();
+    const modalEl = document.getElementById('add-part-modal');
+    if (window.bootstrap && window.bootstrap.Modal) {
+      const m = window.bootstrap.Modal.getOrCreateInstance(modalEl);
+      m.show();
+      setTimeout(() => document.getElementById('add-part-name').focus(), 200);
+    } else {
+      // Fallback if Bootstrap JS not loaded for some reason
+      modalEl.classList.add('show');
+      modalEl.style.display = 'block';
+    }
+  }
+
+  function closeAddPartModal() {
+    const modalEl = document.getElementById('add-part-modal');
+    if (window.bootstrap && window.bootstrap.Modal) {
+      const m = window.bootstrap.Modal.getInstance(modalEl);
+      if (m) m.hide();
+    } else if (modalEl) {
+      modalEl.classList.remove('show');
+      modalEl.style.display = 'none';
+    }
+  }
+
+  async function submitAddPart() {
+    const name = document.getElementById('add-part-name').value.trim();
+    if (!name) {
+      const errEl = document.getElementById('add-part-error');
+      errEl.textContent = 'A name is required.';
+      errEl.classList.remove('d-none');
+      return;
+    }
+    const sku = document.getElementById('add-part-sku').value.trim() || null;
+    const mpn = document.getElementById('add-part-mpn').value.trim() || null;
+    const supplier = document.getElementById('add-part-supplier').value.trim() || null;
+    const tagsRaw = document.getElementById('add-part-tags').value.trim();
+    const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim().toLowerCase()).filter(Boolean) : [];
+    const body = { name };
+    if (sku) body.sku = sku;
+    if (mpn) body.mpn = mpn;
+    if (supplier) body.supplier_url = supplier;
+    if (tags.length) body.tags = tags;
+
+    const saveBtn = document.getElementById('add-part-save');
+    saveBtn.disabled = true;
+    saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Saving...';
+    try {
+      const resp = await apiFetch(API + '/api/parts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (resp.status === 403) {
+        showAccountAgeAlert(await resp.json().catch(() => ({})));
+        closeAddPartModal();
+        return;
+      }
+      if (!resp.ok) {
+        let detail = 'Could not create part.';
+        try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+        const errEl = document.getElementById('add-part-error');
+        errEl.textContent = detail;
+        errEl.classList.remove('d-none');
+        return;
+      }
+      const part = await resp.json();
+      closeAddPartModal();
+      // If we were called from a BOM row, link the new part to that row
+      if (addPartTargetInput) {
+        const row = addPartTargetInput.closest('tr');
+        if (row) {
+          const itemId = row.dataset.bomId;
+          row.dataset.partId = part.id;
+          row.dataset.partSlug = part.slug || '';
+          addPartTargetInput.value = part.name || name;
+          const supplierInput = row.querySelector('input[data-field="supplier_url"]');
+          if (supplierInput && part.primary_supplier_url) supplierInput.value = part.primary_supplier_url;
+          if (itemId) window.updateBOM(parseInt(itemId, 10), addPartTargetInput);
+        }
+      }
+    } catch (e) {
+      const errEl = document.getElementById('add-part-error');
+      errEl.textContent = 'Network error. Please try again.';
+      errEl.classList.remove('d-none');
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.innerHTML = 'Create part';
+    }
+  }
+
+  // --- Account-age (14-day) friendly error ---
+  function showAccountAgeAlert(payload) {
+    // Backend may include a date string (e.g. eligible_at) — if so, show it; otherwise generic.
+    const eligibleAt = (payload && (payload.eligible_at || payload.eligibleAt || payload.detail?.eligible_at));
+    let dateStr = '';
+    if (eligibleAt) {
+      try { dateStr = new Date(eligibleAt).toLocaleDateString(); } catch (_) {}
+    }
+    const msg = dateStr
+      ? `You need to have had an account for at least 14 days before editing parts. Try again on ${dateStr}.`
+      : `You need to have had an account for at least 14 days before editing parts. Please try again later.`;
+    let toast = document.getElementById('parts-age-alert');
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.id = 'parts-age-alert';
+      toast.className = 'alert alert-warning alert-dismissible position-fixed shadow';
+      toast.style.cssText = 'top: 80px; right: 20px; z-index: 11000; max-width: 360px;';
+      document.body.appendChild(toast);
+    }
+    toast.innerHTML = `<i class="fas fa-clock me-1"></i> ${msg}
+      <button type="button" class="btn-close" aria-label="Close"></button>`;
+    toast.querySelector('.btn-close').addEventListener('click', () => toast.remove());
+    setTimeout(() => { if (toast.parentNode) toast.remove(); }, 8000);
+  }
+  window.showAccountAgeAlert = showAccountAgeAlert;
 
   // --- Links ---
   document.getElementById('add-link-btn').addEventListener('click', async () => {

--- a/web/parts/edit.html
+++ b/web/parts/edit.html
@@ -1,0 +1,379 @@
+---
+title: Edit Part
+layout: default
+description: Edit a part in the catalog
+---
+
+<link rel="stylesheet" href="/assets/css/project-editor.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+
+<div class="container py-4">
+  <div class="mb-3">
+    <a href="javascript:history.back()" class="text-decoration-none text-muted"><i class="fas fa-arrow-left"></i> Back</a>
+  </div>
+
+  <div id="auth-required" class="alert alert-warning d-none">
+    You need to <a href="/login">log in</a> to edit parts.
+  </div>
+
+  <div id="loading" class="text-center py-5">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+
+  <div id="edit-container" class="d-none">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h1 id="page-title" class="mb-0"><i class="fas fa-pencil-alt me-2 text-primary"></i><span id="page-title-text">Edit part</span></h1>
+      <a id="view-link" href="#" class="btn btn-sm btn-outline-secondary d-none"><i class="fas fa-eye me-1"></i> View</a>
+    </div>
+
+    <div id="account-age-alert" class="alert alert-warning d-none">
+      <i class="fas fa-clock me-1"></i> <span id="account-age-message"></span>
+    </div>
+
+    <div id="save-error" class="alert alert-danger d-none"></div>
+
+    <div class="row">
+      <div class="col-lg-8">
+        <div class="mb-3">
+          <label for="part-name" class="form-label">Name <span class="text-danger">*</span></label>
+          <input type="text" id="part-name" class="form-control" maxlength="200" placeholder="e.g. SG90 micro servo">
+        </div>
+
+        <div class="row g-2 mb-3">
+          <div class="col-md-6">
+            <label for="part-sku" class="form-label">SKU</label>
+            <input type="text" id="part-sku" class="form-control" placeholder="optional">
+          </div>
+          <div class="col-md-6">
+            <label for="part-mpn" class="form-label">MPN</label>
+            <input type="text" id="part-mpn" class="form-control" placeholder="manufacturer part number">
+          </div>
+        </div>
+
+        <div class="mb-3">
+          <label for="part-image-url" class="form-label">Image URL</label>
+          <input type="url" id="part-image-url" class="form-control" placeholder="https://...">
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">Tags</label>
+          <div id="part-tags-container" class="d-flex flex-wrap gap-1 mb-1"></div>
+          <div class="input-group input-group-sm">
+            <input type="text" id="part-tag-input" class="form-control" placeholder="Add a tag and press Enter">
+            <button class="btn btn-outline-secondary" id="part-add-tag-btn" type="button">Add</button>
+          </div>
+        </div>
+
+        <div class="mb-3">
+          <div class="d-flex justify-content-between align-items-center mb-1">
+            <label class="form-label mb-0">Suppliers</label>
+            <button class="btn btn-sm btn-outline-primary" id="add-supplier-btn" type="button"><i class="fas fa-plus me-1"></i>Add supplier</button>
+          </div>
+          <div id="suppliers-list"></div>
+        </div>
+
+        <div class="mb-3">
+          <label for="part-description" class="form-label">Description (Markdown)</label>
+          <textarea id="part-description"></textarea>
+        </div>
+
+        <div class="card mb-3 bg-light">
+          <div class="card-body">
+            <label for="part-change-summary" class="form-label fw-bold">
+              <i class="fas fa-pencil-ruler me-1"></i> What changed? <span class="text-danger">*</span>
+            </label>
+            <input type="text" id="part-change-summary" class="form-control" maxlength="200" placeholder="A short summary, e.g. 'Fixed SKU and added supplier link'">
+            <div class="form-text">This message goes into the part's revision history. Max 200 characters.</div>
+          </div>
+        </div>
+
+        <div class="d-flex gap-2">
+          <button class="btn btn-primary" id="save-btn">
+            <i class="fas fa-save me-1"></i> <span id="save-btn-label">Save part</span>
+          </button>
+          <a href="javascript:history.back()" class="btn btn-outline-secondary">Cancel</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script src="/assets/js/project-auth.js"></script>
+<script>
+(function() {
+  const API = 'https://projects.kevsrobots.com';
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+  const isNew = params.get('new') === '1' || !slug;
+  let easyMDE = null;
+  let currentPart = null;
+
+  function esc(s) { const d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+
+  function show(el) { el.classList.remove('d-none'); }
+  function hide(el) { el.classList.add('d-none'); }
+
+  // --- Tags ---
+  const tagsContainer = document.getElementById('part-tags-container');
+  const tagInput = document.getElementById('part-tag-input');
+
+  function renderTags(tags) {
+    tagsContainer.innerHTML = '';
+    (tags || []).forEach(t => addTagBadge(t));
+  }
+  function addTagBadge(tag) {
+    const el = document.createElement('span');
+    el.className = 'tag-badge';
+    el.dataset.tag = tag;
+    el.innerHTML = esc(tag) + ' <span class="remove-tag">&times;</span>';
+    el.querySelector('.remove-tag').addEventListener('click', () => el.remove());
+    tagsContainer.appendChild(el);
+  }
+  function getTags() {
+    return Array.from(tagsContainer.querySelectorAll('.tag-badge')).map(el => el.dataset.tag);
+  }
+  document.getElementById('part-add-tag-btn').addEventListener('click', () => {
+    const t = tagInput.value.trim().toLowerCase();
+    if (!t) return;
+    if (getTags().includes(t)) { tagInput.value = ''; return; }
+    addTagBadge(t);
+    tagInput.value = '';
+  });
+  tagInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); document.getElementById('part-add-tag-btn').click(); }
+  });
+
+  // --- Suppliers ---
+  const suppliersList = document.getElementById('suppliers-list');
+  function renderSuppliers(suppliers) {
+    suppliersList.innerHTML = '';
+    (suppliers || []).forEach(s => addSupplierRow(s.name || '', s.url || ''));
+  }
+  function addSupplierRow(name, url) {
+    const row = document.createElement('div');
+    row.className = 'row g-2 mb-2 supplier-row';
+    row.innerHTML = `
+      <div class="col-4"><input type="text" class="form-control form-control-sm supplier-name" placeholder="Supplier name" value="${esc(name)}"></div>
+      <div class="col-7"><input type="url" class="form-control form-control-sm supplier-url" placeholder="https://..." value="${esc(url)}"></div>
+      <div class="col-1 d-flex align-items-center"><button class="btn btn-sm text-danger supplier-remove" type="button" aria-label="Remove"><i class="fas fa-times"></i></button></div>
+    `;
+    row.querySelector('.supplier-remove').addEventListener('click', () => row.remove());
+    suppliersList.appendChild(row);
+  }
+  function getSuppliers() {
+    return Array.from(suppliersList.querySelectorAll('.supplier-row')).map(r => ({
+      name: r.querySelector('.supplier-name').value.trim(),
+      url: r.querySelector('.supplier-url').value.trim(),
+    })).filter(s => s.name || s.url);
+  }
+  document.getElementById('add-supplier-btn').addEventListener('click', () => addSupplierRow('', ''));
+
+  // --- Editor ---
+  function initEditor() {
+    if (easyMDE) return;
+    easyMDE = new EasyMDE({
+      element: document.getElementById('part-description'),
+      spellChecker: false,
+      placeholder: 'Describe what the part is, how it works, common pinouts, gotchas...',
+      status: false,
+      minHeight: '250px',
+      toolbar: ['bold', 'italic', 'heading', '|', 'code', 'quote', 'unordered-list', 'ordered-list', '|', 'link', 'table', '|', 'preview', 'side-by-side', 'fullscreen', '|', 'guide'],
+    });
+  }
+
+  // --- Auth check ---
+  async function checkAuth() {
+    try {
+      const resp = await ProjectAuth.apiFetch(API + '/api/projects/my/list');
+      if (!resp.ok) {
+        hide(document.getElementById('loading'));
+        show(document.getElementById('auth-required'));
+        return false;
+      }
+      return true;
+    } catch (e) {
+      hide(document.getElementById('loading'));
+      show(document.getElementById('auth-required'));
+      return false;
+    }
+  }
+
+  // --- Load ---
+  async function loadPart() {
+    if (isNew) {
+      currentPart = null;
+      document.getElementById('page-title-text').textContent = 'New part';
+      hide(document.getElementById('view-link'));
+      hide(document.getElementById('loading'));
+      show(document.getElementById('edit-container'));
+      initEditor();
+      // Pre-fill name from ?name= so we can route here from the BOM autosuggest
+      const prefillName = params.get('name');
+      if (prefillName) document.getElementById('part-name').value = prefillName;
+      return;
+    }
+    try {
+      const resp = await fetch(API + '/api/parts/' + encodeURIComponent(slug));
+      if (!resp.ok) {
+        const err = document.getElementById('save-error');
+        err.textContent = 'Could not load this part.';
+        show(err);
+        hide(document.getElementById('loading'));
+        show(document.getElementById('edit-container'));
+        return;
+      }
+      currentPart = await resp.json();
+      document.getElementById('page-title-text').textContent = 'Edit: ' + currentPart.name;
+      const viewLink = document.getElementById('view-link');
+      viewLink.href = '/parts/view.html?slug=' + encodeURIComponent(slug);
+      show(viewLink);
+
+      document.getElementById('part-name').value = currentPart.name || '';
+      document.getElementById('part-sku').value = currentPart.sku || '';
+      document.getElementById('part-mpn').value = currentPart.mpn || '';
+      document.getElementById('part-image-url').value = currentPart.image_url || '';
+      renderTags(currentPart.tags || []);
+      renderSuppliers(currentPart.suppliers || []);
+
+      hide(document.getElementById('loading'));
+      show(document.getElementById('edit-container'));
+      initEditor();
+      // Populate the editor *after* it's been initialised
+      easyMDE.value(currentPart.description_md || '');
+    } catch (e) {
+      const err = document.getElementById('save-error');
+      err.textContent = 'Network error loading part: ' + (e.message || e);
+      show(err);
+      hide(document.getElementById('loading'));
+      show(document.getElementById('edit-container'));
+    }
+  }
+
+  // --- Save ---
+  function buildBody() {
+    return {
+      name: document.getElementById('part-name').value.trim(),
+      sku: document.getElementById('part-sku').value.trim() || null,
+      mpn: document.getElementById('part-mpn').value.trim() || null,
+      image_url: document.getElementById('part-image-url').value.trim() || null,
+      tags: getTags(),
+      suppliers: getSuppliers(),
+      description_md: easyMDE ? easyMDE.value() : '',
+      change_summary: document.getElementById('part-change-summary').value.trim(),
+    };
+  }
+
+  function showAccountAge(payload) {
+    const eligibleAt = payload && (payload.eligible_at || payload.eligibleAt || (payload.detail && payload.detail.eligible_at));
+    let dateStr = '';
+    if (eligibleAt) {
+      try { dateStr = new Date(eligibleAt).toLocaleDateString(); } catch (_) {}
+    }
+    document.getElementById('account-age-message').textContent = dateStr
+      ? `You need to have had an account for at least 14 days before editing parts. Try again on ${dateStr}.`
+      : `You need to have had an account for at least 14 days before editing parts. Please try again later.`;
+    show(document.getElementById('account-age-alert'));
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function showError(msg) {
+    const el = document.getElementById('save-error');
+    el.textContent = msg;
+    show(el);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  async function save() {
+    hide(document.getElementById('save-error'));
+    hide(document.getElementById('account-age-alert'));
+
+    const body = buildBody();
+    if (!body.name) { showError('A name is required.'); return; }
+    if (!isNew && !body.change_summary) {
+      showError('Please describe what changed in the "What changed?" field — it goes into the revision log.');
+      return;
+    }
+
+    const saveBtn = document.getElementById('save-btn');
+    const label = document.getElementById('save-btn-label');
+    saveBtn.disabled = true;
+    label.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Saving...';
+
+    try {
+      let resp;
+      if (isNew) {
+        // For POST we don't send change_summary or description_md (backend
+        // accepts a small subset). If the user wrote a description, we still
+        // send it as best-effort.
+        const createBody = { name: body.name };
+        if (body.sku) createBody.sku = body.sku;
+        if (body.mpn) createBody.mpn = body.mpn;
+        if (body.tags && body.tags.length) createBody.tags = body.tags;
+        const firstSupplier = (body.suppliers || []).find(s => s.url);
+        if (firstSupplier) {
+          createBody.supplier_url = firstSupplier.url;
+          if (firstSupplier.name) createBody.supplier_name = firstSupplier.name;
+        }
+        resp = await ProjectAuth.apiFetch(API + '/api/parts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(createBody),
+        });
+      } else {
+        resp = await ProjectAuth.apiFetch(API + '/api/parts/' + encodeURIComponent(slug), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }
+      if (resp.status === 403) {
+        let payload = {};
+        try { payload = await resp.json(); } catch (_) {}
+        showAccountAge(payload);
+        return;
+      }
+      if (!resp.ok) {
+        let detail = 'Could not save part (HTTP ' + resp.status + ').';
+        try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+        showError(detail);
+        return;
+      }
+      const saved = await resp.json();
+      // On create, the freshly-saved description (if any) didn't reach the
+      // backend because POST doesn't accept description_md. If the user wrote
+      // a description, do a follow-up PUT to persist it.
+      if (isNew && body.description_md && saved && saved.slug) {
+        try {
+          await ProjectAuth.apiFetch(API + '/api/parts/' + encodeURIComponent(saved.slug), {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              description_md: body.description_md,
+              suppliers: body.suppliers,
+              image_url: body.image_url,
+              change_summary: body.change_summary || 'Initial description',
+            }),
+          });
+        } catch (_) {}
+      }
+      // Redirect to the view page on success
+      window.location.href = '/parts/view.html?slug=' + encodeURIComponent(saved.slug || slug);
+    } catch (e) {
+      showError('Network error: ' + (e.message || e));
+    } finally {
+      saveBtn.disabled = false;
+      label.textContent = 'Save part';
+    }
+  }
+
+  document.getElementById('save-btn').addEventListener('click', save);
+
+  // --- Boot ---
+  (async () => {
+    const ok = await checkAuth();
+    if (!ok) return;
+    await loadPart();
+  })();
+})();
+</script>

--- a/web/parts/history.html
+++ b/web/parts/history.html
@@ -1,0 +1,238 @@
+---
+title: Part History
+layout: default
+description: Revision history for a part in the catalog
+---
+
+<link rel="stylesheet" href="/assets/css/project-editor.css">
+
+<div class="container py-4">
+  <div class="mb-3">
+    <a id="back-link" href="/parts/" class="text-decoration-none text-muted"><i class="fas fa-arrow-left"></i> Back to part</a>
+  </div>
+
+  <div id="loading" class="text-center py-5">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+
+  <div id="missing-slug" class="text-center py-5 d-none">
+    <i class="fas fa-exclamation-triangle fa-3x text-warning mb-3"></i>
+    <p class="text-muted">No part specified.</p>
+    <a href="/parts/" class="btn btn-primary mt-3">Browse parts catalog</a>
+  </div>
+
+  <div id="history-container" class="d-none">
+    <h1 class="mb-1"><i class="fas fa-history me-2 text-primary"></i>Revision history</h1>
+    <p class="text-muted" id="history-subtitle"></p>
+
+    <div id="account-age-alert" class="alert alert-warning d-none">
+      <i class="fas fa-clock me-1"></i> <span id="account-age-message"></span>
+    </div>
+
+    <div id="restore-error" class="alert alert-danger d-none"></div>
+
+    <div id="revisions-list" class="list-group mb-3"></div>
+
+    <div id="revisions-empty" class="text-muted small d-none">No revisions found.</div>
+
+    <div id="preview-section" class="card mt-4 d-none">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <strong><i class="fas fa-eye me-1"></i> Preview: <span id="preview-title"></span></strong>
+        <button class="btn btn-sm btn-outline-secondary" id="preview-close" type="button"><i class="fas fa-times"></i></button>
+      </div>
+      <div class="card-body">
+        <div id="preview-body" class="small"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="/assets/js/project-auth.js"></script>
+<script>
+(function() {
+  const API = 'https://projects.kevsrobots.com';
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+
+  if (!slug) {
+    document.getElementById('loading').classList.add('d-none');
+    document.getElementById('missing-slug').classList.remove('d-none');
+    return;
+  }
+
+  document.getElementById('back-link').href = '/parts/view.html?slug=' + encodeURIComponent(slug);
+
+  function esc(s) { const d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+
+  function fmtTime(dateStr) {
+    if (!dateStr) return 'unknown';
+    try {
+      const d = new Date(dateStr);
+      return d.toLocaleString();
+    } catch (_) { return 'unknown'; }
+  }
+
+  function relTime(dateStr) {
+    if (!dateStr) return '';
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + 'm ago';
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return hrs + 'h ago';
+    const days = Math.floor(hrs / 24);
+    if (days < 7) return days + 'd ago';
+    return new Date(dateStr).toLocaleDateString();
+  }
+
+  let revisions = [];
+  let isOwnerOrEditor = false;
+
+  function renderRevisions() {
+    const listEl = document.getElementById('revisions-list');
+    const emptyEl = document.getElementById('revisions-empty');
+    if (!revisions || revisions.length === 0) {
+      listEl.innerHTML = '';
+      emptyEl.classList.remove('d-none');
+      return;
+    }
+    emptyEl.classList.add('d-none');
+    listEl.innerHTML = revisions.map((r, idx) => {
+      const isCurrent = idx === 0;
+      return `
+        <div class="list-group-item">
+          <div class="d-flex justify-content-between align-items-start gap-3">
+            <div class="flex-grow-1">
+              <div>
+                <strong>${esc(r.author || 'someone')}</strong>
+                <span class="text-muted small ms-2" title="${esc(fmtTime(r.created_at))}">${esc(relTime(r.created_at))}</span>
+                ${isCurrent ? '<span class="badge bg-primary ms-2">current</span>' : ''}
+              </div>
+              <div class="small text-muted mt-1">${r.change_summary ? esc(r.change_summary) : '<em>No summary provided</em>'}</div>
+            </div>
+            <div class="d-flex gap-1 flex-shrink-0">
+              <button class="btn btn-sm btn-outline-secondary view-rev-btn" data-rev-id="${esc(r.id)}" type="button"><i class="fas fa-eye me-1"></i>View</button>
+              ${(!isCurrent && isOwnerOrEditor) ? `<button class="btn btn-sm btn-outline-primary restore-rev-btn" data-rev-id="${esc(r.id)}" type="button"><i class="fas fa-undo me-1"></i>Restore</button>` : ''}
+            </div>
+          </div>
+        </div>`;
+    }).join('');
+
+    listEl.querySelectorAll('.view-rev-btn').forEach(b => b.addEventListener('click', () => viewRevision(b.dataset.revId)));
+    listEl.querySelectorAll('.restore-rev-btn').forEach(b => b.addEventListener('click', () => restoreRevision(b.dataset.revId)));
+  }
+
+  async function viewRevision(revId) {
+    // The base /revisions endpoint may return the snapshot inline. If not,
+    // we just render whatever metadata we have for that revision.
+    const r = revisions.find(x => String(x.id) === String(revId));
+    if (!r) return;
+    const sec = document.getElementById('preview-section');
+    document.getElementById('preview-title').textContent = (r.author || 'someone') + ' — ' + fmtTime(r.created_at);
+    const body = document.getElementById('preview-body');
+    // Use whatever snapshot fields the API gives us. Common fields:
+    //   description_md, name, sku, mpn, image_url, tags, suppliers
+    let html = '';
+    if (r.name) html += `<p><strong>Name:</strong> ${esc(r.name)}</p>`;
+    if (r.sku) html += `<p><strong>SKU:</strong> ${esc(r.sku)}</p>`;
+    if (r.mpn) html += `<p><strong>MPN:</strong> ${esc(r.mpn)}</p>`;
+    if (Array.isArray(r.tags) && r.tags.length) html += `<p><strong>Tags:</strong> ${r.tags.map(esc).join(', ')}</p>`;
+    if (Array.isArray(r.suppliers) && r.suppliers.length) {
+      html += `<p><strong>Suppliers:</strong></p><ul>` + r.suppliers.map(s => `<li>${esc(s.name || s.url || '')} — ${esc(s.url || '')}</li>`).join('') + `</ul>`;
+    }
+    if (r.description_md) {
+      html += `<hr><div>${marked.parse(r.description_md)}</div>`;
+    } else if (!html) {
+      html = '<p class="text-muted fst-italic">No snapshot fields available for this revision. Restore it to view full details on the part page.</p>';
+    }
+    body.innerHTML = html;
+    body.querySelectorAll('table').forEach(t => t.classList.add('table', 'table-single', 'table-narrow'));
+    sec.classList.remove('d-none');
+    sec.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  document.getElementById('preview-close').addEventListener('click', () => {
+    document.getElementById('preview-section').classList.add('d-none');
+  });
+
+  function showAccountAge(payload) {
+    const eligibleAt = payload && (payload.eligible_at || payload.eligibleAt || (payload.detail && payload.detail.eligible_at));
+    let dateStr = '';
+    if (eligibleAt) { try { dateStr = new Date(eligibleAt).toLocaleDateString(); } catch (_) {} }
+    document.getElementById('account-age-message').textContent = dateStr
+      ? `You need to have had an account for at least 14 days before editing parts. Try again on ${dateStr}.`
+      : `You need to have had an account for at least 14 days before editing parts. Please try again later.`;
+    document.getElementById('account-age-alert').classList.remove('d-none');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  async function restoreRevision(revId) {
+    if (!confirm('Restore this revision? A new revision will be created with these contents — your current version stays in the history.')) return;
+    document.getElementById('restore-error').classList.add('d-none');
+    document.getElementById('account-age-alert').classList.add('d-none');
+    try {
+      const resp = await ProjectAuth.apiFetch(
+        API + '/api/parts/' + encodeURIComponent(slug) + '/revisions/' + encodeURIComponent(revId) + '/restore',
+        { method: 'POST' }
+      );
+      if (resp.status === 403) {
+        let payload = {};
+        try { payload = await resp.json(); } catch (_) {}
+        showAccountAge(payload);
+        return;
+      }
+      if (!resp.ok) {
+        let detail = 'Could not restore that revision (HTTP ' + resp.status + ').';
+        try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+        const errEl = document.getElementById('restore-error');
+        errEl.textContent = detail;
+        errEl.classList.remove('d-none');
+        return;
+      }
+      window.location.href = '/parts/view.html?slug=' + encodeURIComponent(slug);
+    } catch (e) {
+      const errEl = document.getElementById('restore-error');
+      errEl.textContent = 'Network error: ' + (e.message || e);
+      errEl.classList.remove('d-none');
+    }
+  }
+
+  async function loadHistory() {
+    try {
+      // Whether the current user is logged in (we show Restore buttons to
+      // logged-in users; the API still enforces the 14-day rule).
+      try {
+        const me = await ProjectAuth.apiFetch(API + '/api/projects/my/list');
+        isOwnerOrEditor = me.ok;
+      } catch (_) { isOwnerOrEditor = false; }
+
+      const resp = await fetch(API + '/api/parts/' + encodeURIComponent(slug) + '/revisions?limit=50');
+      if (!resp.ok) {
+        document.getElementById('loading').classList.add('d-none');
+        document.getElementById('history-container').classList.remove('d-none');
+        const err = document.getElementById('restore-error');
+        err.textContent = 'Could not load revisions for this part.';
+        err.classList.remove('d-none');
+        return;
+      }
+      const data = await resp.json();
+      revisions = Array.isArray(data) ? data : (Array.isArray(data && data.revisions) ? data.revisions : []);
+      // Sort newest first (defensive — backend should already do this)
+      revisions.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      document.getElementById('history-subtitle').innerHTML = 'for <a href="/parts/view.html?slug=' + encodeURIComponent(slug) + '">' + esc(slug) + '</a>';
+      document.getElementById('loading').classList.add('d-none');
+      document.getElementById('history-container').classList.remove('d-none');
+      renderRevisions();
+    } catch (e) {
+      document.getElementById('loading').classList.add('d-none');
+      document.getElementById('history-container').classList.remove('d-none');
+      const err = document.getElementById('restore-error');
+      err.textContent = 'Network error loading revisions.';
+      err.classList.remove('d-none');
+    }
+  }
+
+  loadHistory();
+})();
+</script>

--- a/web/parts/index.html
+++ b/web/parts/index.html
@@ -1,0 +1,151 @@
+---
+title: Parts Catalog
+layout: default
+description: Browse and search the community parts catalog
+---
+
+<link rel="stylesheet" href="/assets/css/project-editor.css">
+
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
+    <div>
+      <h1 class="mb-1"><i class="fas fa-cubes me-2 text-primary"></i>Parts Catalog</h1>
+      <p class="text-muted mb-0">A shared, community-edited catalog of the parts we use in projects.</p>
+    </div>
+    <div>
+      <a href="/parts/edit.html?new=1" id="new-part-btn" class="btn btn-sm btn-outline-primary d-none">
+        <i class="fas fa-plus me-1"></i> New part
+      </a>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <label for="parts-search" class="form-label small text-muted">Search by name, SKU or MPN</label>
+      <div class="input-group">
+        <span class="input-group-text bg-white"><i class="fas fa-search text-muted"></i></span>
+        <input type="search" id="parts-search" class="form-control" placeholder="Start typing... e.g. SG90, motor driver, 9V battery" autocomplete="off">
+      </div>
+      <div class="form-text">Searches name, aliases, SKU and MPN. Results update as you type.</div>
+    </div>
+  </div>
+
+  <div id="parts-status" class="text-muted small mb-2"></div>
+
+  <div id="parts-results" class="list-group"></div>
+
+  <div id="parts-empty" class="text-center py-5 d-none">
+    <i class="fas fa-search fa-2x text-muted mb-2"></i>
+    <p class="text-muted">No parts match that search yet.</p>
+    <a href="/parts/edit.html?new=1" id="parts-empty-new" class="btn btn-sm btn-outline-primary d-none">
+      <i class="fas fa-plus me-1"></i> Add the first one
+    </a>
+  </div>
+</div>
+
+<script src="/assets/js/project-auth.js"></script>
+<script>
+(function() {
+  const API = 'https://projects.kevsrobots.com';
+  const searchInput = document.getElementById('parts-search');
+  const statusEl = document.getElementById('parts-status');
+  const resultsEl = document.getElementById('parts-results');
+  const emptyEl = document.getElementById('parts-empty');
+  const newBtn = document.getElementById('new-part-btn');
+  const emptyNewBtn = document.getElementById('parts-empty-new');
+  let debounceTimer = null;
+  let inFlight = null;
+
+  function esc(s) {
+    const d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+  }
+
+  function statusBadge(status) {
+    if (status === 'verified') {
+      return '<span class="badge bg-success-subtle text-success"><i class="fas fa-check-circle me-1"></i>verified</span>';
+    }
+    if (status === 'under_review') {
+      return '<span class="badge bg-warning-subtle text-warning">under review</span>';
+    }
+    return '<span class="badge bg-secondary-subtle text-secondary">draft</span>';
+  }
+
+  function renderParts(parts) {
+    if (!parts || parts.length === 0) {
+      resultsEl.innerHTML = '';
+      emptyEl.classList.remove('d-none');
+      statusEl.textContent = '';
+      return;
+    }
+    emptyEl.classList.add('d-none');
+    statusEl.textContent = parts.length + ' result' + (parts.length === 1 ? '' : 's');
+    resultsEl.innerHTML = parts.map(p => `
+      <a href="/parts/view.html?slug=${encodeURIComponent(p.slug)}" class="list-group-item list-group-item-action">
+        <div class="d-flex justify-content-between align-items-start gap-3">
+          <div class="flex-grow-1">
+            <div class="fw-bold">${esc(p.name)}</div>
+            <div class="small text-muted">
+              ${p.sku ? '<span class="me-2"><strong>SKU:</strong> ' + esc(p.sku) + '</span>' : ''}
+              ${typeof p.usage_count === 'number' ? '<span class="me-2"><i class="fas fa-clipboard-list me-1"></i>used in ' + p.usage_count + ' project' + (p.usage_count === 1 ? '' : 's') + '</span>' : ''}
+            </div>
+          </div>
+          <div class="text-end">${statusBadge(p.status)}</div>
+        </div>
+      </a>
+    `).join('');
+  }
+
+  async function search(query) {
+    if (inFlight && inFlight.abort) { try { inFlight.abort(); } catch (_) {} }
+    inFlight = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+    statusEl.textContent = 'Searching...';
+    try {
+      const opts = inFlight ? { signal: inFlight.signal } : {};
+      const resp = await fetch(API + '/api/parts?q=' + encodeURIComponent(query) + '&limit=25', opts);
+      if (!resp.ok) {
+        statusEl.textContent = 'Could not reach the parts catalog. Please try again later.';
+        resultsEl.innerHTML = '';
+        return;
+      }
+      const data = await resp.json();
+      renderParts(Array.isArray(data) ? data : []);
+    } catch (e) {
+      if (e && e.name === 'AbortError') return;
+      statusEl.textContent = 'Could not reach the parts catalog. Please try again later.';
+      resultsEl.innerHTML = '';
+    }
+  }
+
+  searchInput.addEventListener('input', () => {
+    const q = searchInput.value.trim();
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (q.length === 0) {
+      // Empty search returns recently-edited / popular if backend allows it
+      debounceTimer = setTimeout(() => search(''), 250);
+      return;
+    }
+    if (q.length < 2) {
+      statusEl.textContent = 'Keep typing...';
+      return;
+    }
+    debounceTimer = setTimeout(() => search(q), 250);
+  });
+
+  // Show "new part" buttons if the user is logged in (server enforces age).
+  async function checkAuth() {
+    try {
+      const resp = await ProjectAuth.apiFetch(API + '/api/projects/my/list');
+      if (resp.ok) {
+        newBtn.classList.remove('d-none');
+        emptyNewBtn.classList.remove('d-none');
+      }
+    } catch (_) {}
+  }
+  checkAuth();
+
+  // Initial load — show some results immediately
+  search('');
+})();
+</script>

--- a/web/parts/view.html
+++ b/web/parts/view.html
@@ -1,0 +1,221 @@
+---
+title: Part
+layout: default
+description: View a part in the catalog
+---
+
+<link rel="stylesheet" href="/assets/css/project-editor.css">
+
+<div class="container py-4">
+  <div class="mb-3">
+    <a href="/parts/" class="text-decoration-none text-muted"><i class="fas fa-arrow-left"></i> Back to Parts Catalog</a>
+  </div>
+
+  <div id="loading" class="text-center py-5">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+
+  <div id="not-found" class="text-center py-5 d-none">
+    <i class="fas fa-exclamation-triangle fa-3x text-warning mb-3"></i>
+    <h3>Part not found</h3>
+    <p class="text-muted">We couldn't find a part with that slug.</p>
+    <a href="/parts/" class="btn btn-primary mt-3">Browse parts catalog</a>
+  </div>
+
+  <div id="part-view" class="d-none">
+    <div class="row">
+      <div class="col-lg-8">
+        <div class="d-flex align-items-center gap-3 mb-1 flex-wrap">
+          <h1 id="part-name" class="mb-0"></h1>
+          <span id="part-status-badge"></span>
+        </div>
+        <div id="part-ids" class="text-muted small mb-3"></div>
+
+        <div id="part-image-wrap" class="mb-4 d-none">
+          <img id="part-image" class="img-fluid rounded" alt="">
+        </div>
+
+        <div id="part-tags" class="d-flex flex-wrap gap-2 mb-3"></div>
+
+        <hr>
+
+        <div id="part-description" class="mb-4" style="line-height:1.7"></div>
+
+        <div id="part-suppliers-section" class="mb-4 d-none">
+          <h4><i class="fas fa-truck me-2"></i> Suppliers</h4>
+          <ul id="part-suppliers" class="list-group"></ul>
+        </div>
+
+        <div id="part-revisions-section" class="mb-4 d-none">
+          <h5 class="text-muted small text-uppercase"><i class="fas fa-history me-1"></i> Recent revisions</h5>
+          <ul id="part-revisions" class="list-unstyled small"></ul>
+          <a id="part-history-link" href="#" class="small">View full history &rarr;</a>
+        </div>
+      </div>
+
+      <div class="col-lg-4">
+        <div class="card mb-3">
+          <div class="card-body">
+            <div class="small text-muted mb-2">
+              <i class="fas fa-user me-1"></i> Created by <strong id="part-author"></strong>
+            </div>
+            <div class="small text-muted mb-2">
+              <i class="fas fa-calendar-plus me-1"></i> Added <span id="part-created"></span>
+            </div>
+            <div class="small text-muted mb-3">
+              <i class="fas fa-clock me-1"></i> Updated <span id="part-updated"></span>
+            </div>
+            <div class="mb-2">
+              <span class="badge bg-light text-dark"><i class="fas fa-clipboard-list me-1"></i> <span id="part-usage">0</span> project<span id="part-usage-plural"></span></span>
+            </div>
+            <div id="part-edit-container" class="d-grid gap-2 mt-3 d-none">
+              <a id="part-edit-link" href="#" class="btn btn-sm btn-outline-primary"><i class="fas fa-pencil-alt me-1"></i> Edit part</a>
+              <a id="part-history-btn" href="#" class="btn btn-sm btn-outline-secondary"><i class="fas fa-history me-1"></i> Revision history</a>
+            </div>
+            <div id="part-login-container" class="d-grid mt-3 d-none">
+              <a href="/login" class="btn btn-sm btn-outline-secondary"><i class="fas fa-sign-in-alt me-1"></i> Log in to edit</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="/assets/js/project-auth.js"></script>
+<script>
+(function() {
+  const API = 'https://projects.kevsrobots.com';
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+
+  if (!slug) {
+    document.getElementById('loading').classList.add('d-none');
+    document.getElementById('not-found').classList.remove('d-none');
+    return;
+  }
+
+  function esc(t) { const d = document.createElement('div'); d.textContent = t || ''; return d.innerHTML; }
+
+  function styleMarkdownTables(el) {
+    if (!el) return;
+    el.querySelectorAll('table').forEach(t => t.classList.add('table', 'table-single', 'table-narrow'));
+  }
+
+  function statusBadge(status) {
+    if (status === 'verified') return '<span class="badge bg-success"><i class="fas fa-check-circle me-1"></i>verified</span>';
+    if (status === 'under_review') return '<span class="badge bg-warning text-dark">under review</span>';
+    return '<span class="badge bg-secondary">draft</span>';
+  }
+
+  function supplierStatusBadge(s) {
+    if (s === 'ok') return '<span class="badge bg-success-subtle text-success ms-2">link OK</span>';
+    if (s === 'broken') return '<span class="badge bg-danger-subtle text-danger ms-2">link broken</span>';
+    return '';
+  }
+
+  function fmtTime(dateStr) {
+    if (!dateStr) return 'unknown';
+    try { return new Date(dateStr).toLocaleDateString(); } catch (_) { return 'unknown'; }
+  }
+
+  async function load() {
+    let part;
+    try {
+      const resp = await fetch(API + '/api/parts/' + encodeURIComponent(slug));
+      if (!resp.ok) throw new Error('not found');
+      part = await resp.json();
+    } catch (e) {
+      document.getElementById('loading').classList.add('d-none');
+      document.getElementById('not-found').classList.remove('d-none');
+      return;
+    }
+
+    document.getElementById('loading').classList.add('d-none');
+    document.getElementById('part-view').classList.remove('d-none');
+    document.title = (part.name || 'Part') + ' — KevsRobots Parts';
+
+    document.getElementById('part-name').textContent = part.name || slug;
+    document.getElementById('part-status-badge').innerHTML = statusBadge(part.status);
+
+    const idsParts = [];
+    if (part.sku) idsParts.push(`<span class="badge bg-light text-dark me-2"><strong>SKU:</strong> ${esc(part.sku)}</span>`);
+    if (part.mpn) idsParts.push(`<span class="badge bg-light text-dark me-2"><strong>MPN:</strong> ${esc(part.mpn)}</span>`);
+    document.getElementById('part-ids').innerHTML = idsParts.join('');
+
+    if (part.image_url) {
+      document.getElementById('part-image-wrap').classList.remove('d-none');
+      const img = document.getElementById('part-image');
+      img.src = part.image_url;
+      img.alt = part.name || '';
+      img.loading = 'lazy';
+    }
+
+    const tagsEl = document.getElementById('part-tags');
+    (part.tags || []).forEach(t => {
+      tagsEl.innerHTML += `<span class="badge bg-light text-primary">${esc(t)}</span>`;
+    });
+
+    const descEl = document.getElementById('part-description');
+    if (part.description_md) {
+      descEl.innerHTML = marked.parse(part.description_md);
+      styleMarkdownTables(descEl);
+    } else {
+      descEl.innerHTML = '<p class="text-muted fst-italic">No description yet. <a href="/parts/edit.html?slug=' + encodeURIComponent(slug) + '">Help write one</a>.</p>';
+    }
+
+    if (Array.isArray(part.suppliers) && part.suppliers.length > 0) {
+      const sec = document.getElementById('part-suppliers-section');
+      sec.classList.remove('d-none');
+      document.getElementById('part-suppliers').innerHTML = part.suppliers.map(s => `
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div>
+            <a href="${esc(s.url)}" target="_blank" rel="noopener">${esc(s.name || s.url)} <i class="fas fa-external-link-alt fa-xs text-muted"></i></a>
+            ${supplierStatusBadge(s.last_status)}
+          </div>
+          ${s.last_checked_at ? `<small class="text-muted">checked ${fmtTime(s.last_checked_at)}</small>` : ''}
+        </li>
+      `).join('');
+    }
+
+    document.getElementById('part-author').textContent = part.created_by || 'unknown';
+    document.getElementById('part-created').textContent = fmtTime(part.created_at);
+    document.getElementById('part-updated').textContent = fmtTime(part.updated_at);
+    const usage = typeof part.usage_count === 'number' ? part.usage_count : 0;
+    document.getElementById('part-usage').textContent = usage;
+    document.getElementById('part-usage-plural').textContent = usage === 1 ? '' : 's';
+
+    if (Array.isArray(part.revisions) && part.revisions.length > 0) {
+      const sec = document.getElementById('part-revisions-section');
+      sec.classList.remove('d-none');
+      document.getElementById('part-revisions').innerHTML = part.revisions.slice(0, 5).map(r => `
+        <li class="mb-1">
+          <strong>${esc(r.author || 'someone')}</strong>
+          <span class="text-muted">${fmtTime(r.created_at)}</span>
+          ${r.change_summary ? ' &mdash; ' + esc(r.change_summary) : ''}
+        </li>
+      `).join('');
+      document.getElementById('part-history-link').href = '/parts/history.html?slug=' + encodeURIComponent(slug);
+    }
+
+    // Show edit / history buttons if the user is logged in. The API enforces
+    // the 14-day account-age rule when they actually try to save, so we keep
+    // the buttons optimistically visible to logged-in users.
+    try {
+      const me = await ProjectAuth.apiFetch(API + '/api/projects/my/list');
+      if (me.ok) {
+        document.getElementById('part-edit-container').classList.remove('d-none');
+        document.getElementById('part-edit-link').href = '/parts/edit.html?slug=' + encodeURIComponent(slug);
+        document.getElementById('part-history-btn').href = '/parts/history.html?slug=' + encodeURIComponent(slug);
+      } else {
+        document.getElementById('part-login-container').classList.remove('d-none');
+      }
+    } catch (_) {
+      document.getElementById('part-login-container').classList.remove('d-none');
+    }
+  }
+
+  load();
+})();
+</script>

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -378,8 +378,14 @@ description: View project details
     let total = 0;
     tbody.innerHTML = items.map(i => {
       total += i.quantity * (i.unit_cost || 0);
+      // If a part_id + slug came back with the BOM row, link the part name to
+      // its parts-catalog page. Backwards compatible: rows without part_slug
+      // stay as plain text.
+      const nameCell = i.part_id && i.part_slug
+        ? `<a href="/parts/view.html?slug=${encodeURIComponent(i.part_slug)}">${esc(i.name)}</a>`
+        : esc(i.name);
       return `<tr>
-        <td>${esc(i.name)}</td>
+        <td>${nameCell}</td>
         <td>${i.quantity}</td>
         <td>${esc(i.unit)}</td>
         <td>${i.unit_cost ? '£' + i.unit_cost.toFixed(2) : '-'}</td>


### PR DESCRIPTION
Implements the frontend half of #121 (parts catalog Phase 1).

Depends on the parallel backend PR adding the `/api/parts` endpoints to `projects-api` — until that ships, the new pages render and degrade gracefully (errors show a friendly message; BOM updates still save without `part_id`).

## Summary

- **BOM autosuggest** in `web/assets/js/project-editor.js` + new CSS in `web/assets/css/project-editor.css`. 250ms debounced search, keyboard-navigable dropdown with name (bold) / SKU (muted) / usage badge / verified badge, plus an "Add as new part..." Bootstrap modal that POSTs `/api/parts` and links the new part to the row. Supplier URL auto-fills from the chosen part with a "from parts catalog" hint.
- **Linked-part pill** on reload — `loadBOM` renders a small pill linking to `/parts/view.html?slug=<slug>` when the BOM row has `part_id`+`part_slug`.
- **Graceful degradation**: `updateBOM` sends `part_id` best-effort and retries without it if a (still-shipping) backend rejects the field.
- **Four new Jekyll pages** under `web/parts/`:
  - `index.html` — minimal search/browse landing
  - `view.html` — read-only wiki page (`?slug=`), renders markdown via marked.js with `table-narrow` styling, shows tags, suppliers with link-health badges, "used in N projects", and Edit/History buttons to logged-in users
  - `edit.html` — `?slug=` to edit, `?new=1` (optional `&name=`) to create; EasyMDE editor matching the project editor's style, repeatable supplier rows, tag chips, and a required `change_summary` field
  - `history.html` — revisions newest-first with View (inline preview) and Restore (POST `/restore`, then redirects to the part view)
- **403 account-age UX**: friendly Bootstrap alert ("You need to have had an account for at least 14 days before editing parts. Try again on `<date>`."). Date is parsed from the response when supplied; otherwise a generic message. Absolute dates only (per spec).
- **Projects view linkback**: `web/projects/view.html` now links the BOM part name to the parts catalog page when the backend returns `part_id`+`part_slug` on the BOM row. Backwards compatible — rows without a slug stay as plain text.

## Decisions made (couldn't ask)

- Routed "Add new part" via a Bootstrap modal from the BOM autosuggest *and* surfaced `/parts/edit.html?new=1` from the parts index page. Both call the same `POST /api/parts`.
- `/parts/edit.html` does a follow-up `PUT` if a description was written during create (the issue body's `POST /api/parts` shape doesn't include `description_md`, so we save it as a second revision with summary "Initial description").
- Edit/Restore buttons are shown to *all* logged-in users; the API enforces the 14-day rule and we show a friendly toast on 403. Anonymous users get a "Log in to edit" link.
- No nav-menu changes — parts catalog is discoverable from the BOM autosuggest and BOM row links for v1.
- Did not modify anything under `stacks/projects-api/` (as required).
- `_site/` is gitignored so the test Jekyll build output isn't committed.

## Test plan

- [ ] Backend PR for #121 deployed
- [ ] In the project editor, type a query in a BOM Part-name cell — dropdown appears within ~250ms
- [ ] Arrow keys / Enter / Escape work in the dropdown
- [ ] Click "+ Add as new part" — modal opens with pre-filled name; saving links the new part to the row and auto-fills the supplier URL
- [ ] Reload the project editor — rows with `part_id` show the "/parts/<slug>" pill
- [ ] Visit `/parts/` and search — results render with usage + status badges
- [ ] Visit `/parts/view.html?slug=<known-slug>` — markdown description renders with site table styling
- [ ] Visit `/parts/edit.html?slug=<known-slug>` — fields populate, EasyMDE loads, save with a change summary redirects to the view page
- [ ] Visit `/parts/history.html?slug=<known-slug>` — revisions render newest-first; View shows inline preview; Restore returns to the view page
- [ ] Submit any PUT/POST/restore as a sub-14-day account — friendly toast/alert appears with the eligible date
- [ ] On `/projects/view.html?id=...`, BOM rows with `part_slug` link to the parts catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)