### PR TITLE
feat(projects): remixes (fork & attribution)

### DIFF
--- a/stacks/projects-api/projects_api/db.py
+++ b/stacks/projects-api/projects_api/db.py
@@ -133,3 +133,51 @@ async def repair_stale_fks() -> None:
                 f'ALTER TABLE "{owning_table}" ADD CONSTRAINT "{fk_name}" '
                 f'FOREIGN KEY ("{fk_column}") REFERENCES "{live_target}" (id){cascade}'
             ))
+
+
+async def add_remix_columns_if_missing() -> None:
+    """Additive migration for issue #108 (project remixes).
+
+    Adds ``remixed_from_id`` (FK -> projects.id ON DELETE SET NULL) and
+    ``remix_description`` (TEXT) to the existing ``projects`` table when
+    they do not already exist. SQLAlchemy's ``create_all`` does not ALTER
+    existing tables, so this lightweight idempotent helper keeps existing
+    Postgres deployments in sync. Safe to run on every startup; no-op when
+    the columns are already present. Postgres-only — SQLite test runs use
+    ``create_all`` against a fresh in-memory DB which already includes the
+    new columns.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.begin() as conn:
+        # Check existence of the projects table first; if the DB is brand
+        # new, create_all will already have built it with these columns.
+        table_check = await conn.execute(text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = 'projects'"
+        ))
+        if table_check.first() is None:
+            return
+
+        existing = await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'projects'"
+        ))
+        cols = {row[0] for row in existing.fetchall()}
+
+        if "remixed_from_id" not in cols:
+            logger.warning("Adding projects.remixed_from_id column (issue #108)")
+            await conn.execute(text(
+                'ALTER TABLE "projects" ADD COLUMN "remixed_from_id" INTEGER '
+                'REFERENCES "projects" (id) ON DELETE SET NULL'
+            ))
+            await conn.execute(text(
+                'CREATE INDEX IF NOT EXISTS "ix_projects_remixed_from_id" '
+                'ON "projects" ("remixed_from_id")'
+            ))
+        if "remix_description" not in cols:
+            logger.warning("Adding projects.remix_description column (issue #108)")
+            await conn.execute(text(
+                'ALTER TABLE "projects" ADD COLUMN "remix_description" TEXT'
+            ))

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -9,14 +9,16 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
-from .db import create_all, repair_stale_fks
-from .routers import bom, files, health, images, journal, links, moderation, projects
+from .db import add_remix_columns_if_missing, create_all, repair_stale_fks
+from .routers import bom, files, health, images, journal, links, moderation, projects, remixes
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await create_all()
     await repair_stale_fks()
+    # Issue #108: ensure remix columns exist on legacy Postgres deployments.
+    await add_remix_columns_if_missing()
     yield
 
 
@@ -43,6 +45,8 @@ def create_app() -> FastAPI:
     app.include_router(links.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
+    # Issue #108: project remixes (fork & attribution).
+    app.include_router(remixes.router)
     return app
 
 

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -39,6 +39,15 @@ class Project(Base):
     cover_image: Mapped[Optional[str]] = mapped_column(Text)
     is_blocked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     moderation_note: Mapped[Optional[str]] = mapped_column(Text)
+    # Remix/fork attribution (issue #108). remixed_from_id points at the parent
+    # project this one was remixed from. ondelete=SET NULL so deleting an
+    # original project doesn't cascade-delete its derivatives. The
+    # application layer is responsible for ensuring remix_description is
+    # populated whenever remixed_from_id is set.
+    remixed_from_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    remix_description: Mapped[Optional[str]] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )

--- a/stacks/projects-api/projects_api/routers/projects.py
+++ b/stacks/projects-api/projects_api/routers/projects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +17,7 @@ from ..schemas import (
     ProjectListItem,
     ProjectResponse,
     ProjectUpdate,
+    RemixedFromRef,
 )
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
@@ -41,6 +42,25 @@ async def _set_tags(session: AsyncSession, project_id: int, tags: list[str]) -> 
 
 async def _project_response(session: AsyncSession, project: Project) -> ProjectResponse:
     tags = await _get_tags(session, project.id)
+
+    # Issue #108: compute remix attribution & counts.
+    remixed_from_ref: Optional[RemixedFromRef] = None
+    parent_id = getattr(project, "remixed_from_id", None)
+    if parent_id is not None:
+        parent = await session.get(Project, parent_id)
+        if parent is not None:
+            remixed_from_ref = RemixedFromRef(
+                id=parent.id,
+                title=parent.title,
+                author_username=parent.author_username,
+            )
+
+    remixes_count = (
+        await session.scalar(
+            select(func.count(Project.id)).where(Project.remixed_from_id == project.id)
+        )
+    ) or 0
+
     return ProjectResponse(
         id=project.id,
         title=project.title,
@@ -55,6 +75,10 @@ async def _project_response(session: AsyncSession, project: Project) -> ProjectR
         tags=tags,
         created_at=project.created_at,
         updated_at=project.updated_at,
+        remixed_from=remixed_from_ref,
+        remix_description=getattr(project, "remix_description", None),
+        remixes_count=int(remixes_count),
+        is_remix=remixed_from_ref is not None,
     )
 
 
@@ -108,6 +132,8 @@ async def list_projects(
                 cover_image=p.cover_image,
                 tags=tags,
                 created_at=p.created_at,
+                # Issue #108: surface remix indicator on list cards.
+                is_remix=getattr(p, "remixed_from_id", None) is not None,
             )
         )
     return items
@@ -154,6 +180,7 @@ async def create_project(
 async def update_project(
     project_id: int,
     body: ProjectUpdate,
+    request: Request,
     user: str = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ) -> ProjectResponse:
@@ -162,6 +189,25 @@ async def update_project(
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
     if project.author_username != user:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not the project owner")
+
+    # Issue #108: remix attribution is permanent. Even though ProjectUpdate
+    # does not expose remixed_from_id / remix_description, defensively
+    # inspect the raw request body and reject any explicit attempt to
+    # change them. Surface as 400 with a clear message.
+    try:
+        raw_body = await request.json()
+    except Exception:  # pragma: no cover - body may not be JSON
+        raw_body = {}
+    if isinstance(raw_body, dict):
+        for forbidden in ("remixed_from_id", "remix_description"):
+            if forbidden in raw_body:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Remix attribution is permanent and cannot be modified. "
+                        f"Field '{forbidden}' may not be changed via PUT."
+                    ),
+                )
 
     update_data = body.model_dump(exclude_unset=True)
     tags = update_data.pop("tags", None)
@@ -219,6 +265,8 @@ async def my_projects(
                 cover_image=p.cover_image,
                 tags=tags,
                 created_at=p.created_at,
+                # Issue #108: surface remix indicator on list cards.
+                is_remix=getattr(p, "remixed_from_id", None) is not None,
             )
         )
     return items

--- a/stacks/projects-api/projects_api/routers/remixes.py
+++ b/stacks/projects-api/projects_api/routers/remixes.py
@@ -1,0 +1,185 @@
+"""Remix / fork endpoints (issue #108).
+
+Provides:
+
+* ``POST /api/projects/{project_id}/remix`` — create a NEW project owned
+  by the calling user, pre-linked as a remix of ``project_id``.
+* ``GET  /api/projects/{project_id}/remixes`` — list direct remixes of a
+  project.
+* ``GET  /api/projects/{project_id}/remix-chain`` — ancestry chain from
+  the original ancestor down to this project, with cycle/depth safety.
+
+All write paths refuse to clear or change remix attribution once set
+(see ``routers/projects.py::update_project``).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import get_current_user
+from ..db import get_session
+from ..models import Project, ProjectTag
+from ..schemas import (
+    ProjectListItem,
+    ProjectResponse,
+    ProjectRemixCreate,
+)
+from .projects import _get_tags, _project_response, _set_tags
+
+router = APIRouter(prefix="/api/projects", tags=["remixes"])
+
+# Defensive cap so we never walk an infinite remix chain. 20 is well above
+# any realistic ancestry depth and matches the spec.
+MAX_CHAIN_DEPTH = 20
+
+
+def _list_item_from_project(project: Project, tags: list[str]) -> ProjectListItem:
+    return ProjectListItem(
+        id=project.id,
+        title=project.title,
+        short_description=project.short_description,
+        difficulty=project.difficulty,
+        estimated_minutes=project.estimated_minutes,
+        status=project.status,
+        author_username=project.author_username,
+        cover_image=project.cover_image,
+        tags=tags,
+        created_at=project.created_at,
+        is_remix=getattr(project, "remixed_from_id", None) is not None,
+    )
+
+
+@router.post(
+    "/{project_id}/remix",
+    response_model=ProjectResponse,
+    status_code=201,
+)
+async def create_remix(
+    project_id: int,
+    body: ProjectRemixCreate,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectResponse:
+    """Create a remix of an existing project.
+
+    The new project is owned by the caller and pre-linked to the original
+    via ``remixed_from_id``. Fields like description and tags are inherited
+    from the original to give the remixer a starting point; they can edit
+    everything afterwards via the normal editor flow.
+    """
+    original = await session.get(Project, project_id)
+    if original is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+    if getattr(original, "is_blocked", False):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail="This project is blocked and cannot be remixed",
+        )
+
+    title = (body.title or f"Remix of {original.title}").strip()
+    if len(title) < 5:
+        title = f"Remix of {original.title}"
+
+    remix = Project(
+        title=title[:200],
+        short_description=original.short_description,
+        content_md=original.content_md,
+        difficulty=original.difficulty,
+        estimated_minutes=original.estimated_minutes,
+        # Don't inherit the original code_repo_url — the remixer's fork
+        # will live somewhere different. They can fill it in later.
+        code_repo_url=None,
+        status="wip",
+        author_username=user,
+        remixed_from_id=original.id,
+        remix_description=body.remix_description.strip(),
+    )
+    session.add(remix)
+    await session.flush()
+
+    # Inherit tags from the original so the remix shows up in the same
+    # filters by default. Remixer can edit these later.
+    inherited_tags = await _get_tags(session, original.id)
+    if inherited_tags:
+        await _set_tags(session, remix.id, inherited_tags)
+
+    # TODO(#106): Remixer badge eval hook here — when the badges service
+    # lands, fire an event so the caller can level up their Remixer tier.
+
+    await session.commit()
+    await session.refresh(remix)
+    return await _project_response(session, remix)
+
+
+@router.get("/{project_id}/remixes", response_model=list[ProjectListItem])
+async def list_remixes(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> list[ProjectListItem]:
+    """List direct (one-hop) remixes of a given project."""
+    # 404 the parent itself so callers get a clear signal.
+    parent = await session.get(Project, project_id)
+    if parent is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+
+    remixes = (
+        await session.scalars(
+            select(Project)
+            .where(Project.remixed_from_id == project_id)
+            .where(Project.is_blocked == False)  # noqa: E712
+            .order_by(Project.created_at.desc())
+        )
+    ).all()
+
+    items: list[ProjectListItem] = []
+    for r in remixes:
+        tags = await _get_tags(session, r.id)
+        items.append(_list_item_from_project(r, tags))
+    return items
+
+
+@router.get("/{project_id}/remix-chain", response_model=list[ProjectListItem])
+async def remix_chain(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> list[ProjectListItem]:
+    """Return the ancestry chain ``[original, ..., this]``.
+
+    Walks ``remixed_from_id`` upwards from the given project, then reverses
+    so the original ancestor appears first. Caps at :data:`MAX_CHAIN_DEPTH`
+    and breaks on cycles by tracking visited ids — both are defensive
+    against malformed data, not expected in normal operation.
+    """
+    current: Optional[Project] = await session.get(Project, project_id)
+    if current is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+
+    chain: list[Project] = []
+    visited: set[int] = set()
+    while current is not None:
+        if current.id in visited:
+            # Cycle detected — bail out. Should never happen with normal
+            # creation flow but defend the endpoint just in case.
+            break
+        visited.add(current.id)
+        chain.append(current)
+        if len(chain) >= MAX_CHAIN_DEPTH:
+            break
+        parent_id = getattr(current, "remixed_from_id", None)
+        if parent_id is None:
+            break
+        current = await session.get(Project, parent_id)
+
+    # We walked child -> parent; reverse so the response is original -> this.
+    chain.reverse()
+
+    items: list[ProjectListItem] = []
+    for p in chain:
+        tags = await _get_tags(session, p.id)
+        items.append(_list_item_from_project(p, tags))
+    return items

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -30,6 +30,19 @@ class ProjectUpdate(BaseModel):
     tags: Optional[list[str]] = None
 
 
+class RemixedFromRef(BaseModel):
+    """Minimal reference to a parent project (issue #108).
+
+    Embedded inside :class:`ProjectResponse` when the project is a remix.
+    ``slug`` is reserved for when project slugs land — keep optional now.
+    """
+
+    id: int
+    slug: Optional[str] = None
+    title: str
+    author_username: str
+
+
 class ProjectResponse(BaseModel):
     id: int
     title: str
@@ -44,6 +57,11 @@ class ProjectResponse(BaseModel):
     tags: list[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
+    # Issue #108: remix / fork attribution.
+    remixed_from: Optional[RemixedFromRef] = None
+    remix_description: Optional[str] = None
+    remixes_count: int = 0
+    is_remix: bool = False
 
 
 class ProjectListItem(BaseModel):
@@ -57,6 +75,19 @@ class ProjectListItem(BaseModel):
     cover_image: Optional[str]
     tags: list[str] = Field(default_factory=list)
     created_at: datetime
+    # Issue #108: surface remix indicator on list cards.
+    is_remix: bool = False
+
+
+class ProjectRemixCreate(BaseModel):
+    """Body for ``POST /api/projects/{id}/remix`` (issue #108).
+
+    ``remix_description`` is mandatory and must be at least 10 characters
+    so the resulting attribution actually documents what changed.
+    """
+
+    title: Optional[str] = Field(None, min_length=5, max_length=200)
+    remix_description: str = Field(..., min_length=10, max_length=2000)
 
 
 class BOMItemCreate(BaseModel):

--- a/stacks/projects-api/tests/test_remixes.py
+++ b/stacks/projects-api/tests/test_remixes.py
@@ -1,0 +1,213 @@
+"""Tests for project remix / fork attribution (issue #108)."""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+async def _create_project(client, headers, **fields) -> dict:
+    payload = {"title": "Original Robot", "short_description": "A great bot"}
+    payload.update(fields)
+    resp = await client.post("/api/projects", json=payload, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_create_remix_links_to_original(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+
+    original = await _create_project(client, alice, title="Original Robot")
+
+    resp = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={"remix_description": "Swapped the motor driver for a TB6612"},
+        headers=bob,
+    )
+    assert resp.status_code == 201, resp.text
+    remix = resp.json()
+
+    assert remix["author_username"] == "bob"
+    assert remix["title"].startswith("Remix of ")
+    assert remix["remixed_from"]["id"] == original["id"]
+    assert remix["remixed_from"]["title"] == "Original Robot"
+    assert remix["remixed_from"]["author_username"] == "alice"
+    assert remix["is_remix"] is True
+    assert remix["remix_description"].startswith("Swapped the motor")
+    assert remix["status"] == "wip"
+
+
+@pytest.mark.asyncio
+async def test_remix_appears_in_originals_remix_list(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+
+    original = await _create_project(client, alice, title="Original Robot")
+    remix_resp = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={"remix_description": "Added an OLED display for battery info"},
+        headers=bob,
+    )
+    remix = remix_resp.json()
+
+    # Direct remixes list contains the new project.
+    listing = await client.get(f"/api/projects/{original['id']}/remixes")
+    assert listing.status_code == 200
+    ids = [r["id"] for r in listing.json()]
+    assert remix["id"] in ids
+
+    # The original now reports a remix count of 1.
+    refreshed = await client.get(f"/api/projects/{original['id']}")
+    body = refreshed.json()
+    assert body["remixes_count"] == 1
+    assert body["is_remix"] is False
+
+
+@pytest.mark.asyncio
+async def test_remix_chain_returns_full_ancestry(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+    carol = make_auth_header("carol")
+
+    a = await _create_project(client, alice, title="Project A")
+
+    b_resp = await client.post(
+        f"/api/projects/{a['id']}/remix",
+        json={"remix_description": "B is A but with smaller wheels"},
+        headers=bob,
+    )
+    b = b_resp.json()
+
+    c_resp = await client.post(
+        f"/api/projects/{b['id']}/remix",
+        json={"remix_description": "C is B but with a Pi Pico controller"},
+        headers=carol,
+    )
+    c = c_resp.json()
+
+    chain = await client.get(f"/api/projects/{c['id']}/remix-chain")
+    assert chain.status_code == 200
+    ids = [p["id"] for p in chain.json()]
+    assert ids == [a["id"], b["id"], c["id"]]
+
+
+@pytest.mark.asyncio
+async def test_put_cannot_clear_remix_attribution(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+
+    original = await _create_project(client, alice, title="Original Robot")
+    remix_resp = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={"remix_description": "Refactored the chassis for laser cutting"},
+        headers=bob,
+    )
+    remix_id = remix_resp.json()["id"]
+
+    # Attempt to clear the parent link.
+    clear_attempt = await client.put(
+        f"/api/projects/{remix_id}",
+        json={"remixed_from_id": None},
+        headers=bob,
+    )
+    assert clear_attempt.status_code == 400
+    assert "permanent" in clear_attempt.json()["detail"].lower()
+
+    # Attempt to change the description after the fact.
+    change_attempt = await client.put(
+        f"/api/projects/{remix_id}",
+        json={"remix_description": "actually I changed nothing"},
+        headers=bob,
+    )
+    assert change_attempt.status_code == 400
+
+    # Sanity: normal updates still work and attribution survives.
+    ok = await client.put(
+        f"/api/projects/{remix_id}",
+        json={"title": "My Improved Remix"},
+        headers=bob,
+    )
+    assert ok.status_code == 200
+    assert ok.json()["remixed_from"]["id"] == original["id"]
+    assert ok.json()["remix_description"].startswith("Refactored")
+
+
+@pytest.mark.asyncio
+async def test_remix_requires_description(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+    original = await _create_project(client, alice, title="Original Robot")
+
+    missing = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={},
+        headers=bob,
+    )
+    assert missing.status_code == 422
+
+    too_short = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={"remix_description": "tiny"},
+        headers=bob,
+    )
+    assert too_short.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_remix_requires_auth(client) -> None:
+    alice = make_auth_header("alice")
+    original = await _create_project(client, alice, title="Original Robot")
+    resp = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={"remix_description": "Anonymous would-be remixer"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_remix_of_unknown_project_404s(client) -> None:
+    bob = make_auth_header("bob")
+    resp = await client.post(
+        "/api/projects/99999/remix",
+        json={"remix_description": "Trying to fork a ghost"},
+        headers=bob,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_remix_with_custom_title(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+    original = await _create_project(client, alice, title="Original Robot")
+    resp = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={
+            "title": "Bob's Beefed-Up Bot",
+            "remix_description": "Doubled the battery capacity",
+        },
+        headers=bob,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["title"] == "Bob's Beefed-Up Bot"
+
+
+@pytest.mark.asyncio
+async def test_list_projects_marks_remixes(client) -> None:
+    alice = make_auth_header("alice")
+    bob = make_auth_header("bob")
+    original = await _create_project(client, alice, title="Original Robot")
+    remix_resp = await client.post(
+        f"/api/projects/{original['id']}/remix",
+        json={"remix_description": "Added neopixel underlights"},
+        headers=bob,
+    )
+    remix_id = remix_resp.json()["id"]
+
+    listing = await client.get("/api/projects")
+    by_id = {p["id"]: p for p in listing.json()}
+    assert by_id[remix_id]["is_remix"] is True
+    assert by_id[original["id"]]["is_remix"] is False

--- a/web/projects/hub.md
+++ b/web/projects/hub.md
@@ -153,12 +153,15 @@ thanks: false
             <div class="card h-100 border-0 shadow-sm card-hover">
               ${projectThumbnail(p, 200)}
               <div class="card-body">
-                <h5 class="card-title text-dark">${esc(p.title)}</h5>
+                <h5 class="card-title text-dark">
+                  ${p.is_remix ? '<i class="fas fa-code-branch text-muted me-1" title="Remix of another project" data-bs-toggle="tooltip"></i>' : ''}${esc(p.title)}
+                </h5>
                 <p class="card-text text-muted small">${esc(p.short_description || '')}</p>
                 <div class="d-flex flex-wrap gap-1 mb-2">
                   ${statusBadges[p.status] || ''}
                   ${p.difficulty ? `<span class="badge bg-${difficultyColors[p.difficulty] || 'secondary'}">${p.difficulty}</span>` : ''}
                   ${p.estimated_minutes ? `<span class="badge bg-light text-dark"><i class="fas fa-clock"></i> ${p.estimated_minutes}min</span>` : ''}
+                  ${p.is_remix ? '<span class="badge bg-light text-muted"><i class="fas fa-code-branch"></i> Remix</span>' : ''}
                 </div>
                 <div class="d-flex flex-wrap gap-1">
                   ${(p.tags || []).slice(0, 4).map(t => `<span class="badge bg-light text-primary">${esc(t)}</span>`).join('')}

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -31,13 +31,34 @@ description: View project details
 
       <!-- MIDDLE: Main content -->
       <div class="col-lg-7">
+        <!-- Remix chain breadcrumb (issue #108) — hidden unless this project is a remix -->
+        <nav id="remix-chain-crumbs" class="remix-chain-crumbs small text-muted mb-2 d-none" aria-label="Remix chain"></nav>
+
         <div class="d-flex align-items-center gap-3 mb-1">
           <h1 id="view-title" class="mb-0"></h1>
           <span id="like-container"></span>
           <a id="edit-icon" href="#" class="d-none text-muted" title="Edit this project" aria-label="Edit this project" style="font-size:1.1rem">
             <i class="fas fa-pencil-alt"></i>
           </a>
+          <a id="remix-icon" href="#" class="d-none text-muted" title="Remix this project" aria-label="Remix this project" style="font-size:1.1rem" data-bs-toggle="modal" data-bs-target="#remix-modal">
+            <i class="fas fa-code-branch"></i>
+          </a>
         </div>
+
+        <!-- Remix attribution banner (issue #108) — shown when this project is a remix -->
+        <div id="remix-attribution-banner" class="alert alert-info d-none py-2 px-3 mb-3" role="note">
+          <i class="fas fa-code-branch me-2" aria-hidden="true"></i>
+          Remix of <a id="remix-attribution-link" href="#"></a>
+          by <strong id="remix-attribution-author"></strong>
+          <i class="fas fa-info-circle text-muted ms-1"
+             id="remix-attribution-tooltip"
+             tabindex="0"
+             data-bs-toggle="tooltip"
+             data-bs-placement="bottom"
+             title=""
+             aria-label="What changed in this remix"></i>
+        </div>
+
         <p id="view-description" class="lead text-muted"></p>
 
         <div id="view-meta-badges" class="d-flex flex-wrap gap-2 mb-4"></div>
@@ -144,8 +165,55 @@ description: View project details
               <div id="view-journal"></div>
             </div>
           </div>
+
+          <!-- Remixes (issue #108) — direct derivatives of this project -->
+          <div id="view-remixes-section" class="card mb-3 d-none">
+            <div class="card-header py-2 d-flex justify-content-between align-items-center">
+              <span><i class="fas fa-code-branch me-2"></i> Remixes <span id="view-remixes-count" class="badge bg-secondary"></span></span>
+            </div>
+            <div class="card-body">
+              <div id="view-remixes"></div>
+            </div>
+          </div>
         </div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Remix creation modal (issue #108) -->
+<div class="modal fade" id="remix-modal" tabindex="-1" aria-labelledby="remix-modal-label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="remix-form">
+        <div class="modal-header">
+          <h5 class="modal-title" id="remix-modal-label"><i class="fas fa-code-branch me-2"></i> Remix this project</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p class="small text-muted">
+            A remix creates a new project linked back to the original with attribution.
+            Tell future readers what you changed — this description is permanent.
+          </p>
+          <div class="mb-3">
+            <label for="remix-title" class="form-label">Title <span class="text-muted small">(optional)</span></label>
+            <input type="text" class="form-control" id="remix-title" maxlength="200">
+            <div class="form-text" id="remix-title-help">Defaults to "Remix of …"</div>
+          </div>
+          <div class="mb-3">
+            <label for="remix-description" class="form-label">What did you change? <span class="text-danger">*</span></label>
+            <textarea class="form-control" id="remix-description" rows="4" minlength="10" maxlength="2000" required></textarea>
+            <div class="form-text">At least 10 characters. This stays on the remix forever.</div>
+          </div>
+          <div id="remix-error" class="alert alert-danger d-none py-2 mb-0" role="alert"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary" id="remix-submit">
+            <i class="fas fa-code-branch me-1"></i> Create remix
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 </div>
@@ -211,6 +279,53 @@ description: View project details
     text-align: center;
     margin: 1.5rem 0;
   }
+
+  /* Remix chain breadcrumb (issue #108) */
+  .remix-chain-crumbs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.4rem;
+    align-items: center;
+  }
+  .remix-chain-crumbs a {
+    color: #6c757d;
+    text-decoration: none;
+  }
+  .remix-chain-crumbs a:hover { color: #4A90D9; }
+  .remix-chain-crumbs .crumb-current {
+    color: #212529;
+    font-weight: 500;
+  }
+  .remix-chain-crumbs .crumb-sep {
+    color: #adb5bd;
+    font-size: 0.75rem;
+  }
+  .remix-chain-crumbs .crumb-ellipsis {
+    color: #adb5bd;
+  }
+
+  /* Remix attribution banner */
+  #remix-attribution-banner { font-size: 0.95rem; }
+  #remix-attribution-tooltip { cursor: help; }
+
+  /* Sidebar remix list */
+  #view-remixes .remix-item {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid #f1f3f5;
+  }
+  #view-remixes .remix-item:last-child { border-bottom: none; }
+  #view-remixes .remix-thumb {
+    width: 40px;
+    height: 40px;
+    border-radius: 4px;
+    object-fit: cover;
+    flex: 0 0 40px;
+    background: #f1f3f5;
+  }
+  #view-remixes .remix-item a { text-decoration: none; }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jszip@3/dist/jszip.min.js"></script>
@@ -340,11 +455,20 @@ description: View project details
             editIcon.href = editUrl;
             editIcon.classList.remove('d-none');
           } else {
+            // Logged-in non-owner: show remix button & report form (issue #108).
+            const remixIcon = document.getElementById('remix-icon');
+            if (remixIcon) remixIcon.classList.remove('d-none');
+            setupRemixForm(project);
             document.getElementById('report-section').classList.remove('d-none');
             setupReportForm(project.id);
           }
         }
       } catch (e) {}
+
+      // Render remix attribution banner & chain crumbs (issue #108).
+      renderRemixAttribution(project);
+      loadRemixChain(project);
+      loadRemixesSidebar(project);
 
       loadBOM();
       loadFiles();
@@ -365,6 +489,160 @@ description: View project details
       document.getElementById('loading').classList.add('d-none');
       document.getElementById('not-found').classList.remove('d-none');
     }
+  }
+
+  // ---- Remix attribution (issue #108) ----------------------------------
+  function renderRemixAttribution(project) {
+    if (!project || !project.remixed_from) return;
+    const banner = document.getElementById('remix-attribution-banner');
+    const link = document.getElementById('remix-attribution-link');
+    const author = document.getElementById('remix-attribution-author');
+    const tip = document.getElementById('remix-attribution-tooltip');
+    if (!banner || !link || !author) return;
+
+    link.textContent = project.remixed_from.title;
+    link.href = '/projects/view.html?id=' + project.remixed_from.id;
+    author.textContent = project.remixed_from.author_username;
+    if (tip) {
+      const desc = project.remix_description || 'No change description provided.';
+      tip.setAttribute('title', desc);
+      tip.setAttribute('data-bs-original-title', desc);
+      // Initialise Bootstrap tooltip if available; fail silently otherwise.
+      try {
+        if (window.bootstrap && window.bootstrap.Tooltip) {
+          new window.bootstrap.Tooltip(tip);
+        }
+      } catch (e) {}
+    }
+    banner.classList.remove('d-none');
+  }
+
+  async function loadRemixChain(project) {
+    // Only render when this project is itself a remix.
+    if (!project || !project.remixed_from) return;
+    const crumbs = document.getElementById('remix-chain-crumbs');
+    if (!crumbs) return;
+    try {
+      const resp = await fetch(API + '/api/projects/' + project.id + '/remix-chain');
+      if (!resp.ok) return;
+      const chain = await resp.json();
+      if (!Array.isArray(chain) || chain.length < 2) return;
+
+      // Truncate intermediate hops if the chain is long: show first, ellipsis, last two before current.
+      let shown = chain;
+      let truncated = false;
+      if (chain.length > 5) {
+        shown = [chain[0], null, chain[chain.length - 3], chain[chain.length - 2], chain[chain.length - 1]];
+        truncated = true;
+      }
+
+      const parts = [];
+      for (let i = 0; i < shown.length; i++) {
+        if (i > 0) parts.push('<span class="crumb-sep"><i class="fas fa-angle-right"></i></span>');
+        const item = shown[i];
+        if (item === null) {
+          parts.push('<span class="crumb-ellipsis" title="' + (chain.length - 4) + ' intermediate remixes hidden">…</span>');
+          continue;
+        }
+        const isCurrent = item.id === project.id;
+        if (isCurrent) {
+          parts.push('<span class="crumb-current">' + esc(item.title) + '</span>');
+        } else {
+          parts.push('<a href="/projects/view.html?id=' + item.id + '">' + esc(item.title) + '</a>');
+        }
+      }
+      crumbs.innerHTML = '<i class="fas fa-code-branch me-1 text-muted" aria-hidden="true"></i>' + parts.join(' ');
+      crumbs.classList.remove('d-none');
+      if (truncated) {
+        crumbs.setAttribute('title', 'Full chain depth: ' + chain.length);
+      }
+    } catch (e) {
+      // Non-fatal — banner alone is still useful.
+    }
+  }
+
+  async function loadRemixesSidebar(project) {
+    if (!project) return;
+    const section = document.getElementById('view-remixes-section');
+    const countEl = document.getElementById('view-remixes-count');
+    const listEl = document.getElementById('view-remixes');
+    if (!section || !listEl) return;
+    try {
+      const resp = await fetch(API + '/api/projects/' + project.id + '/remixes');
+      if (!resp.ok) return;
+      const remixes = await resp.json();
+      if (!Array.isArray(remixes) || remixes.length === 0) return;
+      if (countEl) countEl.textContent = remixes.length;
+      listEl.innerHTML = remixes.map(function (r) {
+        var thumb = r.cover_image
+          ? '<img class="remix-thumb" loading="lazy" src="' + esc(r.cover_image) + '" alt="">'
+          : '<span class="remix-thumb d-inline-flex align-items-center justify-content-center text-muted"><i class="fas fa-code-branch"></i></span>';
+        return '<div class="remix-item">' +
+          thumb +
+          '<div class="flex-grow-1 small">' +
+            '<a href="/projects/view.html?id=' + r.id + '" class="d-block text-truncate">' + esc(r.title) + '</a>' +
+            '<span class="text-muted">by ' + esc(r.author_username) + '</span>' +
+          '</div>' +
+        '</div>';
+      }).join('');
+      section.classList.remove('d-none');
+    } catch (e) {
+      // Silent failure — sidebar tile is optional.
+    }
+  }
+
+  function setupRemixForm(project) {
+    var form = document.getElementById('remix-form');
+    var titleInput = document.getElementById('remix-title');
+    var descInput = document.getElementById('remix-description');
+    var errEl = document.getElementById('remix-error');
+    var submitBtn = document.getElementById('remix-submit');
+    var titleHelp = document.getElementById('remix-title-help');
+    if (!form || !titleInput || !descInput) return;
+    if (titleHelp) titleHelp.textContent = 'Defaults to "Remix of ' + project.title + '"';
+    titleInput.setAttribute('placeholder', 'Remix of ' + project.title);
+
+    form.addEventListener('submit', async function (ev) {
+      ev.preventDefault();
+      errEl.classList.add('d-none');
+      var desc = (descInput.value || '').trim();
+      if (desc.length < 10) {
+        errEl.textContent = 'Please describe what you changed (at least 10 characters).';
+        errEl.classList.remove('d-none');
+        return;
+      }
+      submitBtn.disabled = true;
+      submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Creating…';
+      try {
+        var payload = { remix_description: desc };
+        var titleVal = (titleInput.value || '').trim();
+        if (titleVal.length >= 5) payload.title = titleVal;
+        var resp = await ProjectAuth.apiFetch(API + '/api/projects/' + project.id + '/remix', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (resp.status === 401) {
+          errEl.textContent = 'Please log in to remix this project.';
+          errEl.classList.remove('d-none');
+        } else if (!resp.ok) {
+          var body = null;
+          try { body = await resp.json(); } catch (e) {}
+          errEl.textContent = (body && body.detail) ? body.detail : 'Failed to create remix. Please try again.';
+          errEl.classList.remove('d-none');
+        } else {
+          var newProject = await resp.json();
+          // Send the user to the editor for their new remix.
+          window.location.href = '/projects/editor.html?id=' + newProject.id;
+          return;
+        }
+      } catch (e) {
+        errEl.textContent = 'Network error. Please try again.';
+        errEl.classList.remove('d-none');
+      }
+      submitBtn.disabled = false;
+      submitBtn.innerHTML = '<i class="fas fa-code-branch me-1"></i> Create remix';
+    });
   }
 
   async function loadBOM() {


### PR DESCRIPTION
## Summary

- Backend: adds `remixed_from_id` (FK SET NULL) and `remix_description` to projects, plus a new remixes router exposing `POST /api/projects/{id}/remix`, `GET /api/projects/{id}/remixes`, and `GET /api/projects/{id}/remix-chain` (depth-capped, cycle-safe). `PUT /api/projects/{id}` now rejects any attempt to clear or change remix attribution with HTTP 400.
- Schemas: `ProjectResponse` gains `remixed_from`, `remix_description`, `remixes_count`, `is_remix`; `ProjectListItem` gains `is_remix`; new `ProjectRemixCreate {title?, remix_description}` body (description required, >= 10 chars).
- Frontend: view page shows a Remix button (logged-in non-owners), a modal that posts the remix and redirects to the editor, a fork-icon attribution banner with tooltip explaining the change, a remix-chain breadcrumb above the title, and a Remixes sidebar card. Hub cards show a fork icon and "Remix" badge when `is_remix=true`. No remix fields are exposed in the editor (attribution is permanent).
- Tests: 9 new tests in `stacks/projects-api/tests/test_remixes.py` cover creation, chain ancestry, attribution permanence (clear/change both 400), missing/short description (422), auth, custom title, and the `is_remix` flag on listings. All 43 backend tests pass.

A small idempotent Postgres migration helper (`add_remix_columns_if_missing`) is wired into the FastAPI lifespan so existing deployments pick up the new columns. SQLite tests pick them up via `create_all`.

Out of scope (left for #106): Remixer badge evaluation and notifications. A `TODO(#106)` is left at the remix-creation endpoint as a hook point.

Closes #108

## Test plan

- [x] `python3 -m pytest` in `stacks/projects-api` (43/43 passing)
- [ ] Manually verify the Remix button only appears for logged-in non-owners
- [ ] Manually verify the modal posts and redirects to the editor for the new project
- [ ] Manually verify the attribution banner and remix-chain breadcrumb render on a remixed project
- [ ] Manually verify the Remixes sidebar card lists derivatives on the original
- [ ] Manually verify the fork icon and "Remix" badge appear on hub cards for remixes

Generated with [Claude Code](https://claude.com/claude-code)