### PR TITLE
feat(makes): community "I Made This!" posts on projects

### DIFF
--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -10,7 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
 from .db import create_all, repair_stale_fks
-from .routers import bom, files, health, images, journal, links, moderation, projects
+from .routers import bom, files, health, images, journal, links, makes, moderation, projects
 
 
 @asynccontextmanager
@@ -43,6 +43,7 @@ def create_app() -> FastAPI:
     app.include_router(links.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
+    app.include_router(makes.router)
     return app
 
 

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -164,3 +164,48 @@ class ProjectJournalImage(Base):
     uploaded_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )
+
+
+# --- Community Makes ("I Made This!") -- issue #107 -----------------------
+#
+# A `Make` is a user-submitted "I built this!" post on someone else's
+# project. It carries optional notes + modifications text and 0-5 images.
+# The project's author may "heart" individual makes; we model that with a
+# single nullable `hearted_at` column on `Make` rather than a join table
+# because hearts come from exactly one user (the project author) so a
+# many-to-many relation is overkill. If we later want multi-user hearts we
+# can promote this to a `make_hearts` table without rewriting the read
+# path (the `hearted_by_author` response field stays the same).
+
+
+class Make(Base):
+    __tablename__ = "makes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    notes: Mapped[Optional[str]] = mapped_column(Text)
+    modifications: Mapped[Optional[str]] = mapped_column(Text)
+    hearted_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+
+class MakeImage(Base):
+    __tablename__ = "make_images"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    make_id: Mapped[int] = mapped_column(
+        ForeignKey("makes.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    file_path: Mapped[str] = mapped_column(Text, nullable=False)
+    file_size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    caption: Mapped[Optional[str]] = mapped_column(Text)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    uploaded_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )

--- a/stacks/projects-api/projects_api/routers/makes.py
+++ b/stacks/projects-api/projects_api/routers/makes.py
@@ -1,0 +1,390 @@
+"""Community Makes ("I Made This!") endpoints — issue #107.
+
+A `Make` is a user post on someone else's project that says "I built this!".
+It carries optional notes + modifications text and up to 5 images.
+
+Permissions:
+  * Anyone authenticated may post a make on any project.
+  * Only the make's `user_id` (the poster) may delete it.
+  * Only the project's `author_username` may heart/unheart a make.
+
+Out of scope here (see #106):
+  * Badge evaluation hook — TODO markers are left where a Make is
+    created and deleted so that subsystem can attach later without
+    a refactor.
+  * Activity feed integration.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import get_current_user
+from ..config import get_settings
+from ..db import get_session
+from ..models import Make, MakeImage, Project
+from ..schemas import MakeImageResponse, MakeResponse
+from ..storage import (
+    ALLOWED_IMAGE_EXTENSIONS,
+    delete_file,
+    generate_filename,
+    read_file,
+    save_file,
+)
+
+MAX_IMAGES_PER_MAKE = 5
+
+# Two routers because makes span three URL spaces:
+#   /api/projects/{project_id}/makes  (list + create)
+#   /api/users/{username}/makes        (user-scoped list)
+#   /api/makes/{make_id}/...           (detail / delete / heart / image view)
+router = APIRouter(tags=["makes"])
+
+
+def _serialize_image(img: MakeImage) -> MakeImageResponse:
+    return MakeImageResponse(
+        id=img.id,
+        filename=img.filename,
+        caption=img.caption,
+        sort_order=img.sort_order,
+        file_size=img.file_size or 0,
+    )
+
+
+def _serialize_make(
+    make: Make,
+    images: list[MakeImage],
+    project_author: Optional[str] = None,
+    project_title: Optional[str] = None,
+) -> MakeResponse:
+    return MakeResponse(
+        id=make.id,
+        project_id=make.project_id,
+        user_id=make.user_id,
+        created_at=make.created_at,
+        notes=make.notes,
+        modifications=make.modifications,
+        images=[_serialize_image(i) for i in images],
+        hearted_by_author=make.hearted_at is not None,
+        project_title=project_title,
+    )
+
+
+async def _load_images_for(
+    session: AsyncSession, make_ids: list[int]
+) -> dict[int, list[MakeImage]]:
+    if not make_ids:
+        return {}
+    rows = (
+        await session.scalars(
+            select(MakeImage)
+            .where(MakeImage.make_id.in_(make_ids))
+            .order_by(MakeImage.sort_order, MakeImage.id)
+        )
+    ).all()
+    grouped: dict[int, list[MakeImage]] = {mid: [] for mid in make_ids}
+    for img in rows:
+        grouped.setdefault(img.make_id, []).append(img)
+    return grouped
+
+
+# --- Create / list under a project ----------------------------------------
+
+
+@router.post(
+    "/api/projects/{project_id}/makes",
+    response_model=MakeResponse,
+    status_code=201,
+)
+async def create_make(
+    project_id: int,
+    notes: Optional[str] = Form(default=None),
+    modifications: Optional[str] = Form(default=None),
+    images: list[UploadFile] = [],  # noqa: B006 — FastAPI handles default
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> MakeResponse:
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+    # Filter out the empty UploadFile FastAPI sometimes synthesises when
+    # the client sends the multipart field with no actual file attached.
+    real_images = [
+        f for f in (images or [])
+        if f is not None and getattr(f, "filename", None)
+    ]
+    if len(real_images) > MAX_IMAGES_PER_MAKE:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"Too many images (max {MAX_IMAGES_PER_MAKE})",
+        )
+
+    # Validate every image up-front before we write anything so a bad file
+    # at index 4 doesn't leave us with orphans on disk.
+    settings = get_settings()
+    validated: list[tuple[UploadFile, bytes]] = []
+    for f in real_images:
+        content = await f.read()
+        ext = (
+            "." + f.filename.rsplit(".", 1)[-1].lower()
+            if "." in f.filename
+            else ""
+        )
+        if ext not in ALLOWED_IMAGE_EXTENSIONS:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                detail=f"Image type {ext} not allowed",
+            )
+        if len(content) > settings.max_image_size:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST, detail="Image too large"
+            )
+        validated.append((f, content))
+
+    make = Make(
+        project_id=project_id,
+        user_id=user,
+        notes=notes,
+        modifications=modifications,
+    )
+    session.add(make)
+    await session.flush()  # need make.id for image rows / storage paths
+
+    saved_images: list[MakeImage] = []
+    for idx, (f, content) in enumerate(validated):
+        # Reuse the storage layout: makes/<make_id>/<filename>. We pass
+        # make.id as the "project_id" arg because the helper only uses it
+        # to namespace the directory.
+        stored_name = generate_filename(f.filename, make.id)
+        path = save_file(content, stored_name, make.id, "makes")
+        if path is None:
+            # Best-effort clean up of anything we already wrote.
+            for prior in saved_images:
+                delete_file(prior.file_path)
+            raise HTTPException(
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to save image",
+            )
+        img = MakeImage(
+            make_id=make.id,
+            filename=f.filename,
+            file_path=path,
+            file_size=len(content),
+            sort_order=idx,
+        )
+        session.add(img)
+        saved_images.append(img)
+
+    await session.commit()
+    await session.refresh(make)
+    for img in saved_images:
+        await session.refresh(img)
+
+    # TODO(#106): badge eval hook — call into the badges service here with
+    # (user=make.user_id, event="make.created", make_id=make.id).
+
+    return _serialize_make(make, saved_images)
+
+
+@router.get(
+    "/api/projects/{project_id}/makes",
+    response_model=list[MakeResponse],
+)
+async def list_makes_for_project(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> list[MakeResponse]:
+    makes = (
+        await session.scalars(
+            select(Make)
+            .where(Make.project_id == project_id)
+            .order_by(Make.created_at.desc(), Make.id.desc())
+        )
+    ).all()
+    img_map = await _load_images_for(session, [m.id for m in makes])
+    return [_serialize_make(m, img_map.get(m.id, [])) for m in makes]
+
+
+# --- User-scoped list -----------------------------------------------------
+
+
+@router.get("/api/users/{username}/makes", response_model=list[MakeResponse])
+async def list_makes_for_user(
+    username: str,
+    session: AsyncSession = Depends(get_session),
+) -> list[MakeResponse]:
+    makes = (
+        await session.scalars(
+            select(Make)
+            .where(Make.user_id == username)
+            .order_by(Make.created_at.desc(), Make.id.desc())
+        )
+    ).all()
+    img_map = await _load_images_for(session, [m.id for m in makes])
+    # Decorate with project title so the user-profile UI can render a
+    # "for <project>" line without a follow-up fetch per row.
+    title_map: dict[int, str] = {}
+    if makes:
+        project_ids = list({m.project_id for m in makes})
+        projects = (
+            await session.scalars(
+                select(Project).where(Project.id.in_(project_ids))
+            )
+        ).all()
+        title_map = {p.id: p.title for p in projects}
+    return [
+        _serialize_make(
+            m,
+            img_map.get(m.id, []),
+            project_title=title_map.get(m.project_id),
+        )
+        for m in makes
+    ]
+
+
+# --- Single make detail / delete / heart ---------------------------------
+
+
+@router.get("/api/makes/{make_id}", response_model=MakeResponse)
+async def get_make(
+    make_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> MakeResponse:
+    make = await session.get(Make, make_id)
+    if make is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    img_map = await _load_images_for(session, [make.id])
+    project = await session.get(Project, make.project_id)
+    return _serialize_make(
+        make,
+        img_map.get(make.id, []),
+        project_title=project.title if project else None,
+    )
+
+
+@router.delete("/api/makes/{make_id}", status_code=204)
+async def delete_make(
+    make_id: int,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    make = await session.get(Make, make_id)
+    if make is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if make.user_id != user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
+
+    # Clean up image blobs from NAS/local before the rows go away. We
+    # ignore individual failures — orphaned files are recoverable, lost
+    # rows are not.
+    image_rows = (
+        await session.scalars(
+            select(MakeImage).where(MakeImage.make_id == make_id)
+        )
+    ).all()
+    for img in image_rows:
+        try:
+            delete_file(img.file_path)
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
+
+    await session.delete(make)
+    await session.commit()
+
+    # TODO(#106): badge eval hook — call into the badges service here with
+    # (user=make.user_id, event="make.deleted", make_id=make_id).
+
+
+@router.post("/api/makes/{make_id}/heart", response_model=MakeResponse)
+async def heart_make(
+    make_id: int,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> MakeResponse:
+    make = await session.get(Make, make_id)
+    if make is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    project = await session.get(Project, make.project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if project.author_username != user:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail="Only the project author can heart a make",
+        )
+    make.hearted_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    await session.commit()
+    await session.refresh(make)
+    img_map = await _load_images_for(session, [make.id])
+    return _serialize_make(
+        make, img_map.get(make.id, []), project_title=project.title
+    )
+
+
+@router.delete("/api/makes/{make_id}/heart", response_model=MakeResponse)
+async def unheart_make(
+    make_id: int,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> MakeResponse:
+    make = await session.get(Make, make_id)
+    if make is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    project = await session.get(Project, make.project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if project.author_username != user:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail="Only the project author can unheart a make",
+        )
+    make.hearted_at = None
+    await session.commit()
+    await session.refresh(make)
+    img_map = await _load_images_for(session, [make.id])
+    return _serialize_make(
+        make, img_map.get(make.id, []), project_title=project.title
+    )
+
+
+# --- Image view (binary) -------------------------------------------------
+
+
+@router.get("/api/makes/{make_id}/images/{image_id}/view")
+async def view_make_image(
+    make_id: int,
+    image_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    img = await session.get(MakeImage, image_id)
+    if img is None or img.make_id != make_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    data = read_file(img.file_path)
+    if data is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Image not found in storage"
+        )
+    ext = (
+        img.filename.rsplit(".", 1)[-1].lower()
+        if "." in img.filename
+        else "png"
+    )
+    media_types = {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "webp": "image/webp",
+        "svg": "image/svg+xml",
+    }
+    return Response(
+        content=data,
+        media_type=media_types.get(ext, "application/octet-stream"),
+    )

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -156,3 +156,33 @@ class BlockedProjectResponse(BaseModel):
     is_blocked: bool
     moderation_note: Optional[str]
     created_at: datetime
+
+
+# --- Community Makes ("I Made This!") -- issue #107 -----------------------
+
+
+class MakeCreate(BaseModel):
+    notes: Optional[str] = Field(None, max_length=5000)
+    modifications: Optional[str] = Field(None, max_length=5000)
+
+
+class MakeImageResponse(BaseModel):
+    id: int
+    filename: str
+    caption: Optional[str] = None
+    sort_order: int
+    file_size: int
+
+
+class MakeResponse(BaseModel):
+    id: int
+    project_id: int
+    user_id: str
+    created_at: datetime
+    notes: Optional[str] = None
+    modifications: Optional[str] = None
+    images: list[MakeImageResponse] = Field(default_factory=list)
+    hearted_by_author: bool = False
+    # Populated only when returning a single make (detail view); harmless
+    # when omitted from list responses.
+    project_title: Optional[str] = None

--- a/stacks/projects-api/tests/test_makes.py
+++ b/stacks/projects-api/tests/test_makes.py
@@ -1,0 +1,221 @@
+"""Tests for Community Makes ("I Made This!") — issue #107.
+
+These exercise the contract laid out in the issue:
+  * Anyone authenticated can create a make on someone else's project.
+  * Only the make's poster can delete it.
+  * Only the project's author can heart/unheart the make.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+# 1x1 transparent PNG used for image upload tests.
+TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
+    b"\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00"
+    b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture
+async def project_id(client) -> int:
+    """A project owned by `author_user` so we can post makes against it."""
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Cool Robot Project"},
+        headers=make_auth_header("author_user"),
+    )
+    return resp.json()["id"]
+
+
+async def _create_make_with_image(client, project_id: int, *, as_user: str = "maker_one"):
+    return await client.post(
+        f"/api/projects/{project_id}/makes",
+        data={
+            "notes": "Worked great!",
+            "modifications": "Used a different motor.",
+        },
+        files={"images": ("photo.png", TINY_PNG, "image/png")},
+        headers=make_auth_header(as_user),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_make_with_one_image(client, project_id) -> None:
+    resp = await _create_make_with_image(client, project_id)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["project_id"] == project_id
+    assert body["user_id"] == "maker_one"
+    assert body["notes"] == "Worked great!"
+    assert body["modifications"] == "Used a different motor."
+    assert len(body["images"]) == 1
+    assert body["images"][0]["filename"] == "photo.png"
+    assert body["hearted_by_author"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_make_unauthenticated(client, project_id) -> None:
+    resp = await client.post(
+        f"/api/projects/{project_id}/makes",
+        data={"notes": "no auth"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_make_rejects_unknown_project(client) -> None:
+    resp = await client.post(
+        "/api/projects/99999/makes",
+        data={"notes": "ghost"},
+        headers=make_auth_header("maker_one"),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_make_rejects_too_many_images(client, project_id) -> None:
+    files = [("images", (f"p{i}.png", TINY_PNG, "image/png")) for i in range(6)]
+    resp = await client.post(
+        f"/api/projects/{project_id}/makes",
+        data={"notes": "lots"},
+        files=files,
+        headers=make_auth_header("maker_one"),
+    )
+    assert resp.status_code == 400
+    assert "max" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_list_makes_for_project(client, project_id) -> None:
+    await _create_make_with_image(client, project_id, as_user="maker_one")
+    await _create_make_with_image(client, project_id, as_user="maker_two")
+    resp = await client.get(f"/api/projects/{project_id}/makes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    # Newest first.
+    assert body[0]["user_id"] in {"maker_one", "maker_two"}
+    assert {m["user_id"] for m in body} == {"maker_one", "maker_two"}
+
+
+@pytest.mark.asyncio
+async def test_list_makes_for_user_across_projects(client) -> None:
+    # Two projects by different authors so the user-scoped list has to
+    # actually filter by user_id rather than coincidentally project-by-project.
+    p1 = (await client.post(
+        "/api/projects",
+        json={"title": "Project Alpha"},
+        headers=make_auth_header("author_a"),
+    )).json()["id"]
+    p2 = (await client.post(
+        "/api/projects",
+        json={"title": "Project Beta"},
+        headers=make_auth_header("author_b"),
+    )).json()["id"]
+
+    await _create_make_with_image(client, p1, as_user="builder")
+    await _create_make_with_image(client, p2, as_user="builder")
+    await _create_make_with_image(client, p1, as_user="someone_else")
+
+    resp = await client.get("/api/users/builder/makes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    assert {m["project_id"] for m in body} == {p1, p2}
+    # The user-scoped list should decorate each make with its project title.
+    titles = {m["project_title"] for m in body}
+    assert titles == {"Project Alpha", "Project Beta"}
+
+
+@pytest.mark.asyncio
+async def test_get_make_detail_includes_project_title(client, project_id) -> None:
+    create = await _create_make_with_image(client, project_id, as_user="maker_one")
+    make_id = create.json()["id"]
+    resp = await client.get(f"/api/makes/{make_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["project_title"] == "Cool Robot Project"
+    assert body["project_id"] == project_id
+
+
+@pytest.mark.asyncio
+async def test_view_make_image(client, project_id) -> None:
+    create = await _create_make_with_image(client, project_id, as_user="maker_one")
+    make = create.json()
+    image_id = make["images"][0]["id"]
+    resp = await client.get(
+        f"/api/makes/{make['id']}/images/{image_id}/view"
+    )
+    assert resp.status_code == 200
+    assert resp.content == TINY_PNG
+
+
+@pytest.mark.asyncio
+async def test_delete_make_as_owner(client, project_id) -> None:
+    create = await _create_make_with_image(client, project_id, as_user="maker_one")
+    make_id = create.json()["id"]
+    resp = await client.delete(
+        f"/api/makes/{make_id}",
+        headers=make_auth_header("maker_one"),
+    )
+    assert resp.status_code == 204
+    # Subsequent fetch should 404.
+    detail = await client.get(f"/api/makes/{make_id}")
+    assert detail.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_make_as_other_user_forbidden(client, project_id) -> None:
+    create = await _create_make_with_image(client, project_id, as_user="maker_one")
+    make_id = create.json()["id"]
+    resp = await client.delete(
+        f"/api/makes/{make_id}",
+        headers=make_auth_header("not_the_maker"),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_heart_as_project_author(client, project_id) -> None:
+    create = await _create_make_with_image(client, project_id, as_user="maker_one")
+    make_id = create.json()["id"]
+    resp = await client.post(
+        f"/api/makes/{make_id}/heart",
+        headers=make_auth_header("author_user"),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["hearted_by_author"] is True
+
+    # Now unheart.
+    resp = await client.delete(
+        f"/api/makes/{make_id}/heart",
+        headers=make_auth_header("author_user"),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["hearted_by_author"] is False
+
+
+@pytest.mark.asyncio
+async def test_heart_as_other_user_forbidden(client, project_id) -> None:
+    create = await _create_make_with_image(client, project_id, as_user="maker_one")
+    make_id = create.json()["id"]
+    # The make's poster is NOT the project author; they shouldn't be able
+    # to heart their own make.
+    resp = await client.post(
+        f"/api/makes/{make_id}/heart",
+        headers=make_auth_header("maker_one"),
+    )
+    assert resp.status_code == 403
+
+    # And a bystander can't either.
+    resp = await client.post(
+        f"/api/makes/{make_id}/heart",
+        headers=make_auth_header("random_user"),
+    )
+    assert resp.status_code == 403

--- a/web/projects/hub.md
+++ b/web/projects/hub.md
@@ -166,7 +166,10 @@ thanks: false
               </div>
               <div class="card-footer bg-transparent border-0 d-flex justify-content-between align-items-center">
                 <small class="text-muted">by ${esc(p.author_username)} &middot; ${new Date(p.created_at).toLocaleDateString()}</small>
-                <small class="text-muted" id="card-likes-${p.id}"><i class="far fa-heart"></i> </small>
+                <small class="text-muted">
+                  <span id="card-makes-${p.id}" class="me-2 d-none"><i class="fas fa-hammer"></i> <span data-count></span></span>
+                  <span id="card-likes-${p.id}"><i class="far fa-heart"></i> </span>
+                </small>
               </div>
             </div>
           </a>
@@ -182,6 +185,21 @@ thanks: false
             el.innerHTML = '<i class="far fa-heart"></i> ' + data.count;
           }
         });
+      });
+
+      // Fetch makes counts for visible cards (issue #107). Best-effort —
+      // failures just leave the badge hidden.
+      projects.forEach(function (p) {
+        fetch(API + '/api/projects/' + p.id + '/makes')
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (makes) {
+            if (!makes || makes.length === 0) return;
+            var wrap = document.getElementById('card-makes-' + p.id);
+            if (!wrap) return;
+            wrap.querySelector('[data-count]').textContent = makes.length;
+            wrap.classList.remove('d-none');
+          })
+          .catch(function () {});
       });
 
     } catch (e) {

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -96,6 +96,18 @@ description: View project details
           <h4><i class="fas fa-comments me-2"></i> Comments</h4>
           <div id="comments-container"></div>
         </div>
+
+        <!-- Community Makes ("I Made This!") -->
+        <div id="makes-section" class="mb-4">
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <h4 class="mb-0"><i class="fas fa-hammer me-2"></i> Community Makes <span id="makes-count" class="text-muted small fw-normal"></span></h4>
+            <button id="i-made-this-btn" class="btn btn-sm btn-primary d-none" type="button">
+              <i class="fas fa-plus-circle me-1"></i> I Made This!
+            </button>
+          </div>
+          <p id="makes-empty" class="text-muted small mb-3 d-none">No makes yet — be the first to share your build!</p>
+          <div id="makes-grid" class="row row-cols-1 row-cols-md-2 g-3"></div>
+        </div>
       </div>
 
       <!-- RIGHT: Sidebar (scrolls with main content) -->
@@ -144,7 +156,70 @@ description: View project details
               <div id="view-journal"></div>
             </div>
           </div>
+
+          <!-- Makes sidebar link -->
+          <div id="view-makes-sidebar" class="card mb-3 d-none">
+            <div class="card-body py-2">
+              <a href="#makes-section" id="view-makes-link" class="text-decoration-none small">
+                <i class="fas fa-hammer me-2"></i> Makes (<span id="view-makes-count">0</span>)
+              </a>
+            </div>
+          </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- "I Made This!" Modal -->
+<div id="i-made-this-modal" class="modal fade" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><i class="fas fa-hammer me-2"></i> Share your build</h5>
+        <button type="button" class="btn-close" data-imt-close aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="imt-error" class="alert alert-danger d-none" role="alert"></div>
+
+        <label class="form-label small fw-bold">Photos (up to 5)</label>
+        <div id="imt-dropzone" class="text-center p-3 border border-dashed rounded mb-2">
+          <small class="text-muted">
+            <label for="imt-image-input" style="cursor:pointer" class="text-primary">Click to choose images</label>
+            or drag &amp; drop here
+          </small>
+          <input type="file" id="imt-image-input" class="d-none" multiple accept="image/*">
+        </div>
+        <div id="imt-previews" class="row g-2 mb-3"></div>
+
+        <label for="imt-notes" class="form-label small fw-bold">Notes</label>
+        <textarea id="imt-notes" class="form-control mb-3" rows="3" maxlength="5000"
+                  placeholder="How did your build go? Anything you'd want others to know..."></textarea>
+
+        <label for="imt-modifications" class="form-label small fw-bold">Modifications</label>
+        <textarea id="imt-modifications" class="form-control" rows="3" maxlength="5000"
+                  placeholder="Did you change anything? List parts swaps, code tweaks, design improvements..."></textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-imt-close>Cancel</button>
+        <button type="button" id="imt-submit" class="btn btn-primary">
+          <i class="fas fa-paper-plane me-1"></i> Post Make
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Make detail modal -->
+<div id="make-detail-modal" class="modal fade" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><i class="fas fa-hammer me-2"></i> <span id="make-detail-title">Make</span></h5>
+        <button type="button" class="btn-close" data-make-detail-close aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="make-detail-body"></div>
       </div>
     </div>
   </div>
@@ -210,6 +285,17 @@ description: View project details
   #view-content .mermaid {
     text-align: center;
     margin: 1.5rem 0;
+  }
+
+  /* "I Made This!" dropzone (mirrors project-editor.css dropzone styling) */
+  #imt-dropzone {
+    border-style: dashed !important;
+    border-color: #dee2e6 !important;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  #imt-dropzone.dragover {
+    background: #e8f4fd;
+    border-color: #4A90D9 !important;
   }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -351,6 +437,7 @@ description: View project details
       loadImages();
       loadLinks();
       loadJournal();
+      loadMakes(project);
 
       // Load interactions (likes + comments) via Chatter
       var projectUrl = 'projects/view.html?id=' + projectId;
@@ -598,6 +685,381 @@ description: View project details
       .replace(/^-|-$/g, '');
   }
 
+  // --- Community Makes ("I Made This!") -- issue #107 ---------------------
+
+  var MAX_MAKE_IMAGES = 5;
+  var ALLOWED_IMAGE_MIME = /^image\//;
+  var imtSelectedFiles = [];
+  var imtCurrentProject = null;
+
+  function timeAgo(iso) {
+    var d = new Date(iso);
+    var s = Math.round((Date.now() - d.getTime()) / 1000);
+    if (s < 60) return s + 's ago';
+    var m = Math.round(s / 60);
+    if (m < 60) return m + 'm ago';
+    var h = Math.round(m / 60);
+    if (h < 24) return h + 'h ago';
+    var dd = Math.round(h / 24);
+    if (dd < 30) return dd + 'd ago';
+    return d.toLocaleDateString();
+  }
+
+  function openModal(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.classList.add('show');
+    el.style.display = 'block';
+    el.removeAttribute('aria-hidden');
+    document.body.classList.add('modal-open');
+    if (!document.querySelector('.modal-backdrop[data-for="' + id + '"]')) {
+      var bd = document.createElement('div');
+      bd.className = 'modal-backdrop fade show';
+      bd.setAttribute('data-for', id);
+      document.body.appendChild(bd);
+    }
+  }
+  function closeModal(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.classList.remove('show');
+    el.style.display = 'none';
+    el.setAttribute('aria-hidden', 'true');
+    var bd = document.querySelector('.modal-backdrop[data-for="' + id + '"]');
+    if (bd) bd.parentNode.removeChild(bd);
+    if (!document.querySelector('.modal.show')) {
+      document.body.classList.remove('modal-open');
+    }
+  }
+
+  function loadMakes(project) {
+    imtCurrentProject = project;
+
+    // Show the "I Made This!" button only to logged-in users who are NOT
+    // the project author. We piggyback on the same auth check loadProject
+    // already does (it sets edit-btn-container visibility); a more direct
+    // check via ProjectAuth.apiFetch keeps this self-contained.
+    ProjectAuth.apiFetch(API + '/api/projects/my/list').then(function (resp) {
+      if (!resp.ok) return;
+      return resp.json().then(function (mine) {
+        var isAuthor = mine.some(function (p) { return p.id === project.id; });
+        if (!isAuthor) {
+          document.getElementById('i-made-this-btn').classList.remove('d-none');
+        }
+      });
+    }).catch(function () {});
+
+    setupImtModal(project);
+    fetchMakes(project);
+  }
+
+  function fetchMakes(project) {
+    fetch(API + '/api/projects/' + project.id + '/makes')
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (makes) { renderMakes(makes, project); })
+      .catch(function () { renderMakes([], project); });
+  }
+
+  function renderMakes(makes, project) {
+    var grid = document.getElementById('makes-grid');
+    var empty = document.getElementById('makes-empty');
+    var count = document.getElementById('makes-count');
+    count.textContent = makes.length > 0 ? '(' + makes.length + ')' : '';
+
+    // Sidebar link only shows when there are makes.
+    var sb = document.getElementById('view-makes-sidebar');
+    var sbCount = document.getElementById('view-makes-count');
+    if (makes.length > 0) {
+      sb.classList.remove('d-none');
+      sbCount.textContent = makes.length;
+    } else {
+      sb.classList.add('d-none');
+    }
+
+    if (makes.length === 0) {
+      empty.classList.remove('d-none');
+      grid.innerHTML = '';
+      return;
+    }
+    empty.classList.add('d-none');
+
+    var isProjectAuthor = imtCurrentProject &&
+      project.author_username &&
+      makeAuthorIs(project.author_username);
+
+    grid.innerHTML = makes.map(function (m) {
+      var thumbs = (m.images || []).slice(0, 5).map(function (img, idx) {
+        var src = API + '/api/makes/' + m.id + '/images/' + img.id + '/view';
+        return '<img src="' + src + '" class="rounded" alt="" ' +
+               'style="width:60px;height:60px;object-fit:cover;margin-right:4px;" ' +
+               'data-make-thumb data-make-id="' + m.id + '" data-img-idx="' + idx + '">';
+      }).join('');
+      var preview = (m.notes || '').slice(0, 140);
+      if ((m.notes || '').length > 140) preview += '…';
+      var heart = '';
+      if (isProjectAuthor) {
+        var heartIcon = m.hearted_by_author ? 'fas fa-heart text-danger' : 'far fa-heart text-muted';
+        heart = '<button class="btn btn-link btn-sm p-0 ms-2" data-heart-make ' +
+                'data-make-id="' + m.id + '" data-hearted="' + (m.hearted_by_author ? '1' : '0') + '" ' +
+                'title="' + (m.hearted_by_author ? 'Unheart this make' : 'Heart this make') + '">' +
+                '<i class="' + heartIcon + '"></i></button>';
+      } else if (m.hearted_by_author) {
+        heart = '<span class="ms-2 small text-danger" title="Hearted by project author"><i class="fas fa-heart"></i></span>';
+      }
+      return '' +
+        '<div class="col">' +
+          '<div class="card h-100 shadow-sm">' +
+            '<div class="card-body p-3">' +
+              '<div class="mb-2">' + (thumbs || '<span class="text-muted small">No images</span>') + '</div>' +
+              '<div class="d-flex align-items-center mb-1">' +
+                '<strong class="small">' + esc(m.user_id) + '</strong>' +
+                '<span class="text-muted small ms-2">' + timeAgo(m.created_at) + '</span>' +
+                heart +
+              '</div>' +
+              (preview ? '<div class="small text-muted">' + esc(preview) + '</div>' : '') +
+              '<button class="btn btn-link btn-sm px-0 mt-2" data-open-make="' + m.id + '">View details</button>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+    }).join('');
+
+    grid.querySelectorAll('[data-open-make]').forEach(function (b) {
+      b.addEventListener('click', function () {
+        openMakeDetail(parseInt(b.getAttribute('data-open-make'), 10));
+      });
+    });
+    grid.querySelectorAll('[data-make-thumb]').forEach(function (img) {
+      img.addEventListener('click', function () {
+        var mid = parseInt(img.getAttribute('data-make-id'), 10);
+        openMakeDetail(mid);
+      });
+    });
+    grid.querySelectorAll('[data-heart-make]').forEach(function (b) {
+      b.addEventListener('click', function (e) {
+        e.preventDefault();
+        toggleHeart(b);
+      });
+    });
+  }
+
+  // Track whether the currently-loaded `me` matches the project author so
+  // the heart buttons render correctly. We populate this lazily.
+  var _meCache = null;
+  function makeAuthorIs(authorUsername) {
+    // The author-detection in loadProject() flips #edit-btn-container
+    // visible iff the current user owns this project. Reuse that signal.
+    return !document.getElementById('edit-btn-container').classList.contains('d-none');
+  }
+
+  function toggleHeart(btn) {
+    var makeId = btn.getAttribute('data-make-id');
+    var hearted = btn.getAttribute('data-hearted') === '1';
+    var method = hearted ? 'DELETE' : 'POST';
+    btn.disabled = true;
+    ProjectAuth.apiFetch(API + '/api/makes/' + makeId + '/heart', { method: method })
+      .then(function (r) {
+        if (!r.ok) throw new Error('heart failed');
+        return r.json();
+      })
+      .then(function (updated) {
+        btn.setAttribute('data-hearted', updated.hearted_by_author ? '1' : '0');
+        var icon = btn.querySelector('i');
+        if (updated.hearted_by_author) {
+          icon.className = 'fas fa-heart text-danger';
+          btn.title = 'Unheart this make';
+        } else {
+          icon.className = 'far fa-heart text-muted';
+          btn.title = 'Heart this make';
+        }
+      })
+      .catch(function () { alert('Could not update heart. Try again.'); })
+      .then(function () { btn.disabled = false; });
+  }
+
+  function openMakeDetail(makeId) {
+    var body = document.getElementById('make-detail-body');
+    body.innerHTML = '<div class="text-center py-4"><div class="spinner-border text-primary"></div></div>';
+    openModal('make-detail-modal');
+    fetch(API + '/api/makes/' + makeId)
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (m) {
+        if (!m) { body.innerHTML = '<p class="text-muted">Make not found.</p>'; return; }
+        document.getElementById('make-detail-title').textContent = 'Make by ' + m.user_id;
+        var imgs = m.images || [];
+        var carousel = '';
+        if (imgs.length > 0) {
+          var slides = imgs.map(function (img, idx) {
+            var src = API + '/api/makes/' + m.id + '/images/' + img.id + '/view';
+            return '<div class="carousel-item ' + (idx === 0 ? 'active' : '') + '">' +
+                   '<img src="' + src + '" class="d-block w-100 rounded" alt="" style="max-height:480px;object-fit:contain;background:#f8f9fa;">' +
+                   '</div>';
+          }).join('');
+          var controls = imgs.length > 1 ?
+            '<button class="carousel-control-prev" type="button" data-bs-target="#make-carousel-' + m.id + '" data-carousel-prev>' +
+              '<span class="carousel-control-prev-icon"></span></button>' +
+            '<button class="carousel-control-next" type="button" data-bs-target="#make-carousel-' + m.id + '" data-carousel-next>' +
+              '<span class="carousel-control-next-icon"></span></button>' : '';
+          carousel = '<div id="make-carousel-' + m.id + '" class="carousel slide mb-3">' +
+                     '<div class="carousel-inner">' + slides + '</div>' + controls + '</div>';
+        }
+        var notes = m.notes ? '<div class="mb-3"><strong>Notes</strong><div>' + marked.parse(m.notes) + '</div></div>' : '';
+        var mods = m.modifications ? '<div class="mb-3"><strong>Modifications</strong><div>' + marked.parse(m.modifications) + '</div></div>' : '';
+        var origin = '<p class="mb-0"><a href="/projects/view.html?id=' + m.project_id + '" class="text-decoration-none">' +
+                     '<i class="fas fa-arrow-up-right-from-square me-1"></i> View original project' +
+                     (m.project_title ? ': ' + esc(m.project_title) : '') + '</a></p>';
+        body.innerHTML = carousel + notes + mods + origin;
+
+        // Tiny manual carousel cycling (we don't depend on bootstrap JS).
+        var carouselEl = document.getElementById('make-carousel-' + m.id);
+        if (carouselEl) {
+          var items = carouselEl.querySelectorAll('.carousel-item');
+          function shift(delta) {
+            var idx = -1;
+            items.forEach(function (it, i) { if (it.classList.contains('active')) idx = i; });
+            if (idx < 0) return;
+            items[idx].classList.remove('active');
+            var next = (idx + delta + items.length) % items.length;
+            items[next].classList.add('active');
+          }
+          var prev = carouselEl.querySelector('[data-carousel-prev]');
+          var next = carouselEl.querySelector('[data-carousel-next]');
+          if (prev) prev.addEventListener('click', function () { shift(-1); });
+          if (next) next.addEventListener('click', function () { shift(1); });
+        }
+      });
+  }
+
+  function setupImtModal(project) {
+    var openBtn = document.getElementById('i-made-this-btn');
+    var modal = document.getElementById('i-made-this-modal');
+    var input = document.getElementById('imt-image-input');
+    var dropzone = document.getElementById('imt-dropzone');
+    var previews = document.getElementById('imt-previews');
+    var submit = document.getElementById('imt-submit');
+    var notes = document.getElementById('imt-notes');
+    var mods = document.getElementById('imt-modifications');
+    var err = document.getElementById('imt-error');
+
+    if (!openBtn || openBtn.dataset.bound === '1') return;
+    openBtn.dataset.bound = '1';
+
+    openBtn.addEventListener('click', function () {
+      imtSelectedFiles = [];
+      previews.innerHTML = '';
+      notes.value = '';
+      mods.value = '';
+      err.classList.add('d-none');
+      err.textContent = '';
+      openModal('i-made-this-modal');
+    });
+
+    modal.querySelectorAll('[data-imt-close]').forEach(function (b) {
+      b.addEventListener('click', function () { closeModal('i-made-this-modal'); });
+    });
+
+    input.addEventListener('change', function (e) {
+      addImtFiles(Array.from(e.target.files || []));
+      input.value = '';
+    });
+
+    ['dragenter', 'dragover'].forEach(function (evt) {
+      dropzone.addEventListener(evt, function (e) {
+        e.preventDefault();
+        dropzone.classList.add('dragover');
+      });
+    });
+    ['dragleave', 'drop'].forEach(function (evt) {
+      dropzone.addEventListener(evt, function (e) {
+        e.preventDefault();
+        dropzone.classList.remove('dragover');
+      });
+    });
+    dropzone.addEventListener('drop', function (e) {
+      addImtFiles(Array.from((e.dataTransfer && e.dataTransfer.files) || []));
+    });
+
+    submit.addEventListener('click', function () { submitMake(project); });
+  }
+
+  function addImtFiles(files) {
+    var err = document.getElementById('imt-error');
+    err.classList.add('d-none');
+    files.forEach(function (f) {
+      if (imtSelectedFiles.length >= MAX_MAKE_IMAGES) {
+        err.textContent = 'You can upload at most ' + MAX_MAKE_IMAGES + ' images per make.';
+        err.classList.remove('d-none');
+        return;
+      }
+      if (!ALLOWED_IMAGE_MIME.test(f.type || '')) {
+        err.textContent = 'Only image files are allowed.';
+        err.classList.remove('d-none');
+        return;
+      }
+      imtSelectedFiles.push(f);
+    });
+    renderImtPreviews();
+  }
+
+  function renderImtPreviews() {
+    var previews = document.getElementById('imt-previews');
+    previews.innerHTML = imtSelectedFiles.map(function (f, idx) {
+      var url = URL.createObjectURL(f);
+      return '<div class="col-4 col-md-3">' +
+               '<div class="position-relative">' +
+                 '<img src="' + url + '" class="img-fluid rounded" style="height:96px;width:100%;object-fit:cover;">' +
+                 '<button type="button" class="btn btn-sm btn-light position-absolute top-0 end-0" ' +
+                   'style="padding:2px 6px" data-remove-imt="' + idx + '" aria-label="Remove">&times;</button>' +
+               '</div>' +
+             '</div>';
+    }).join('');
+    previews.querySelectorAll('[data-remove-imt]').forEach(function (b) {
+      b.addEventListener('click', function () {
+        var i = parseInt(b.getAttribute('data-remove-imt'), 10);
+        imtSelectedFiles.splice(i, 1);
+        renderImtPreviews();
+      });
+    });
+  }
+
+  function submitMake(project) {
+    var submit = document.getElementById('imt-submit');
+    var err = document.getElementById('imt-error');
+    var notes = document.getElementById('imt-notes').value.trim();
+    var mods = document.getElementById('imt-modifications').value.trim();
+
+    if (imtSelectedFiles.length === 0 && !notes && !mods) {
+      err.textContent = 'Add at least one photo, notes, or modifications.';
+      err.classList.remove('d-none');
+      return;
+    }
+
+    var fd = new FormData();
+    if (notes) fd.append('notes', notes);
+    if (mods) fd.append('modifications', mods);
+    imtSelectedFiles.forEach(function (f) { fd.append('images', f); });
+
+    submit.disabled = true;
+    submit.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i> Posting...';
+    ProjectAuth.apiFetch(API + '/api/projects/' + project.id + '/makes', {
+      method: 'POST',
+      body: fd
+    }).then(function (r) {
+      if (!r.ok) {
+        return r.json().then(function (j) { throw new Error(j.detail || 'Failed to post'); });
+      }
+      return r.json();
+    }).then(function () {
+      closeModal('i-made-this-modal');
+      fetchMakes(project);
+    }).catch(function (e) {
+      err.textContent = e.message || 'Failed to post make.';
+      err.classList.remove('d-none');
+    }).then(function () {
+      submit.disabled = false;
+      submit.innerHTML = '<i class="fas fa-paper-plane me-1"></i> Post Make';
+    });
+  }
+
   function buildTOC() {
     const nav = document.getElementById('toc-nav');
     if (!nav) return;
@@ -617,6 +1079,7 @@ description: View project details
     const extras = [
       { id: 'view-bom-section', label: 'Bill of Materials' },
       { id: 'view-files-section', label: 'Files & Downloads' },
+      { id: 'makes-section', label: 'Community Makes' },
     ];
     extras.forEach(ex => {
       const el = document.getElementById(ex.id);


### PR DESCRIPTION
Closes #107

## Summary
- New `Make` + `MakeImage` models (additive only — nullable `hearted_at` on `Make` rather than a join table since exactly one user — the project author — can heart).
- New `routers/makes.py` mounted in `main.py`:
  - `POST /api/projects/{id}/makes` (multipart, up to 5 images) — anyone authenticated may post.
  - `GET /api/projects/{id}/makes` and `GET /api/users/{username}/makes`
  - `GET /api/makes/{id}` (detail; decorates with project_title for the UI)
  - `DELETE /api/makes/{id}` (owner only)
  - `POST` / `DELETE /api/makes/{id}/heart` (project author only)
  - `GET /api/makes/{id}/images/{image_id}/view` (binary, matches `routers/images.py`)
- Image storage reuses existing NAS-aware helpers + `ALLOWED_IMAGE_EXTENSIONS`.
- `TODO(#106)` hooks left at the two badge-eval touchpoints (make create + delete).
- Frontend on `web/projects/view.html`: "I Made This!" button (hidden for the project's own author), modal with photo dropzone + notes/modifications, makes grid, detail modal with image carousel + "View original project" link, sidebar "Makes (N)" link, TOC entry.
- `web/projects/hub.md`: makes-count badge on project cards.

## Test plan
- [x] `pytest tests/test_makes.py` — 12 new tests, all pass (create-with-image, list-by-project, list-by-user across projects, owner delete allowed, other-user delete forbidden, project-author heart allowed, others forbidden, unheart, detail includes project title, image view returns bytes, unauth rejected, >5 images rejected).
- [x] Full suite: `pytest` — 46 passed.
- [ ] Manual: log in as a non-author, click "I Made This!" on `view.html`, upload 1-5 photos, verify it appears in the grid.
- [ ] Manual: as project author, heart a make and verify the heart toggles.
- [ ] Manual: confirm makes count shows on `hub.md` cards.

## Notes for review
- All `stacks/projects-api/projects_api/{models,schemas,main}.py` edits are additive (appended new classes / appended new router include) — expect minor merge conflicts with the 4 concurrent branches that touch the same files; resolution should be trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)