### PR TITLE
feat(projects): download tracking, analytics, popular ranking

### DIFF
--- a/stacks/projects-api/.env.example
+++ b/stacks/projects-api/.env.example
@@ -17,3 +17,9 @@ NAS_HOST=192.168.2.200
 NAS_USERNAME=kevsrobots
 NAS_PASSWORD=your-nas-password
 NAS_SHARE_NAME=chatter
+
+# Salt used to hash anonymous client IPs when tracking downloads.
+# Set this to a long random value (e.g. `openssl rand -hex 32`) and keep it
+# stable across restarts so download dedup works. Raw IPs are NEVER stored
+# or returned by the API — only the salted SHA-256 hash.
+IP_HASH_SALT=change-me-to-a-long-random-string

--- a/stacks/projects-api/projects_api/config.py
+++ b/stacks/projects-api/projects_api/config.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import secrets
 from pathlib import Path
 from typing import Optional
 
-from pydantic import computed_field
+from pydantic import computed_field, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+# Stable per-process salt fallback so download dedup keeps working across
+# repeated calls to ``get_settings()`` even when the env var isn't set.
+# This is overridden by the IP_HASH_SALT env var when present.
+_PROCESS_IP_HASH_SALT_FALLBACK = secrets.token_hex(32)
 
 
 class Settings(BaseSettings):
@@ -48,6 +55,13 @@ class Settings(BaseSettings):
     max_file_size: int = 25 * 1024 * 1024  # 25MB
     max_image_size: int = 10 * 1024 * 1024  # 10MB
     max_project_storage: int = 50 * 1024 * 1024  # 50MB total per project
+
+    # IP hashing for download dedup — never expose raw IPs in API responses.
+    # In production, set this via env (e.g. IP_HASH_SALT=...) to a long random
+    # value so hashes are not predictable. Default is a per-process random
+    # value that's stable for the life of this Python process — fine for tests
+    # and dev, but loses dedup across restarts unless IP_HASH_SALT is set.
+    ip_hash_salt: str = Field(default_factory=lambda: _PROCESS_IP_HASH_SALT_FALLBACK)
 
 
 def get_settings() -> Settings:

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -10,7 +10,17 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
 from .db import create_all, repair_stale_fks
-from .routers import bom, files, health, images, journal, links, moderation, projects
+from .routers import (
+    bom,
+    downloads,
+    files,
+    health,
+    images,
+    journal,
+    links,
+    moderation,
+    projects,
+)
 
 
 @asynccontextmanager
@@ -36,6 +46,10 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(health.router)
+    # Downloads router declares /api/projects/popular and must be registered
+    # BEFORE projects.router so the more-specific path wins over the
+    # catch-all /api/projects/{project_id}.
+    app.include_router(downloads.router)
     app.include_router(projects.router)
     app.include_router(bom.router)
     app.include_router(files.router)

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -163,4 +164,33 @@ class ProjectJournalImage(Base):
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
     uploaded_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
+    )
+
+
+class Download(Base):
+    """Tracks individual file downloads for analytics and popularity ranking.
+
+    Anonymous downloads use `ip_hash` (sha256 of client IP + IP_HASH_SALT),
+    authenticated downloads use `user_id`. Dedup is enforced at the router
+    level: same (project_id, file_id, identity) within 24h counts once.
+    """
+
+    __tablename__ = "downloads"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    file_id: Mapped[int] = mapped_column(
+        ForeignKey("project_files.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[Optional[str]] = mapped_column(String(100))
+    ip_hash: Mapped[Optional[str]] = mapped_column(String(64))
+    downloaded_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ix_downloads_project_downloaded_at", "project_id", "downloaded_at"),
+        Index("ix_downloads_file_downloaded_at", "file_id", "downloaded_at"),
     )

--- a/stacks/projects-api/projects_api/routers/downloads.py
+++ b/stacks/projects-api/projects_api/routers/downloads.py
@@ -1,0 +1,222 @@
+"""Download analytics and popularity endpoints.
+
+Two endpoints live here:
+
+* ``GET /api/projects/{project_id}/downloads/stats`` — owner-only project
+  analytics (totals, 7d / 30d windows, per-file breakdown, contiguous
+  30-day daily series).
+* ``GET /api/projects/popular`` — public list of projects sorted by
+  download count in the given window (7d / 30d / all-time).
+
+The Download model is populated by the file-download endpoint in
+``routers/files.py``; this module only reads from it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import get_current_user
+from ..db import get_session
+from ..models import Download, Project, ProjectFile, ProjectTag
+from ..schemas import (
+    DailyDownloadCount,
+    FileDownloadStats,
+    PopularProjectItem,
+    ProjectDownloadStats,
+)
+
+router = APIRouter(tags=["downloads"])
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@router.get(
+    "/api/projects/{project_id}/downloads/stats",
+    response_model=ProjectDownloadStats,
+)
+async def get_download_stats(
+    project_id: int,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectDownloadStats:
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+    if project.author_username != user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not the project owner")
+
+    now = _utcnow_naive()
+    seven_days_ago = now - timedelta(days=7)
+    thirty_days_ago = now - timedelta(days=30)
+
+    # Totals
+    total = (
+        await session.execute(
+            select(func.count(Download.id)).where(Download.project_id == project_id)
+        )
+    ).scalar_one() or 0
+    last_7d = (
+        await session.execute(
+            select(func.count(Download.id)).where(
+                Download.project_id == project_id,
+                Download.downloaded_at >= seven_days_ago,
+            )
+        )
+    ).scalar_one() or 0
+    last_30d = (
+        await session.execute(
+            select(func.count(Download.id)).where(
+                Download.project_id == project_id,
+                Download.downloaded_at >= thirty_days_ago,
+            )
+        )
+    ).scalar_one() or 0
+
+    # Per-file breakdown
+    files = (
+        await session.scalars(
+            select(ProjectFile).where(ProjectFile.project_id == project_id)
+        )
+    ).all()
+
+    per_file: list[FileDownloadStats] = []
+    for f in files:
+        f_total = (
+            await session.execute(
+                select(func.count(Download.id)).where(Download.file_id == f.id)
+            )
+        ).scalar_one() or 0
+        f_7d = (
+            await session.execute(
+                select(func.count(Download.id)).where(
+                    Download.file_id == f.id,
+                    Download.downloaded_at >= seven_days_ago,
+                )
+            )
+        ).scalar_one() or 0
+        f_30d = (
+            await session.execute(
+                select(func.count(Download.id)).where(
+                    Download.file_id == f.id,
+                    Download.downloaded_at >= thirty_days_ago,
+                )
+            )
+        ).scalar_one() or 0
+        per_file.append(
+            FileDownloadStats(
+                file_id=f.id,
+                filename=f.filename,
+                total=f_total,
+                last_7d=f_7d,
+                last_30d=f_30d,
+            )
+        )
+    # Sort highest-first to make the table author-friendly
+    per_file.sort(key=lambda x: x.total, reverse=True)
+
+    # Daily series for the last 30 days, zero-filled.
+    # Pull raw rows in the window and bucket them in Python — dialect-agnostic
+    # and avoids portability issues between SQLite (tests) and Postgres (prod).
+    raw_rows = (
+        await session.execute(
+            select(Download.downloaded_at).where(
+                Download.project_id == project_id,
+                Download.downloaded_at >= thirty_days_ago,
+            )
+        )
+    ).all()
+    bucket: dict[str, int] = {}
+    for (ts,) in raw_rows:
+        key = ts.date().isoformat()
+        bucket[key] = bucket.get(key, 0) + 1
+
+    daily: list[DailyDownloadCount] = []
+    # Iterate 30 days inclusive, oldest -> today, so the chart x-axis is
+    # contiguous even when there are no downloads on a given day.
+    today = now.date()
+    for offset in range(29, -1, -1):
+        d = today - timedelta(days=offset)
+        daily.append(
+            DailyDownloadCount(date=d.isoformat(), count=bucket.get(d.isoformat(), 0))
+        )
+
+    return ProjectDownloadStats(
+        project_id=project_id,
+        total=total,
+        last_7d=last_7d,
+        last_30d=last_30d,
+        per_file=per_file,
+        daily=daily,
+    )
+
+
+@router.get("/api/projects/popular", response_model=list[PopularProjectItem])
+async def popular_projects(
+    window: str = Query("30d", pattern="^(7d|30d|all)$"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> list[PopularProjectItem]:
+    """Public list of projects ranked by download count in the window.
+
+    Archived and moderation-blocked projects are excluded. Projects with
+    zero downloads in the window are excluded from the popular list —
+    they're not "popular" by definition.
+    """
+    now = _utcnow_naive()
+    if window == "7d":
+        cutoff: Optional[datetime] = now - timedelta(days=7)
+    elif window == "30d":
+        cutoff = now - timedelta(days=30)
+    else:
+        cutoff = None  # all-time
+
+    count_expr = func.count(Download.id).label("dl_count")
+    query = (
+        select(Project, count_expr)
+        .join(Download, Download.project_id == Project.id)
+        .where(
+            Project.status != "archived",
+            Project.is_blocked == False,  # noqa: E712
+        )
+        .group_by(Project.id)
+        .order_by(count_expr.desc(), Project.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    if cutoff is not None:
+        query = query.where(Download.downloaded_at >= cutoff)
+
+    rows = (await session.execute(query)).all()
+
+    items: list[PopularProjectItem] = []
+    for project, dl_count in rows:
+        tags = (
+            await session.execute(
+                select(ProjectTag.tag).where(ProjectTag.project_id == project.id)
+            )
+        ).scalars().all()
+        items.append(
+            PopularProjectItem(
+                id=project.id,
+                title=project.title,
+                short_description=project.short_description,
+                difficulty=project.difficulty,
+                estimated_minutes=project.estimated_minutes,
+                status=project.status,
+                author_username=project.author_username,
+                cover_image=project.cover_image,
+                tags=list(tags),
+                created_at=project.created_at,
+                download_count=int(dl_count or 0),
+            )
+        )
+    return items

--- a/stacks/projects-api/projects_api/routers/files.py
+++ b/stacks/projects-api/projects_api/routers/files.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
 from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, get_optional_user
 from ..config import get_settings
 from ..db import get_session
-from ..models import Project, ProjectFile
+from ..models import Download, Project, ProjectFile
 from ..schemas import FileResponse
 from ..storage import (
     delete_file,
@@ -20,6 +25,72 @@ from ..storage import (
     save_file,
     validate_file,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP — honour standard reverse-proxy headers but
+    never expose the raw IP anywhere; it's only used to compute ip_hash."""
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _hash_ip(ip: str, salt: str) -> str:
+    return hashlib.sha256(f"{ip}{salt}".encode("utf-8")).hexdigest()
+
+
+async def _log_download(
+    session: AsyncSession,
+    project_id: int,
+    file_id: int,
+    user_id: Optional[str],
+    ip_hash: Optional[str],
+) -> bool:
+    """Insert a Download row if no matching row exists in the last 24h.
+
+    Returns True when a new row was inserted, False when deduped.
+    Identity for dedup: user_id if set, otherwise ip_hash.
+    """
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=24)
+    query = select(Download.id).where(
+        Download.project_id == project_id,
+        Download.file_id == file_id,
+        Download.downloaded_at >= cutoff,
+    )
+    if user_id:
+        query = query.where(Download.user_id == user_id)
+    elif ip_hash:
+        query = query.where(
+            Download.user_id.is_(None),
+            Download.ip_hash == ip_hash,
+        )
+    else:
+        # No identity at all — log it but it won't dedup
+        pass
+
+    existing = (await session.execute(query.limit(1))).scalar_one_or_none()
+    if existing is not None:
+        return False
+
+    record = Download(
+        project_id=project_id,
+        file_id=file_id,
+        user_id=user_id,
+        ip_hash=ip_hash if not user_id else None,
+    )
+    session.add(record)
+    await session.commit()
+    # TODO(#106): Popular Project badge eval hook here — evaluate
+    # download-count thresholds and award badges asynchronously.
+    return True
 
 router = APIRouter(prefix="/api/projects/{project_id}/files", tags=["files"])
 
@@ -36,7 +107,31 @@ async def list_files(
             .order_by(ProjectFile.uploaded_at.desc())
         )
     ).all()
-    return [FileResponse.model_validate(i, from_attributes=True) for i in items]
+    # Per-file download counts — bulk fetch in one query to avoid n+1.
+    counts: dict[int, int] = {}
+    if items:
+        rows = (
+            await session.execute(
+                select(Download.file_id, func.count(Download.id))
+                .where(Download.file_id.in_([i.id for i in items]))
+                .group_by(Download.file_id)
+            )
+        ).all()
+        counts = {fid: int(c) for fid, c in rows}
+    out: list[FileResponse] = []
+    for i in items:
+        out.append(
+            FileResponse(
+                id=i.id,
+                filename=i.filename,
+                file_size=i.file_size,
+                file_type=i.file_type,
+                description=i.description,
+                uploaded_at=i.uploaded_at,
+                download_count=counts.get(i.id, 0),
+            )
+        )
+    return out
 
 
 @router.post("", response_model=FileResponse, status_code=201)
@@ -94,6 +189,8 @@ async def upload_file(
 async def download_file(
     project_id: int,
     file_id: int,
+    request: Request,
+    user: Optional[str] = Depends(get_optional_user),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     record = await session.get(ProjectFile, file_id)
@@ -103,6 +200,17 @@ async def download_file(
     data = read_file(record.file_path)
     if data is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="File not found in storage")
+
+    # Log the download. Never fail the file response if logging breaks —
+    # the user came here to download, not to feed analytics.
+    try:
+        settings = get_settings()
+        ip_hash = None
+        if not user:
+            ip_hash = _hash_ip(_client_ip(request), settings.ip_hash_salt)
+        await _log_download(session, project_id, file_id, user, ip_hash)
+    except Exception:  # pragma: no cover — defensive guard
+        logger.warning("Failed to log download for file %s", file_id, exc_info=True)
 
     return Response(
         content=data,

--- a/stacks/projects-api/projects_api/routers/projects.py
+++ b/stacks/projects-api/projects_api/routers/projects.py
@@ -11,13 +11,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user, get_optional_user
 from ..db import get_session
-from ..models import Project, ProjectTag
+from ..models import Download, Project, ProjectTag
 from ..schemas import (
     ProjectCreate,
     ProjectListItem,
     ProjectResponse,
     ProjectUpdate,
 )
+
+
+async def _download_count(session: AsyncSession, project_id: int) -> int:
+    """Total downloads across all files for a project.
+
+    v1 implementation: correlated count on every read. This is fine for
+    listing pages (n+1 in the dozens, not thousands) and aggregates a
+    small indexed table. If listings start showing latency, denormalise
+    onto ``projects.download_count`` and update inside ``_log_download``.
+    """
+    result = await session.execute(
+        select(func.count(Download.id)).where(Download.project_id == project_id)
+    )
+    return int(result.scalar_one() or 0)
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 
@@ -55,6 +69,7 @@ async def _project_response(session: AsyncSession, project: Project) -> ProjectR
         tags=tags,
         created_at=project.created_at,
         updated_at=project.updated_at,
+        download_count=await _download_count(session, project.id),
     )
 
 
@@ -108,6 +123,7 @@ async def list_projects(
                 cover_image=p.cover_image,
                 tags=tags,
                 created_at=p.created_at,
+                download_count=await _download_count(session, p.id),
             )
         )
     return items
@@ -219,6 +235,7 @@ async def my_projects(
                 cover_image=p.cover_image,
                 tags=tags,
                 created_at=p.created_at,
+                download_count=await _download_count(session, p.id),
             )
         )
     return items

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -44,6 +44,7 @@ class ProjectResponse(BaseModel):
     tags: list[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
+    download_count: int = 0
 
 
 class ProjectListItem(BaseModel):
@@ -57,6 +58,7 @@ class ProjectListItem(BaseModel):
     cover_image: Optional[str]
     tags: list[str] = Field(default_factory=list)
     created_at: datetime
+    download_count: int = 0
 
 
 class BOMItemCreate(BaseModel):
@@ -113,6 +115,7 @@ class FileResponse(BaseModel):
     file_type: str
     description: Optional[str]
     uploaded_at: datetime
+    download_count: int = 0
 
 
 class ImageResponse(BaseModel):
@@ -156,3 +159,50 @@ class BlockedProjectResponse(BaseModel):
     is_blocked: bool
     moderation_note: Optional[str]
     created_at: datetime
+
+
+# --- Download tracking schemas ---
+
+
+class DownloadLogResponse(BaseModel):
+    """Returned when a download is logged. ``dedup`` is True when the
+    request was within the 24h dedup window for the same identity."""
+
+    logged: bool
+    dedup: bool
+
+
+class FileDownloadStats(BaseModel):
+    file_id: int
+    filename: str
+    total: int
+    last_7d: int
+    last_30d: int
+
+
+class DailyDownloadCount(BaseModel):
+    date: str  # ISO date, YYYY-MM-DD
+    count: int
+
+
+class ProjectDownloadStats(BaseModel):
+    project_id: int
+    total: int
+    last_7d: int
+    last_30d: int
+    per_file: list[FileDownloadStats] = Field(default_factory=list)
+    daily: list[DailyDownloadCount] = Field(default_factory=list)
+
+
+class PopularProjectItem(BaseModel):
+    id: int
+    title: str
+    short_description: Optional[str]
+    difficulty: Optional[str]
+    estimated_minutes: Optional[int]
+    status: str
+    author_username: str
+    cover_image: Optional[str]
+    tags: list[str] = Field(default_factory=list)
+    created_at: datetime
+    download_count: int = 0

--- a/stacks/projects-api/tests/test_downloads.py
+++ b/stacks/projects-api/tests/test_downloads.py
@@ -1,0 +1,315 @@
+"""Download tracking + analytics tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from .conftest import make_auth_header
+
+
+# ----- Fixtures -----
+
+
+@pytest.fixture
+async def project_with_file(client) -> dict:
+    """Create a project + one uploaded file, return ids."""
+    headers = make_auth_header()
+    proj = await client.post(
+        "/api/projects",
+        json={"title": "Download Test Project"},
+        headers=headers,
+    )
+    project_id = proj.json()["id"]
+
+    upload = await client.post(
+        f"/api/projects/{project_id}/files",
+        files={"file": ("model.stl", b"binary-stl-data", "application/octet-stream")},
+        headers=headers,
+    )
+    file_id = upload.json()["id"]
+    return {"project_id": project_id, "file_id": file_id}
+
+
+# ----- Logging -----
+
+
+@pytest.mark.asyncio
+async def test_anonymous_download_logs_with_ip_hash(client, session, project_with_file) -> None:
+    """Anonymous request hits the download endpoint -> Download row stored
+    with ip_hash and no user_id."""
+    from projects_api.models import Download
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+
+    resp = await client.get(f"/api/projects/{pid}/files/{fid}/download")
+    assert resp.status_code == 200
+    assert resp.content == b"binary-stl-data"
+
+    rows = (await session.execute(select(Download))).scalars().all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.project_id == pid
+    assert row.file_id == fid
+    assert row.user_id is None
+    assert row.ip_hash is not None
+    assert len(row.ip_hash) == 64  # sha256 hex
+
+
+@pytest.mark.asyncio
+async def test_authenticated_download_logs_with_user_id(client, session, project_with_file) -> None:
+    """Authenticated user downloading -> Download row stores user_id, not ip_hash."""
+    from projects_api.models import Download
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+
+    headers = make_auth_header("alice")
+    resp = await client.get(
+        f"/api/projects/{pid}/files/{fid}/download",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    rows = (await session.execute(select(Download))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].user_id == "alice"
+    assert rows[0].ip_hash is None
+
+
+@pytest.mark.asyncio
+async def test_dedup_within_24h(client, session, project_with_file) -> None:
+    """Same authenticated user downloading the same file twice within 24h
+    only produces one Download row."""
+    from projects_api.models import Download
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+
+    headers = make_auth_header("bob")
+    for _ in range(3):
+        resp = await client.get(
+            f"/api/projects/{pid}/files/{fid}/download",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+    rows = (await session.execute(select(Download))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_anonymous_same_ip(client, session, project_with_file) -> None:
+    """Same anonymous client (same TestClient -> same client IP) hitting
+    twice within 24h dedups."""
+    from projects_api.models import Download
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+
+    for _ in range(2):
+        resp = await client.get(f"/api/projects/{pid}/files/{fid}/download")
+        assert resp.status_code == 200
+
+    rows = (await session.execute(select(Download))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_logging_failure_does_not_break_download(
+    client, project_with_file, monkeypatch
+) -> None:
+    """If the Download insert blows up, the user still gets their file."""
+    from projects_api.routers import files as files_router
+
+    async def _exploding_log(*args, **kwargs):
+        raise RuntimeError("simulated database explosion")
+
+    monkeypatch.setattr(files_router, "_log_download", _exploding_log)
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+    resp = await client.get(f"/api/projects/{pid}/files/{fid}/download")
+    assert resp.status_code == 200
+    assert resp.content == b"binary-stl-data"
+
+
+# ----- Stats endpoint -----
+
+
+@pytest.mark.asyncio
+async def test_stats_requires_owner(client, project_with_file) -> None:
+    """Non-owner gets 403."""
+    pid = project_with_file["project_id"]
+    headers = make_auth_header("not-the-owner")
+    resp = await client.get(
+        f"/api/projects/{pid}/downloads/stats",
+        headers=headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stats_unauthenticated(client, project_with_file) -> None:
+    """No token -> 401."""
+    pid = project_with_file["project_id"]
+    resp = await client.get(f"/api/projects/{pid}/downloads/stats")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stats_owner_returns_breakdown(client, session, project_with_file) -> None:
+    """Owner gets per-file counts and a contiguous 30-day daily series."""
+    from projects_api.models import Download
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+
+    # Seed downloads directly so we can pin timestamps
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session.add_all([
+        Download(project_id=pid, file_id=fid, user_id="u1", downloaded_at=now),
+        Download(project_id=pid, file_id=fid, user_id="u2", downloaded_at=now - timedelta(days=2)),
+        Download(project_id=pid, file_id=fid, user_id="u3", downloaded_at=now - timedelta(days=10)),
+        # Outside the 30d window — should not appear in 30d/7d totals
+        Download(project_id=pid, file_id=fid, user_id="u4", downloaded_at=now - timedelta(days=45)),
+    ])
+    await session.commit()
+
+    headers = make_auth_header()  # default 'testuser' is the owner
+    resp = await client.get(
+        f"/api/projects/{pid}/downloads/stats",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["project_id"] == pid
+    assert body["total"] == 4
+    assert body["last_7d"] == 2
+    assert body["last_30d"] == 3
+    assert len(body["per_file"]) == 1
+    assert body["per_file"][0]["file_id"] == fid
+    assert body["per_file"][0]["total"] == 4
+    assert body["per_file"][0]["last_7d"] == 2
+    assert body["per_file"][0]["last_30d"] == 3
+    # Daily series — exactly 30 contiguous days, every entry has a date+count
+    assert len(body["daily"]) == 30
+    dates = [d["date"] for d in body["daily"]]
+    assert dates == sorted(dates), "daily series should be ascending"
+
+
+# ----- Popular endpoint -----
+
+
+@pytest.mark.asyncio
+async def test_popular_orders_by_count_in_window(client, session) -> None:
+    """Project with more downloads in window ranks first."""
+    from projects_api.models import Download
+
+    headers = make_auth_header()
+    # Create two projects, each with one file.
+    p1 = (await client.post(
+        "/api/projects",
+        json={"title": "Quiet Project"},
+        headers=headers,
+    )).json()
+    p2 = (await client.post(
+        "/api/projects",
+        json={"title": "Popular Project"},
+        headers=headers,
+    )).json()
+
+    f1 = (await client.post(
+        f"/api/projects/{p1['id']}/files",
+        files={"file": ("a.stl", b"a", "application/octet-stream")},
+        headers=headers,
+    )).json()
+    f2 = (await client.post(
+        f"/api/projects/{p2['id']}/files",
+        files={"file": ("b.stl", b"b", "application/octet-stream")},
+        headers=headers,
+    )).json()
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    # 1 download for p1 inside 30d, 5 for p2 inside 30d
+    session.add(Download(project_id=p1["id"], file_id=f1["id"], user_id="x", downloaded_at=now))
+    for i in range(5):
+        session.add(Download(
+            project_id=p2["id"],
+            file_id=f2["id"],
+            user_id=f"u{i}",
+            downloaded_at=now - timedelta(hours=i),
+        ))
+    await session.commit()
+
+    resp = await client.get("/api/projects/popular?window=30d&limit=10")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 2
+    assert items[0]["id"] == p2["id"]
+    assert items[0]["download_count"] == 5
+    assert items[1]["id"] == p1["id"]
+    assert items[1]["download_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_popular_window_filters_old_downloads(client, session) -> None:
+    """Downloads older than the window should not be counted."""
+    from projects_api.models import Download
+
+    headers = make_auth_header()
+    p = (await client.post(
+        "/api/projects",
+        json={"title": "Vintage Project"},
+        headers=headers,
+    )).json()
+    f = (await client.post(
+        f"/api/projects/{p['id']}/files",
+        files={"file": ("old.stl", b"old", "application/octet-stream")},
+        headers=headers,
+    )).json()
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session.add_all([
+        Download(project_id=p["id"], file_id=f["id"], user_id="u1", downloaded_at=now - timedelta(days=60)),
+        Download(project_id=p["id"], file_id=f["id"], user_id="u2", downloaded_at=now - timedelta(days=90)),
+    ])
+    await session.commit()
+
+    resp_30d = await client.get("/api/projects/popular?window=30d")
+    assert resp_30d.status_code == 200
+    assert resp_30d.json() == []  # both downloads are older than 30d
+
+    resp_all = await client.get("/api/projects/popular?window=all")
+    assert resp_all.status_code == 200
+    body = resp_all.json()
+    assert len(body) == 1
+    assert body[0]["download_count"] == 2
+
+
+# ----- ProjectResponse download_count -----
+
+
+@pytest.mark.asyncio
+async def test_project_response_includes_download_count(
+    client, session, project_with_file
+) -> None:
+    """The single-project GET should include the aggregated download_count."""
+    from projects_api.models import Download
+
+    pid = project_with_file["project_id"]
+    fid = project_with_file["file_id"]
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session.add_all([
+        Download(project_id=pid, file_id=fid, user_id="u1", downloaded_at=now),
+        Download(project_id=pid, file_id=fid, user_id="u2", downloaded_at=now),
+    ])
+    await session.commit()
+
+    resp = await client.get(f"/api/projects/{pid}")
+    assert resp.status_code == 200
+    assert resp.json()["download_count"] == 2

--- a/web/projects/analytics.html
+++ b/web/projects/analytics.html
@@ -1,0 +1,224 @@
+---
+title: Project Analytics
+layout: default
+description: Download analytics for your project
+---
+
+<link rel="stylesheet" href="/assets/css/project-editor.css">
+
+<div class="container py-4">
+  <div class="mb-3">
+    <a id="back-link" href="/projects/hub" class="text-decoration-none text-muted">
+      <i class="fas fa-arrow-left"></i> Back to project
+    </a>
+  </div>
+
+  <div id="loading" class="text-center py-5">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+
+  <div id="error-state" class="text-center py-5 d-none">
+    <i class="fas fa-exclamation-triangle fa-3x text-warning mb-3"></i>
+    <h3 id="error-title">Unable to load analytics</h3>
+    <p class="text-muted" id="error-detail"></p>
+    <a href="/projects/hub" class="btn btn-primary mt-3">Back to Projects Hub</a>
+  </div>
+
+  <div id="analytics-view" class="d-none">
+    <h1 class="mb-1">Download analytics</h1>
+    <p class="text-muted" id="project-title-line">&nbsp;</p>
+
+    <!-- Top stats -->
+    <div class="row g-3 mb-4">
+      <div class="col-md-4">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body text-center">
+            <div class="text-muted small text-uppercase">Total downloads</div>
+            <div class="display-6 fw-bold" id="stat-total">0</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body text-center">
+            <div class="text-muted small text-uppercase">Last 7 days</div>
+            <div class="display-6 fw-bold text-primary" id="stat-7d">0</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-body text-center">
+            <div class="text-muted small text-uppercase">Last 30 days</div>
+            <div class="display-6 fw-bold text-success" id="stat-30d">0</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Daily chart -->
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <h5 class="mb-3"><i class="fas fa-chart-line me-2"></i>Downloads over the last 30 days</h5>
+        <canvas id="daily-chart" height="100"></canvas>
+      </div>
+    </div>
+
+    <!-- Per-file breakdown -->
+    <div class="card border-0 shadow-sm mb-4">
+      <div class="card-body">
+        <h5 class="mb-3"><i class="fas fa-file me-2"></i>Downloads by file</h5>
+        <div id="per-file-empty" class="text-muted small d-none">No file downloads recorded yet.</div>
+        <table id="per-file-table" class="table table-single table-narrow d-none">
+          <thead>
+            <tr>
+              <th>File</th>
+              <th class="text-end">Total</th>
+              <th class="text-end">Last 7d</th>
+              <th class="text-end">Last 30d</th>
+            </tr>
+          </thead>
+          <tbody id="per-file-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script src="/assets/js/project-auth.js"></script>
+<script>
+(function() {
+  const API = 'https://projects.kevsrobots.com';
+  const params = new URLSearchParams(window.location.search);
+  const projectId = params.get('id');
+
+  function esc(t) { const d = document.createElement('div'); d.textContent = t || ''; return d.innerHTML; }
+
+  function showError(title, detail) {
+    document.getElementById('loading').classList.add('d-none');
+    document.getElementById('analytics-view').classList.add('d-none');
+    document.getElementById('error-state').classList.remove('d-none');
+    document.getElementById('error-title').textContent = title;
+    document.getElementById('error-detail').textContent = detail || '';
+  }
+
+  if (!projectId) {
+    showError('Missing project id', 'Append ?id=<project_id> to the URL.');
+    return;
+  }
+
+  document.getElementById('back-link').href = '/projects/view.html?id=' + projectId;
+
+  async function loadProjectMeta() {
+    try {
+      const r = await fetch(API + '/api/projects/' + projectId, { credentials: 'include' });
+      if (!r.ok) return null;
+      return await r.json();
+    } catch (e) { return null; }
+  }
+
+  async function loadStats() {
+    return ProjectAuth.apiFetch(API + '/api/projects/' + projectId + '/downloads/stats');
+  }
+
+  function renderDaily(daily) {
+    const ctx = document.getElementById('daily-chart').getContext('2d');
+    const labels = daily.map(d => d.date.slice(5));  // MM-DD
+    const data = daily.map(d => d.count);
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Downloads',
+          data: data,
+          borderColor: '#4A90D9',
+          backgroundColor: 'rgba(74, 144, 217, 0.15)',
+          tension: 0.25,
+          fill: true,
+          pointRadius: 2,
+          pointHoverRadius: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: { precision: 0 }
+          }
+        }
+      }
+    });
+  }
+
+  function renderPerFile(perFile) {
+    const empty = document.getElementById('per-file-empty');
+    const table = document.getElementById('per-file-table');
+    const body = document.getElementById('per-file-body');
+    if (!perFile || perFile.length === 0) {
+      empty.classList.remove('d-none');
+      return;
+    }
+    table.classList.remove('d-none');
+    body.innerHTML = perFile.map(f => `
+      <tr>
+        <td>${esc(f.filename)}</td>
+        <td class="text-end">${f.total}</td>
+        <td class="text-end">${f.last_7d}</td>
+        <td class="text-end">${f.last_30d}</td>
+      </tr>
+    `).join('');
+  }
+
+  async function init() {
+    const project = await loadProjectMeta();
+    if (project && project.title) {
+      document.title = project.title + ' — Analytics — KevsRobots';
+      document.getElementById('project-title-line').textContent = project.title;
+    }
+
+    let resp;
+    try {
+      resp = await loadStats();
+    } catch (e) {
+      showError('Unable to load analytics', 'A network error occurred. Please try again.');
+      return;
+    }
+    if (resp.status === 401) {
+      showError('Login required', 'You need to be signed in as the project owner to view analytics.');
+      return;
+    }
+    if (resp.status === 403) {
+      showError('Not authorised', 'Only the project owner can see download analytics.');
+      return;
+    }
+    if (resp.status === 404) {
+      showError('Project not found', 'The project may have been deleted.');
+      return;
+    }
+    if (!resp.ok) {
+      showError('Unable to load analytics', 'Server returned ' + resp.status + '.');
+      return;
+    }
+    const stats = await resp.json();
+
+    document.getElementById('loading').classList.add('d-none');
+    document.getElementById('analytics-view').classList.remove('d-none');
+
+    document.getElementById('stat-total').textContent = stats.total || 0;
+    document.getElementById('stat-7d').textContent = stats.last_7d || 0;
+    document.getElementById('stat-30d').textContent = stats.last_30d || 0;
+
+    renderDaily(stats.daily || []);
+    renderPerFile(stats.per_file || []);
+  }
+
+  init();
+})();
+</script>

--- a/web/projects/hub.md
+++ b/web/projects/hub.md
@@ -16,6 +16,12 @@ thanks: false
 
 <!-- Project Gallery Component -->
 <div id="projects-hub">
+  <!-- Popular this month -->
+  <div id="popular-section" class="mb-4 d-none">
+    <h4 class="mb-3"><i class="fas fa-fire text-danger me-2"></i>Popular this month</h4>
+    <div id="popular-row" class="row row-cols-2 row-cols-md-3 row-cols-lg-6 g-3"></div>
+  </div>
+
   <!-- Header with Create Button -->
   <div class="row mb-4">
     <div class="col">
@@ -34,8 +40,8 @@ thanks: false
   </div>
 
   <!-- Search and Filters -->
-  <div class="row mb-4">
-    <div class="col-md-6">
+  <div class="row mb-4 g-2">
+    <div class="col-md-4">
       <input type="text" id="project-search" class="form-control" placeholder="Search projects by title or tag...">
     </div>
     <div class="col-md-3">
@@ -46,8 +52,14 @@ thanks: false
         <option value="advanced">Advanced</option>
       </select>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-2">
       <input type="text" id="tag-filter" class="form-control" placeholder="Filter by tag...">
+    </div>
+    <div class="col-md-3">
+      <select id="sort-select" class="form-select" aria-label="Sort projects">
+        <option value="newest">Newest first</option>
+        <option value="downloads_30d">Most downloaded (30d)</option>
+      </select>
     </div>
   </div>
 
@@ -83,6 +95,7 @@ thanks: false
   const searchInput = document.getElementById('project-search');
   const difficultyFilter = document.getElementById('difficulty-filter');
   const tagFilter = document.getElementById('tag-filter');
+  const sortSelect = document.getElementById('sort-select');
 
   const difficultyColors = {
     beginner: 'success',
@@ -127,16 +140,37 @@ thanks: false
     noProjects.classList.add('d-none');
     grid.innerHTML = '';
 
-    const params = new URLSearchParams();
-    if (searchInput.value) params.set('search', searchInput.value);
-    if (difficultyFilter.value) params.set('difficulty', difficultyFilter.value);
-    if (tagFilter.value) params.set('tag', tagFilter.value.toLowerCase());
-
+    const sortMode = (sortSelect && sortSelect.value) || 'newest';
+    let resp;
     try {
-      const resp = await fetch(API + '/api/projects?' + params.toString());
+      if (sortMode === 'downloads_30d') {
+        // Use the popular endpoint for ordering — it already excludes
+        // archived projects and returns download_count baked in.
+        resp = await fetch(API + '/api/projects/popular?window=30d&limit=100');
+      } else {
+        const params = new URLSearchParams();
+        if (searchInput.value) params.set('search', searchInput.value);
+        if (difficultyFilter.value) params.set('difficulty', difficultyFilter.value);
+        if (tagFilter.value) params.set('tag', tagFilter.value.toLowerCase());
+        resp = await fetch(API + '/api/projects?' + params.toString());
+      }
       if (!resp.ok) throw new Error('API error');
       let projects = await resp.json();
       spinner.classList.add('d-none');
+
+      // The popular endpoint doesn't honour the search/filter inputs server-side
+      // — apply them client-side for a consistent UX.
+      if (sortMode === 'downloads_30d') {
+        const q = (searchInput.value || '').toLowerCase();
+        const diff = difficultyFilter.value;
+        const tag = (tagFilter.value || '').toLowerCase();
+        projects = projects.filter(p => {
+          if (q && !((p.title || '').toLowerCase().includes(q) || (p.short_description || '').toLowerCase().includes(q))) return false;
+          if (diff && p.difficulty !== diff) return false;
+          if (tag && !(p.tags || []).some(t => (t || '').toLowerCase() === tag)) return false;
+          return true;
+        });
+      }
 
       if (showingMine) {
         projects = projects.filter(p => myProjectIds.has(p.id));
@@ -166,7 +200,10 @@ thanks: false
               </div>
               <div class="card-footer bg-transparent border-0 d-flex justify-content-between align-items-center">
                 <small class="text-muted">by ${esc(p.author_username)} &middot; ${new Date(p.created_at).toLocaleDateString()}</small>
-                <small class="text-muted" id="card-likes-${p.id}"><i class="far fa-heart"></i> </small>
+                <small class="text-muted d-flex gap-2 align-items-center">
+                  <span id="card-likes-${p.id}"><i class="far fa-heart"></i> </span>
+                  <span title="Total downloads"><i class="fas fa-download"></i> ${(p.download_count || 0)}</span>
+                </small>
               </div>
             </div>
           </a>
@@ -206,7 +243,42 @@ thanks: false
   searchInput.addEventListener('input', debouncedLoad);
   difficultyFilter.addEventListener('change', loadProjects);
   tagFilter.addEventListener('input', debouncedLoad);
+  if (sortSelect) sortSelect.addEventListener('change', loadProjects);
 
-  checkAuth().then(() => loadProjects());
+  // Fail-closed loader for the "Popular this month" row at the top.
+  // If the API errors or returns nothing, the section stays hidden — no UX
+  // damage on a fresh install.
+  async function loadPopular() {
+    try {
+      const resp = await fetch(API + '/api/projects/popular?window=30d&limit=6');
+      if (!resp.ok) return;
+      const items = await resp.json();
+      if (!Array.isArray(items) || items.length === 0) return;
+      const row = document.getElementById('popular-row');
+      row.innerHTML = items.map(p => `
+        <div class="col">
+          <a href="/projects/view.html?id=${p.id}" class="text-decoration-none">
+            <div class="card h-100 border-0 shadow-sm card-hover">
+              ${projectThumbnail(p, 120)}
+              <div class="card-body p-2">
+                <div class="small fw-bold text-dark text-truncate" title="${esc(p.title)}">${esc(p.title)}</div>
+                <div class="small text-muted">
+                  <i class="fas fa-download"></i> ${(p.download_count || 0)}
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+      `).join('');
+      document.getElementById('popular-section').classList.remove('d-none');
+    } catch (e) {
+      // Silent — popular row is non-critical.
+    }
+  }
+
+  checkAuth().then(() => {
+    loadProjects();
+    loadPopular();
+  });
 })();
 </script>

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -50,6 +50,9 @@ description: View project details
         <!-- Files -->
         <div id="view-files-section" class="mb-4 d-none">
           <h4><i class="fas fa-paperclip me-2"></i> Files & Downloads</h4>
+          <div id="view-files-total" class="small text-muted mb-2 d-none">
+            <i class="fas fa-download me-1"></i> Total downloads: <span id="view-files-total-count">0</span>
+          </div>
           <div id="view-files" class="list-group"></div>
         </div>
 
@@ -124,6 +127,11 @@ description: View project details
               <div id="edit-btn-container" class="d-none">
                 <a id="edit-link" href="#" class="btn btn-sm btn-outline-primary w-100">
                   <i class="fas fa-pencil-alt me-2"></i> Edit Project
+                </a>
+              </div>
+              <div id="analytics-btn-container" class="d-none mt-2">
+                <a id="analytics-link" href="#" class="btn btn-sm btn-outline-secondary w-100">
+                  <i class="fas fa-chart-line me-2"></i> Analytics
                 </a>
               </div>
             </div>
@@ -339,6 +347,14 @@ description: View project details
             const editIcon = document.getElementById('edit-icon');
             editIcon.href = editUrl;
             editIcon.classList.remove('d-none');
+            // Analytics dashboard link — owner-only
+            const analyticsUrl = '/projects/analytics.html?id=' + project.id;
+            const analyticsContainer = document.getElementById('analytics-btn-container');
+            const analyticsLink = document.getElementById('analytics-link');
+            if (analyticsContainer && analyticsLink) {
+              analyticsLink.href = analyticsUrl;
+              analyticsContainer.classList.remove('d-none');
+            }
           } else {
             document.getElementById('report-section').classList.remove('d-none');
             setupReportForm(project.id);
@@ -416,11 +432,18 @@ description: View project details
     };
     function fKind(n){var e=(n||'').split('.').pop().toLowerCase();return fileKinds[e]||e.toUpperCase()+' File';}
     function fIcon(n){var e=(n||'').split('.').pop().toLowerCase();return fileIcons[e]||'fas fa-file';}
+    var totalDownloads = files.reduce(function(acc, f) { return acc + (f.download_count || 0); }, 0);
+    var totalEl = document.getElementById('view-files-total');
+    if (totalEl) {
+      document.getElementById('view-files-total-count').textContent = totalDownloads;
+      totalEl.classList.remove('d-none');
+    }
     document.getElementById('view-files').innerHTML = `<table class="table table-single table-narrow table-hover mb-0"><tbody>${files.map(f => `
       <tr>
         <td class="text-muted" style="width:20px"><i class="${fIcon(f.filename)}"></i></td>
         <td><a href="${API}/api/projects/${projectId}/files/${f.id}/download">${esc(f.filename)}</a></td>
         <td class="text-muted small">${fKind(f.filename)}</td>
+        <td class="text-muted small text-end" style="width:90px" title="Downloads"><i class="fas fa-download"></i> ${(f.download_count || 0)}</td>
         <td class="text-muted small text-end" style="width:70px">${(f.file_size / 1024).toFixed(1)} KB</td>
       </tr>
     `).join('')}</tbody></table>`;


### PR DESCRIPTION
Closes #109

## Summary

- Tracks every file download with 24h dedup (authenticated by user_id, anonymous by salted SHA-256 of client IP).
- Adds owner-only analytics endpoint + dashboard page (total / 7d / 30d, daily chart, per-file breakdown).
- Adds public `/api/projects/popular` ranking endpoint and a "Popular this month" row + "Most downloaded (30d)" sort option on the Projects Hub.
- 11 new backend tests covering logging, dedup, stats, popular ordering, and logging-failure resilience.

## Backend changes (additive only)

- `models.py`: new `Download` model (project/file FKs ondelete=CASCADE), indexed on `(project_id, downloaded_at)` and `(file_id, downloaded_at)`.
- `schemas.py`: `DownloadLogResponse`, `FileDownloadStats`, `DailyDownloadCount`, `ProjectDownloadStats`, `PopularProjectItem`. `ProjectResponse`/`ProjectListItem`/`FileResponse` extended with `download_count`.
- `routers/files.py`: existing download endpoint now logs each download with 24h dedup; logging failures are caught/logged and never break the file response. `list_files` returns per-file `download_count` (single bulk query, no n+1).
- `routers/downloads.py` (new):
  - `GET /api/projects/{project_id}/downloads/stats` — owner-only (403 for non-owner, 401 for unauthenticated). Returns `total`, `last_7d`, `last_30d`, `per_file[]` sorted by total desc, and `daily[]` zero-filled 30 days ascending.
  - `GET /api/projects/popular?window=7d|30d|all&limit&offset` — public, excludes archived and moderation-blocked projects.
- `config.py`: `IP_HASH_SALT` setting (random per-process fallback so tests/dev still dedup; set via env in prod and documented in `.env.example`).
- `main.py`: downloads router registered before projects router so `/api/projects/popular` is not shadowed by `/api/projects/{project_id}`.

## Frontend changes

- `web/projects/hub.md`:
  - Download-count badge (`fas fa-download`) alongside the existing likes count on every project card.
  - New "Most downloaded (30d)" entry in the sort dropdown — calls `/api/projects/popular?window=30d` and applies search/difficulty/tag filters client-side.
  - "Popular this month" horizontal row at the top, populated from `/api/projects/popular?window=30d&limit=6`. Fails closed silently on empty/error.
- `web/projects/view.html`:
  - Per-file download count column in the Files & Downloads table.
  - "Total downloads: N" line above the Files table.
  - Owner-only "Analytics" link in the sidebar pointing to `analytics.html?id=<project_id>`.
- `web/projects/analytics.html` (new): owner-only dashboard. Three small cards (Total / 7d / 30d), Chart.js line chart for the 30-day daily series, per-file breakdown table. Renders friendly error states for 401 (login required), 403 (not owner), and 404.

## Privacy

- Raw IPs are never stored or returned by the API — only `sha256(ip + IP_HASH_SALT)`.
- `IP_HASH_SALT` is documented in `stacks/projects-api/.env.example` and must be set to a long random value in production.

## Out of scope

- Badge awarding — left for #106. A `TODO(#106)` comment is in `_log_download` marking the hook point.

## Test plan

- [x] `pytest` — 45/45 tests pass (11 new in `tests/test_downloads.py`, 0 existing regressions).
- [ ] Manual: anonymous download via `/files/{id}/download` increments the per-file count and the project's total only once per 24h.
- [ ] Manual: authenticated download via the same endpoint with `Authorization: Bearer …` logs with `user_id`, not `ip_hash`.
- [ ] Manual: non-owner GET on `/downloads/stats` returns 403; owner sees populated stats.
- [ ] Manual: `/api/projects/popular?window=30d` orders by download count and excludes archived projects.
- [ ] Manual: Projects Hub renders the download badge, the "Popular this month" row, and the "Most downloaded (30d)" sort.
- [ ] Manual: `analytics.html?id=<own project>` renders Chart.js chart and per-file table; same URL for another user's project shows the 403 error state.

## Notes for reviewers

- This PR is intended to be additive: no fields removed, no signatures changed, no existing tests modified. The single behavioural change to an existing endpoint is the file-download endpoint, which now also logs a Download row (wrapped in try/except).
- v1 computes `download_count` on read with a small subquery per project. If listings start showing latency, denormalise onto `projects.download_count` and update inside `_log_download`. The denormalisation note is in `routers/projects.py::_download_count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)