### PR TITLE
feat(badges): badges & achievements system (#106)

### DIFF
--- a/stacks/projects-api/projects_api/badges.py
+++ b/stacks/projects-api/projects_api/badges.py
@@ -1,0 +1,626 @@
+"""Badge catalog + evaluation engine — issue #106.
+
+The badge system has two halves:
+
+1. **Catalog seeding** (``seed_badge_definitions``): an idempotent upsert
+   keyed by ``slug`` so we can change the human-readable name / description
+   / icon / threshold without orphaning earned rows. Runs on every startup
+   from the FastAPI lifespan.
+
+2. **Evaluation** (``evaluate_user``): computes which badges a single user
+   should currently have, given their activity in projects-api's DB, and
+   inserts any missing ``user_badges`` rows. Returns the list of *newly*
+   awarded badges so the caller (e.g. POST /api/projects -> create) can
+   surface a toast.
+
+Data sources used by the evaluator
+----------------------------------
+
+projects-api owns ``projects``, ``makes``, ``downloads`` and remix
+attribution. It does NOT own comments or likes — those live in Chatter /
+the page-counter service. To keep this PR additive and synchronous, the
+"comments" and "likes" badges are *defined* (so the gallery shows them as
+goals) but their evaluator simply counts what we have access to; both
+return 0 today so those badges are never awarded yet. They will start
+being awarded automatically once the comments / likes data lands in
+projects-api or once we add a cross-service lookup.
+
+Tiered families
+---------------
+
+Bronze / silver / gold tiers share a slug *prefix* (e.g.
+``prolific_maker_bronze``, ``prolific_maker_silver``,
+``prolific_maker_gold``) and a ``category``. Crossing the silver threshold
+implies bronze should also be awarded — the evaluator handles this
+naturally because each tier is its own definition row with its own
+threshold check.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Awaitable, Callable
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import BadgeDefinition, Download, Make, Project, UserBadge
+from .schemas import EarnedBadgeResponse
+
+logger = logging.getLogger(__name__)
+
+
+# --- Catalog definition --------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _BadgeSpec:
+    slug: str
+    name: str
+    description: str
+    icon: str  # Font Awesome class — no leading "fas " prefix expected
+    category: str
+    threshold_type: str
+    threshold_value: int
+    tier: str
+
+
+# The canonical badge catalog. Keep this list in sync with the user-facing
+# spec in issue #106. Slugs are forever — once a slug ships, never rename
+# it (existing user_badges rows are keyed by id, but the slug shows up in
+# admin tools and analytics, so stability matters).
+BADGE_CATALOG: tuple[_BadgeSpec, ...] = (
+    _BadgeSpec(
+        slug="first_project",
+        name="First Project",
+        description="Published your first project — welcome to the maker community!",
+        icon="fa-solid fa-seedling",
+        category="first_project",
+        threshold_type="project_count",
+        threshold_value=1,
+        tier="single",
+    ),
+    # Prolific Maker family — 5 / 10 / 25 projects.
+    _BadgeSpec(
+        slug="prolific_maker_bronze",
+        name="Prolific Maker (Bronze)",
+        description="Published 5 projects.",
+        icon="fa-solid fa-medal",
+        category="prolific_maker",
+        threshold_type="project_count",
+        threshold_value=5,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="prolific_maker_silver",
+        name="Prolific Maker (Silver)",
+        description="Published 10 projects.",
+        icon="fa-solid fa-medal",
+        category="prolific_maker",
+        threshold_type="project_count",
+        threshold_value=10,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="prolific_maker_gold",
+        name="Prolific Maker (Gold)",
+        description="Published 25 projects.",
+        icon="fa-solid fa-trophy",
+        category="prolific_maker",
+        threshold_type="project_count",
+        threshold_value=25,
+        tier="gold",
+    ),
+    # Popular Project family — 10 / 100 / 1000 downloads.
+    _BadgeSpec(
+        slug="popular_project_bronze",
+        name="Popular Project (Bronze)",
+        description="Your projects have been downloaded 10 times.",
+        icon="fa-solid fa-download",
+        category="popular_project",
+        threshold_type="downloads",
+        threshold_value=10,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="popular_project_silver",
+        name="Popular Project (Silver)",
+        description="Your projects have been downloaded 100 times.",
+        icon="fa-solid fa-fire",
+        category="popular_project",
+        threshold_type="downloads",
+        threshold_value=100,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="popular_project_gold",
+        name="Popular Project (Gold)",
+        description="Your projects have been downloaded 1,000 times.",
+        icon="fa-solid fa-crown",
+        category="popular_project",
+        threshold_type="downloads",
+        threshold_value=1000,
+        tier="gold",
+    ),
+    # Community Builder family — 5 / 25 / 100 makes received on your projects.
+    _BadgeSpec(
+        slug="community_builder_bronze",
+        name="Community Builder (Bronze)",
+        description="5 community makes posted on your projects.",
+        icon="fa-solid fa-people-group",
+        category="community_builder",
+        threshold_type="makes_received",
+        threshold_value=5,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="community_builder_silver",
+        name="Community Builder (Silver)",
+        description="25 community makes posted on your projects.",
+        icon="fa-solid fa-people-group",
+        category="community_builder",
+        threshold_type="makes_received",
+        threshold_value=25,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="community_builder_gold",
+        name="Community Builder (Gold)",
+        description="100 community makes posted on your projects.",
+        icon="fa-solid fa-star",
+        category="community_builder",
+        threshold_type="makes_received",
+        threshold_value=100,
+        tier="gold",
+    ),
+    # Engaged Member family — comments posted. No comments table yet (see
+    # module docstring), so these are defined-but-never-awarded for now.
+    _BadgeSpec(
+        slug="engaged_member_bronze",
+        name="Engaged Member (Bronze)",
+        description="Posted 10 comments across the community.",
+        icon="fa-solid fa-comments",
+        category="engaged_member",
+        threshold_type="comments",
+        threshold_value=10,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="engaged_member_silver",
+        name="Engaged Member (Silver)",
+        description="Posted 50 comments across the community.",
+        icon="fa-solid fa-comments",
+        category="engaged_member",
+        threshold_type="comments",
+        threshold_value=50,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="engaged_member_gold",
+        name="Engaged Member (Gold)",
+        description="Posted 200 comments across the community.",
+        icon="fa-solid fa-comments",
+        category="engaged_member",
+        threshold_type="comments",
+        threshold_value=200,
+        tier="gold",
+    ),
+    # Well Liked family — likes received. Same data-source caveat as above.
+    _BadgeSpec(
+        slug="well_liked_bronze",
+        name="Well Liked (Bronze)",
+        description="Your projects have received 10 likes.",
+        icon="fa-regular fa-heart",
+        category="well_liked",
+        threshold_type="likes_received",
+        threshold_value=10,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="well_liked_silver",
+        name="Well Liked (Silver)",
+        description="Your projects have received 50 likes.",
+        icon="fa-solid fa-heart",
+        category="well_liked",
+        threshold_type="likes_received",
+        threshold_value=50,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="well_liked_gold",
+        name="Well Liked (Gold)",
+        description="Your projects have received 250 likes.",
+        icon="fa-solid fa-heart-circle-bolt",
+        category="well_liked",
+        threshold_type="likes_received",
+        threshold_value=250,
+        tier="gold",
+    ),
+    # Streak family — distinct calendar months with at least one project.
+    _BadgeSpec(
+        slug="streak_bronze",
+        name="Streak (Bronze)",
+        description="Published projects in 3 consecutive months.",
+        icon="fa-solid fa-calendar-day",
+        category="streak",
+        threshold_type="consecutive_months",
+        threshold_value=3,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="streak_silver",
+        name="Streak (Silver)",
+        description="Published projects in 6 consecutive months.",
+        icon="fa-solid fa-calendar-check",
+        category="streak",
+        threshold_type="consecutive_months",
+        threshold_value=6,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="streak_gold",
+        name="Streak (Gold)",
+        description="Published projects in 12 consecutive months.",
+        icon="fa-solid fa-calendar-star",
+        category="streak",
+        threshold_type="consecutive_months",
+        threshold_value=12,
+        tier="gold",
+    ),
+    # Remixer family — projects you created that are remixes.
+    _BadgeSpec(
+        slug="remixer_bronze",
+        name="Remixer (Bronze)",
+        description="Created your first remix of someone else's project.",
+        icon="fa-solid fa-code-branch",
+        category="remixer",
+        threshold_type="remixes",
+        threshold_value=1,
+        tier="bronze",
+    ),
+    _BadgeSpec(
+        slug="remixer_silver",
+        name="Remixer (Silver)",
+        description="Created 5 remixes.",
+        icon="fa-solid fa-code-branch",
+        category="remixer",
+        threshold_type="remixes",
+        threshold_value=5,
+        tier="silver",
+    ),
+    _BadgeSpec(
+        slug="remixer_gold",
+        name="Remixer (Gold)",
+        description="Created 15 remixes.",
+        icon="fa-solid fa-code-fork",
+        category="remixer",
+        threshold_type="remixes",
+        threshold_value=15,
+        tier="gold",
+    ),
+)
+
+
+# --- Seeding -------------------------------------------------------------
+
+
+async def seed_badge_definitions(session: AsyncSession) -> int:
+    """Upsert the canonical badge catalog into the DB.
+
+    Idempotent: runs on every startup. Updates name/description/icon/
+    threshold for an existing row when they have drifted (so we can tweak
+    copy in the code without a migration), and inserts any new slugs.
+
+    Returns the number of rows touched (insert + update).
+    """
+    existing_rows = (await session.scalars(select(BadgeDefinition))).all()
+    existing_by_slug = {row.slug: row for row in existing_rows}
+
+    touched = 0
+    for spec in BADGE_CATALOG:
+        row = existing_by_slug.get(spec.slug)
+        if row is None:
+            session.add(
+                BadgeDefinition(
+                    slug=spec.slug,
+                    name=spec.name,
+                    description=spec.description,
+                    icon=spec.icon,
+                    category=spec.category,
+                    threshold_type=spec.threshold_type,
+                    threshold_value=spec.threshold_value,
+                    tier=spec.tier,
+                )
+            )
+            touched += 1
+            continue
+
+        # Update mutable copy fields if they've drifted.
+        dirty = False
+        for attr in ("name", "description", "icon", "category", "threshold_type", "threshold_value", "tier"):
+            if getattr(row, attr) != getattr(spec, attr):
+                setattr(row, attr, getattr(spec, attr))
+                dirty = True
+        if dirty:
+            touched += 1
+
+    if touched:
+        await session.commit()
+    return touched
+
+
+# --- Threshold counters --------------------------------------------------
+#
+# Each counter is an async function that returns an int for a given
+# username. Keeping them isolated makes them easy to test (you can build a
+# tiny session-fixture and call them directly) and easy to swap when we
+# wire in external sources for comments / likes.
+
+
+async def _count_projects(session: AsyncSession, username: str) -> int:
+    # All non-archived authored projects. We intentionally include WIP and
+    # blocked projects toward the count — the badge celebrates effort, not
+    # only published-and-live status. (Archived is excluded because users
+    # explicitly hide those.)
+    val = await session.scalar(
+        select(func.count(Project.id)).where(
+            Project.author_username == username,
+            Project.status != "archived",
+        )
+    )
+    return int(val or 0)
+
+
+async def _count_downloads(session: AsyncSession, username: str) -> int:
+    # Total downloads across all projects owned by the user. Join through
+    # Project on author_username to avoid storing the username on Download
+    # rows.
+    val = await session.scalar(
+        select(func.count(Download.id))
+        .join(Project, Project.id == Download.project_id)
+        .where(Project.author_username == username)
+    )
+    return int(val or 0)
+
+
+async def _count_makes_received(session: AsyncSession, username: str) -> int:
+    # Makes posted on projects this user owns.
+    val = await session.scalar(
+        select(func.count(Make.id))
+        .join(Project, Project.id == Make.project_id)
+        .where(Project.author_username == username)
+    )
+    return int(val or 0)
+
+
+async def _count_remixes_created(session: AsyncSession, username: str) -> int:
+    # Projects this user authored that are themselves remixes.
+    val = await session.scalar(
+        select(func.count(Project.id)).where(
+            Project.author_username == username,
+            Project.remixed_from_id.is_not(None),
+        )
+    )
+    return int(val or 0)
+
+
+async def _count_comments(session: AsyncSession, username: str) -> int:
+    # No local comments table — comments live in Chatter. Return 0 so the
+    # Engaged Member badges are defined-but-never-awarded for now. When a
+    # comments source lands, swap this for the real count.
+    return 0
+
+
+async def _count_likes_received(session: AsyncSession, username: str) -> int:
+    # No local likes table — likes are tracked by the page-counter service.
+    # Same treatment as comments above.
+    return 0
+
+
+async def _consecutive_months_with_project(
+    session: AsyncSession, username: str
+) -> int:
+    """Longest run of consecutive calendar months containing a project.
+
+    Builds the set of (year, month) buckets in which the user published a
+    project, then walks them in order counting the longest unbroken run.
+    Two-month gap breaks the streak; one-month gap (i.e. adjacent month)
+    extends it.
+    """
+    rows = (
+        await session.scalars(
+            select(Project.created_at).where(
+                Project.author_username == username,
+                Project.status != "archived",
+            )
+        )
+    ).all()
+    if not rows:
+        return 0
+
+    months: set[tuple[int, int]] = set()
+    for ts in rows:
+        if isinstance(ts, datetime):
+            months.add((ts.year, ts.month))
+    if not months:
+        return 0
+
+    sorted_months = sorted(months)
+    best = current = 1
+    for i in range(1, len(sorted_months)):
+        prev_y, prev_m = sorted_months[i - 1]
+        cur_y, cur_m = sorted_months[i]
+        # Compute month-distance: ((y2*12 + m2) - (y1*12 + m1)) == 1 when adjacent.
+        delta = (cur_y * 12 + cur_m) - (prev_y * 12 + prev_m)
+        if delta == 1:
+            current += 1
+        else:
+            current = 1
+        if current > best:
+            best = current
+    return best
+
+
+_CounterFn = Callable[[AsyncSession, str], Awaitable[int]]
+
+_THRESHOLD_COUNTERS: dict[str, _CounterFn] = {
+    "project_count": _count_projects,
+    "downloads": _count_downloads,
+    "makes_received": _count_makes_received,
+    "remixes": _count_remixes_created,
+    "comments": _count_comments,
+    "likes_received": _count_likes_received,
+    "consecutive_months": _consecutive_months_with_project,
+}
+
+
+# --- Evaluation ---------------------------------------------------------
+
+
+async def evaluate_user(
+    session: AsyncSession,
+    username: str,
+) -> list[EarnedBadgeResponse]:
+    """Recompute earned badges for ``username`` and award any new ones.
+
+    Returns the list of badges awarded on *this call* (i.e. newly created
+    rows in ``user_badges``), so the caller can fire a toast notification.
+    Already-earned badges are not re-emitted.
+
+    Idempotent: calling repeatedly without new activity returns ``[]``.
+
+    The function commits its own changes; callers should call it OUTSIDE
+    of an in-flight transaction they're about to rollback. In practice,
+    event-hook callers commit their own row first (project create, make
+    create, etc.) then invoke this on a follow-up session — see the call
+    sites for the pattern.
+    """
+    # Snapshot the catalog. We don't want to interleave network/DB calls
+    # for each badge — collect first, then loop.
+    definitions = (await session.scalars(select(BadgeDefinition))).all()
+    if not definitions:
+        return []
+
+    # Pre-fetch what the user already has so we don't double-award.
+    earned_rows = (
+        await session.scalars(
+            select(UserBadge).where(UserBadge.user_id == username)
+        )
+    ).all()
+    already_earned_ids = {row.badge_id for row in earned_rows}
+
+    # Cache the per-threshold-type counts so the same counter doesn't run
+    # 3 times for a tiered family. This makes evaluate_user O(distinct
+    # threshold types) DB lookups, not O(catalog size).
+    counts: dict[str, int] = {}
+
+    newly_awarded: list[EarnedBadgeResponse] = []
+    for d in definitions:
+        if d.id in already_earned_ids:
+            continue
+        counter = _THRESHOLD_COUNTERS.get(d.threshold_type)
+        if counter is None:
+            # Defensive: a future migration may add a threshold_type we
+            # haven't wired a counter for yet. Skip rather than crash.
+            logger.warning(
+                "No counter registered for threshold_type %r (badge %s)",
+                d.threshold_type, d.slug,
+            )
+            continue
+
+        if d.threshold_type not in counts:
+            counts[d.threshold_type] = await counter(session, username)
+        if counts[d.threshold_type] < d.threshold_value:
+            continue
+
+        new_row = UserBadge(user_id=username, badge_id=d.id)
+        session.add(new_row)
+        try:
+            await session.flush()
+        except IntegrityError:
+            # Race: another concurrent evaluate_user beat us. Rollback the
+            # bad insert and skip — the badge is already there.
+            await session.rollback()
+            continue
+
+        newly_awarded.append(
+            EarnedBadgeResponse(
+                id=d.id,
+                slug=d.slug,
+                name=d.name,
+                description=d.description,
+                icon=d.icon,
+                category=d.category,
+                tier=d.tier,
+                earned_at=new_row.earned_at or datetime.utcnow(),
+            )
+        )
+
+    if newly_awarded:
+        await session.commit()
+    return newly_awarded
+
+
+async def list_user_badges(
+    session: AsyncSession, username: str
+) -> list[EarnedBadgeResponse]:
+    """Return all badges currently earned by ``username``.
+
+    Joined query so we only round-trip the DB once.
+    """
+    rows = (
+        await session.execute(
+            select(UserBadge, BadgeDefinition)
+            .join(BadgeDefinition, BadgeDefinition.id == UserBadge.badge_id)
+            .where(UserBadge.user_id == username)
+            .order_by(UserBadge.earned_at.asc())
+        )
+    ).all()
+    return [
+        EarnedBadgeResponse(
+            id=d.id,
+            slug=d.slug,
+            name=d.name,
+            description=d.description,
+            icon=d.icon,
+            category=d.category,
+            tier=d.tier,
+            earned_at=ub.earned_at,
+        )
+        for ub, d in rows
+    ]
+
+
+async def retro_award_all_users(session: AsyncSession) -> dict[str, int]:
+    """Run ``evaluate_user`` against every known author + maker username.
+
+    Used at startup (one-shot after a fresh deploy) and exposed via the
+    admin endpoint so badges can be backfilled for everyone who was
+    active before the system existed.
+
+    Returns a ``{username: newly_awarded_count}`` mapping for the audit
+    log. Crashes are swallowed per-user so one bad row doesn't stop the
+    batch.
+    """
+    # Collect every username we know about across the data sources.
+    users: set[str] = set()
+    for rows, col in (
+        ((await session.scalars(select(Project.author_username))).all(), Project.author_username),
+        ((await session.scalars(select(Make.user_id))).all(), Make.user_id),
+    ):
+        for name in rows:
+            if name:
+                users.add(name)
+
+    result: dict[str, int] = {}
+    for name in sorted(users):
+        try:
+            awarded = await evaluate_user(session, name)
+            result[name] = len(awarded)
+        except Exception as exc:  # noqa: BLE001 — best-effort batch
+            logger.warning("Retro badge eval failed for %s: %s", name, exc)
+            result[name] = 0
+    return result

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -8,14 +8,17 @@ from typing import AsyncIterator
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .badges import seed_badge_definitions
 from .config import get_settings
 from .db import (
     add_bom_part_id_if_missing,
     add_remix_columns_if_missing,
     create_all,
+    get_sessionmaker,
     repair_stale_fks,
 )
 from .routers import (
+    badges,
     bom,
     downloads,
     files,
@@ -39,6 +42,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await add_remix_columns_if_missing()
     # Issue #121: ensure project_bom_items.part_id column exists.
     await add_bom_part_id_if_missing()
+    # Issue #106: seed the badge catalog (idempotent upsert by slug).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await seed_badge_definitions(session)
     yield
 
 
@@ -73,6 +80,8 @@ def create_app() -> FastAPI:
     app.include_router(makes.router)
     # Issue #108: project remixes (fork & attribution).
     app.include_router(remixes.router)
+    # Issue #106: badges & achievements.
+    app.include_router(badges.router)
     return app
 
 

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -360,3 +360,59 @@ class PartRevision(Base):
     # Suppliers are denormalised into the revision row as JSON so we don't
     # need a sibling table per revision. Each entry: {name, url}.
     suppliers_json: Mapped[Optional[list]] = mapped_column(JsonType)
+
+
+# --- Badges & Achievements (issue #106) ----------------------------------
+#
+# Two tables: ``badge_definitions`` (catalog of available badges, seeded at
+# startup) and ``user_badges`` (which users have earned which badges).
+#
+# Design decisions:
+#   * ``user_id`` on ``user_badges`` is the **username string** (matching
+#     ``Project.author_username``, ``Make.user_id``, etc.). There is no
+#     local ``users`` table in projects-api — Chatter is the source of
+#     truth. Storing the username here keeps the data model consistent with
+#     the rest of this service.
+#   * ``slug`` is the stable identifier for a badge across redeploys;
+#     ``id`` is an internal autoinc used by FK joins. We upsert seed data
+#     by slug so re-running the seeder doesn't duplicate rows.
+#   * ``tier`` values: ``"bronze" | "silver" | "gold" | "single"``. Tiered
+#     families share a slug **prefix** (e.g. ``prolific_maker_bronze``,
+#     ``prolific_maker_silver``, ``prolific_maker_gold``); the ``category``
+#     column groups them so the gallery UI can render a family card.
+
+
+class BadgeDefinition(Base):
+    __tablename__ = "badge_definitions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    slug: Mapped[str] = mapped_column(String(80), nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    icon: Mapped[str] = mapped_column(String(120), nullable=False)
+    category: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    threshold_type: Mapped[str] = mapped_column(String(60), nullable=False)
+    threshold_value: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    tier: Mapped[str] = mapped_column(String(20), nullable=False, default="single")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+
+class UserBadge(Base):
+    __tablename__ = "user_badges"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    badge_id: Mapped[int] = mapped_column(
+        ForeignKey("badge_definitions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    earned_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ux_user_badges_user_badge", "user_id", "badge_id", unique=True),
+    )

--- a/stacks/projects-api/projects_api/routers/badges.py
+++ b/stacks/projects-api/projects_api/routers/badges.py
@@ -1,0 +1,140 @@
+"""Badges & Achievements endpoints — issue #106.
+
+Public endpoints:
+
+* ``GET /api/badges`` — list the catalog of all defined badges.
+* ``GET /api/users/{username}/badges`` — list badges a user has earned.
+
+Authenticated endpoint:
+
+* ``POST /api/badges/evaluate/{username}`` — trigger badge re-evaluation
+  for a user. Allowed if the caller is the user themselves OR an admin.
+  Returns ``newly_awarded`` so the caller can show a toast.
+
+A separate admin-only retro-award route is also provided to backfill
+badges for everyone after a deploy.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import get_current_user
+from ..badges import (
+    evaluate_user,
+    list_user_badges,
+    retro_award_all_users,
+)
+from ..config import get_settings
+from ..db import get_session
+from ..models import BadgeDefinition
+from ..schemas import (
+    BadgeDefinitionResponse,
+    BadgeEvaluationResponse,
+    EarnedBadgeResponse,
+)
+
+router = APIRouter(tags=["badges"])
+
+
+def _is_admin(username: str) -> bool:
+    return username in get_settings().admin_usernames_list
+
+
+@router.get("/api/badges", response_model=list[BadgeDefinitionResponse])
+async def list_badge_catalog(
+    session: AsyncSession = Depends(get_session),
+) -> list[BadgeDefinitionResponse]:
+    """List every badge in the catalog (public).
+
+    Ordered by category then threshold_value ascending so the gallery can
+    render tiered families top-to-bottom (bronze -> silver -> gold).
+    """
+    rows = (
+        await session.scalars(
+            select(BadgeDefinition).order_by(
+                BadgeDefinition.category,
+                BadgeDefinition.threshold_value,
+            )
+        )
+    ).all()
+    return [
+        BadgeDefinitionResponse(
+            id=r.id,
+            slug=r.slug,
+            name=r.name,
+            description=r.description,
+            icon=r.icon,
+            category=r.category,
+            threshold_type=r.threshold_type,
+            threshold_value=r.threshold_value,
+            tier=r.tier,
+        )
+        for r in rows
+    ]
+
+
+@router.get(
+    "/api/users/{username}/badges",
+    response_model=list[EarnedBadgeResponse],
+)
+async def get_user_badges(
+    username: str,
+    session: AsyncSession = Depends(get_session),
+) -> list[EarnedBadgeResponse]:
+    """List the badges a given user has earned (public)."""
+    return await list_user_badges(session, username)
+
+
+@router.post(
+    "/api/badges/evaluate/{username}",
+    response_model=BadgeEvaluationResponse,
+)
+async def trigger_evaluation(
+    username: str,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> BadgeEvaluationResponse:
+    """Re-evaluate badges for ``username``.
+
+    Auth: the caller must either be the same user, or an admin. We don't
+    let arbitrary callers fire evaluation for anyone — even though it's
+    idempotent and read-mostly, it triggers a small fan of DB reads and
+    we'd rather not expose that as a public DoS vector.
+    """
+    if user != username and not _is_admin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Can only evaluate your own badges",
+        )
+    new_badges = await evaluate_user(session, username)
+    all_badges = await list_user_badges(session, username)
+    return BadgeEvaluationResponse(
+        username=username,
+        newly_awarded=new_badges,
+        total_earned=len(all_badges),
+    )
+
+
+@router.post(
+    "/api/admin/badges/retro-award",
+    response_model=dict[str, int],
+)
+async def admin_retro_award(
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, int]:
+    """Run ``evaluate_user`` against every known username (admin only).
+
+    Returns ``{username: newly_awarded_count}``. Useful after a fresh
+    deploy of the badges feature to backfill recognition for existing
+    activity.
+    """
+    if not _is_admin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return await retro_award_all_users(session)

--- a/stacks/projects-api/projects_api/routers/makes.py
+++ b/stacks/projects-api/projects_api/routers/makes.py
@@ -26,6 +26,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user
+from ..badges import evaluate_user
 from ..config import get_settings
 from ..db import get_session
 from ..models import Make, MakeImage, Project
@@ -187,10 +188,26 @@ async def create_make(
     for img in saved_images:
         await session.refresh(img)
 
-    # TODO(#106): badge eval hook — call into the badges service here with
-    # (user=make.user_id, event="make.created", make_id=make.id).
+    # Issue #106: evaluate badges for BOTH the make poster (could be
+    # crossing future "first make" thresholds — none defined today but the
+    # hook is here for symmetry) AND the project's author, who could be
+    # crossing the Community Builder tier. Best-effort.
+    poster_newly = []
+    try:
+        poster_newly = await evaluate_user(session, user)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        # Only re-evaluate the author if they're a different user — saves a
+        # roundtrip for self-makes (which are rare but possible).
+        if project.author_username != user:
+            await evaluate_user(session, project.author_username)
+    except Exception:  # noqa: BLE001
+        pass
 
-    return _serialize_make(make, saved_images)
+    resp = _serialize_make(make, saved_images)
+    resp.newly_awarded_badges = poster_newly
+    return resp
 
 
 @router.get(
@@ -298,8 +315,9 @@ async def delete_make(
     await session.delete(make)
     await session.commit()
 
-    # TODO(#106): badge eval hook — call into the badges service here with
-    # (user=make.user_id, event="make.deleted", make_id=make_id).
+    # Note: we intentionally do NOT un-award badges on make deletion.
+    # Badges are sticky — earning one and then losing it because someone
+    # deleted a make would be a bad experience. Re-evaluation only adds.
 
 
 @router.post("/api/makes/{make_id}/heart", response_model=MakeResponse)

--- a/stacks/projects-api/projects_api/routers/projects.py
+++ b/stacks/projects-api/projects_api/routers/projects.py
@@ -10,6 +10,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user, get_optional_user
+from ..badges import evaluate_user
 from ..db import get_session
 from ..models import Download, Project, ProjectTag
 from ..schemas import (
@@ -188,7 +189,17 @@ async def create_project(
         await _set_tags(session, project.id, body.tags)
     await session.commit()
     await session.refresh(project)
-    return await _project_response(session, project)
+    # Issue #106: evaluate badges synchronously after the project row is
+    # safely persisted. evaluate_user is best-effort — wrap in a try so a
+    # badge bug can never break project creation.
+    newly = []
+    try:
+        newly = await evaluate_user(session, user)
+    except Exception:  # noqa: BLE001 — never crash project create
+        pass
+    resp = await _project_response(session, project)
+    resp.newly_awarded_badges = newly
+    return resp
 
 
 @router.put("/{project_id}", response_model=ProjectResponse)

--- a/stacks/projects-api/projects_api/routers/remixes.py
+++ b/stacks/projects-api/projects_api/routers/remixes.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user
+from ..badges import evaluate_user
 from ..db import get_session
 from ..models import Project, ProjectTag
 from ..schemas import (
@@ -108,12 +109,19 @@ async def create_remix(
     if inherited_tags:
         await _set_tags(session, remix.id, inherited_tags)
 
-    # TODO(#106): Remixer badge eval hook here — when the badges service
-    # lands, fire an event so the caller can level up their Remixer tier.
-
     await session.commit()
     await session.refresh(remix)
-    return await _project_response(session, remix)
+
+    # Issue #106: evaluate the remixer's badges (Remixer tier + may also
+    # cross "Prolific Maker" if this is their nth project). Best-effort.
+    newly = []
+    try:
+        newly = await evaluate_user(session, user)
+    except Exception:  # noqa: BLE001
+        pass
+    resp = await _project_response(session, remix)
+    resp.newly_awarded_badges = newly
+    return resp
 
 
 @router.get("/{project_id}/remixes", response_model=list[ProjectListItem])

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -8,6 +8,51 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 
+# --- Badges & Achievements (issue #106) ----------------------------------
+# Defined up here because ProjectResponse / MakeResponse reference
+# EarnedBadgeResponse in their ``newly_awarded_badges`` field.
+
+
+class BadgeDefinitionResponse(BaseModel):
+    """One row in the badge catalog. Public — exposed via /api/badges."""
+
+    id: int
+    slug: str
+    name: str
+    description: str
+    icon: str
+    category: str
+    threshold_type: str
+    threshold_value: int
+    tier: str  # "bronze" | "silver" | "gold" | "single"
+
+
+class EarnedBadgeResponse(BaseModel):
+    """A badge a user has earned. Combines the catalog row + earned_at."""
+
+    id: int
+    slug: str
+    name: str
+    description: str
+    icon: str
+    category: str
+    tier: str
+    earned_at: datetime
+
+
+class BadgeEvaluationResponse(BaseModel):
+    """Returned by POST /api/badges/evaluate/{username}.
+
+    ``newly_awarded`` is the list of badges that crossed the threshold on
+    *this* evaluation pass — callers (frontend or another API route) can
+    use it to show "you earned a new badge!" toast notifications.
+    """
+
+    username: str
+    newly_awarded: list[EarnedBadgeResponse] = Field(default_factory=list)
+    total_earned: int = 0
+
+
 class ProjectCreate(BaseModel):
     title: str = Field(..., min_length=5, max_length=200)
     short_description: Optional[str] = Field(None, max_length=500)
@@ -63,6 +108,11 @@ class ProjectResponse(BaseModel):
     remixes_count: int = 0
     is_remix: bool = False
     download_count: int = 0
+    # Issue #106: badges awarded as a side-effect of this request (e.g.
+    # project create crossing the "First Project" threshold). Frontend uses
+    # this to surface a toast notification. Always omitted from
+    # response bodies that didn't trigger evaluation.
+    newly_awarded_badges: list[EarnedBadgeResponse] = Field(default_factory=list)
 
 
 class ProjectListItem(BaseModel):
@@ -227,6 +277,8 @@ class MakeResponse(BaseModel):
     # Populated only when returning a single make (detail view); harmless
     # when omitted from list responses.
     project_title: Optional[str] = None
+    # Issue #106: badges awarded as a side-effect of posting this make.
+    newly_awarded_badges: list[EarnedBadgeResponse] = Field(default_factory=list)
 
 
 # --- Download tracking schemas ---

--- a/stacks/projects-api/tests/conftest.py
+++ b/stacks/projects-api/tests/conftest.py
@@ -57,6 +57,7 @@ async def session(sessionmaker_) -> AsyncIterator[AsyncSession]:
 @pytest_asyncio.fixture
 async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
     from projects_api import db as db_module
+    from projects_api import main as main_module
     from projects_api.main import create_app
 
     async def _override_session() -> AsyncIterator[AsyncSession]:
@@ -69,6 +70,13 @@ async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
     original_create_all = db_module.create_all
     db_module.create_all = _noop_create_all
 
+    # Issue #106: route the lifespan seeder at the test sessionmaker so
+    # the badge catalog lands in the in-memory DB the test fixture set up
+    # (instead of the global engine the seeder would otherwise grab).
+    original_get_sessionmaker = db_module.get_sessionmaker
+    db_module.get_sessionmaker = lambda: sessionmaker_
+    main_module.get_sessionmaker = lambda: sessionmaker_
+
     app = create_app()
     app.dependency_overrides[db_module.get_session] = _override_session
 
@@ -78,6 +86,8 @@ async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
             yield ac
 
     db_module.create_all = original_create_all
+    db_module.get_sessionmaker = original_get_sessionmaker
+    main_module.get_sessionmaker = original_get_sessionmaker
 
 
 def make_auth_header(username: str = "testuser") -> dict:

--- a/stacks/projects-api/tests/test_badges.py
+++ b/stacks/projects-api/tests/test_badges.py
@@ -1,0 +1,325 @@
+"""Tests for badges & achievements (issue #106).
+
+Covers:
+* Catalog seeding is idempotent and re-runs without duplicating rows.
+* Badge awarded on threshold crossing (first project, prolific maker).
+* Badge NOT awarded below threshold.
+* Tiered progression — crossing silver also awards bronze.
+* Re-evaluation is idempotent (no double rows even if you call it twice).
+* Public ``GET /api/badges`` lists the catalog.
+* Public ``GET /api/users/{username}/badges`` returns earned rows.
+* ``POST /api/badges/evaluate/{username}`` enforces self-or-admin.
+* ``newly_awarded_badges`` is attached to the project-create response.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+from sqlalchemy import select
+
+from projects_api.badges import (
+    BADGE_CATALOG,
+    evaluate_user,
+    list_user_badges,
+    seed_badge_definitions,
+)
+from projects_api.models import BadgeDefinition, Project, UserBadge
+
+from .conftest import make_auth_header
+
+
+# --- Seeding -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(session) -> None:
+    n1 = await seed_badge_definitions(session)
+    assert n1 == len(BADGE_CATALOG)  # First run inserts everything.
+
+    # Second run should touch nothing — no copy drift.
+    n2 = await seed_badge_definitions(session)
+    assert n2 == 0
+
+    rows = (await session.scalars(select(BadgeDefinition))).all()
+    assert len(rows) == len(BADGE_CATALOG)
+    # No duplicate slugs.
+    assert len({r.slug for r in rows}) == len(rows)
+
+
+@pytest.mark.asyncio
+async def test_seed_updates_copy_drift(session) -> None:
+    await seed_badge_definitions(session)
+    row = (
+        await session.scalars(
+            select(BadgeDefinition).where(BadgeDefinition.slug == "first_project")
+        )
+    ).one()
+    row.name = "Old Name From A Past Deploy"
+    await session.commit()
+
+    touched = await seed_badge_definitions(session)
+    assert touched >= 1
+    refreshed = (
+        await session.scalars(
+            select(BadgeDefinition).where(BadgeDefinition.slug == "first_project")
+        )
+    ).one()
+    assert refreshed.name == "First Project"
+
+
+# --- Threshold awarding --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_awards_nothing(session) -> None:
+    await seed_badge_definitions(session)
+    # User exists in the system but has done literally nothing — no rows.
+    awarded = await evaluate_user(session, "ghost")
+    assert awarded == []
+
+
+@pytest.mark.asyncio
+async def test_first_project_awards_on_create(client) -> None:
+    headers = make_auth_header("alice")
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Alice's First Bot"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    slugs = {b["slug"] for b in body.get("newly_awarded_badges", [])}
+    assert "first_project" in slugs
+
+
+@pytest.mark.asyncio
+async def test_prolific_maker_tiered_progression(session) -> None:
+    """Crossing the silver threshold awards bronze too (if not yet held).
+
+    Builds 10 projects directly in the DB (faster than 10 API calls), then
+    runs the evaluator once and expects both first_project, prolific_maker_bronze
+    and prolific_maker_silver — but NOT _gold.
+    """
+    await seed_badge_definitions(session)
+
+    for i in range(10):
+        session.add(
+            Project(
+                title=f"Bot {i}",
+                short_description="x",
+                status="wip",
+                author_username="alice",
+            )
+        )
+    await session.commit()
+
+    awarded = await evaluate_user(session, "alice")
+    slugs = {b.slug for b in awarded}
+    assert "first_project" in slugs
+    assert "prolific_maker_bronze" in slugs
+    assert "prolific_maker_silver" in slugs
+    assert "prolific_maker_gold" not in slugs
+
+
+@pytest.mark.asyncio
+async def test_evaluation_is_idempotent(session) -> None:
+    await seed_badge_definitions(session)
+    session.add(
+        Project(
+            title="One Bot",
+            short_description="x",
+            status="wip",
+            author_username="bob",
+        )
+    )
+    await session.commit()
+
+    first = await evaluate_user(session, "bob")
+    assert len(first) >= 1
+
+    second = await evaluate_user(session, "bob")
+    assert second == []  # nothing new the second time
+
+    # And exactly one user_badges row per badge (no duplicates).
+    rows = (
+        await session.scalars(
+            select(UserBadge).where(UserBadge.user_id == "bob")
+        )
+    ).all()
+    assert len({r.badge_id for r in rows}) == len(rows)
+
+
+@pytest.mark.asyncio
+async def test_remixer_badge_awarded(session) -> None:
+    await seed_badge_definitions(session)
+
+    # bob authors a remix (remixed_from_id set, even pointing at himself
+    # for the test — the evaluator doesn't validate the FK target).
+    session.add(
+        Project(
+            title="Original",
+            status="wip",
+            author_username="bob",
+        )
+    )
+    await session.commit()
+    parent = (
+        await session.scalars(select(Project).where(Project.title == "Original"))
+    ).one()
+
+    session.add(
+        Project(
+            title="Bob's Remix",
+            status="wip",
+            author_username="bob",
+            remixed_from_id=parent.id,
+            remix_description="changed something important",
+        )
+    )
+    await session.commit()
+
+    awarded = await evaluate_user(session, "bob")
+    slugs = {b.slug for b in awarded}
+    assert "remixer_bronze" in slugs
+
+
+@pytest.mark.asyncio
+async def test_streak_counts_consecutive_months(session) -> None:
+    await seed_badge_definitions(session)
+
+    # Three projects in consecutive months — should trip the bronze streak.
+    base = _dt.datetime(2025, 1, 15)
+    for offset_months in (0, 1, 2):
+        year, month = base.year, base.month + offset_months
+        # Normalise overflow (simple — month+offset won't exceed 12 in test).
+        ts = _dt.datetime(year, month, 15)
+        session.add(
+            Project(
+                title=f"Streak {offset_months}",
+                status="wip",
+                author_username="streaky",
+                created_at=ts,
+                updated_at=ts,
+            )
+        )
+    await session.commit()
+
+    awarded = await evaluate_user(session, "streaky")
+    slugs = {b.slug for b in awarded}
+    assert "streak_bronze" in slugs
+    assert "streak_silver" not in slugs
+
+
+# --- Endpoints -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_public(client) -> None:
+    resp = await client.get("/api/badges")
+    assert resp.status_code == 200
+    catalog = resp.json()
+    assert len(catalog) == len(BADGE_CATALOG)
+    slugs = {b["slug"] for b in catalog}
+    assert "first_project" in slugs
+    assert "prolific_maker_gold" in slugs
+    # Tiered families are present.
+    assert "remixer_bronze" in slugs and "remixer_gold" in slugs
+
+
+@pytest.mark.asyncio
+async def test_get_user_badges_public(client) -> None:
+    # Make alice earn first_project, then read it back without auth.
+    await client.post(
+        "/api/projects",
+        json={"title": "Alice Earns A Badge"},
+        headers=make_auth_header("alice"),
+    )
+    resp = await client.get("/api/users/alice/badges")
+    assert resp.status_code == 200
+    slugs = {b["slug"] for b in resp.json()}
+    assert "first_project" in slugs
+
+
+@pytest.mark.asyncio
+async def test_evaluate_requires_self_or_admin(client) -> None:
+    # alice creates a project.
+    await client.post(
+        "/api/projects",
+        json={"title": "Alice's Bot"},
+        headers=make_auth_header("alice"),
+    )
+
+    # bob cannot evaluate alice.
+    resp = await client.post(
+        "/api/badges/evaluate/alice",
+        headers=make_auth_header("bob"),
+    )
+    assert resp.status_code == 403
+
+    # alice can evaluate herself.
+    resp = await client.post(
+        "/api/badges/evaluate/alice",
+        headers=make_auth_header("alice"),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["username"] == "alice"
+    # Already awarded on create — re-running adds nothing.
+    assert body["newly_awarded"] == []
+    assert body["total_earned"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_evaluate_unauthenticated_401(client) -> None:
+    resp = await client.post("/api/badges/evaluate/alice")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_admin_retro_award(client) -> None:
+    # Two users with projects, neither evaluated yet (we'll bypass the
+    # auto-eval by going through the DB... but the API already evaluates
+    # on POST so we can't easily skip. Instead, just assert the retro
+    # endpoint returns a mapping and respects admin auth.
+    await client.post(
+        "/api/projects",
+        json={"title": "Alice Bot"},
+        headers=make_auth_header("alice"),
+    )
+    await client.post(
+        "/api/projects",
+        json={"title": "Bob Bot"},
+        headers=make_auth_header("bob"),
+    )
+
+    # Non-admin cannot retro-award.
+    resp = await client.post(
+        "/api/admin/badges/retro-award",
+        headers=make_auth_header("alice"),
+    )
+    assert resp.status_code == 403
+
+    # Admin can (default admin from config is "kev").
+    resp = await client.post(
+        "/api/admin/badges/retro-award",
+        headers=make_auth_header("kev"),
+    )
+    assert resp.status_code == 200
+    mapping = resp.json()
+    assert "alice" in mapping and "bob" in mapping
+
+
+@pytest.mark.asyncio
+async def test_list_user_badges_helper(session) -> None:
+    await seed_badge_definitions(session)
+    session.add(
+        Project(title="X", status="wip", author_username="carol")
+    )
+    await session.commit()
+    await evaluate_user(session, "carol")
+    rows = await list_user_badges(session, "carol")
+    assert any(r.slug == "first_project" for r in rows)
+    # earned_at populated.
+    assert all(r.earned_at is not None for r in rows)

--- a/web/_includes/badge.html
+++ b/web/_includes/badge.html
@@ -1,0 +1,29 @@
+{% comment %}
+Reusable badge display include (issue #106).
+
+Usage:
+  {% include badge.html badge=mybadge size="md" %}
+
+Expected `badge` object shape (matches /api/badges + /api/users/{u}/badges):
+  - name           — human label, e.g. "Prolific Maker (Gold)"
+  - description    — tooltip body
+  - icon           — Font Awesome class, e.g. "fa-solid fa-trophy"
+  - tier           — "bronze" | "silver" | "gold" | "single"
+
+`size` (optional): "sm" | "md" | "lg" — controls the icon size only.
+                   Defaults to "md".
+
+This include is intentionally markup-only so the same fragment can render
+on a static profile page (Jekyll context) or be hydrated by JS — the JS
+helper in /assets/js/badge-toast.js mirrors this DOM shape.
+{% endcomment %}
+{%- assign tier = include.badge.tier | default: "single" -%}
+{%- assign size = include.size | default: "md" -%}
+<span class="kr-badge kr-badge--{{ tier }} kr-badge--{{ size }}"
+      data-bs-toggle="tooltip"
+      data-bs-placement="top"
+      title="{{ include.badge.name | escape }} — {{ include.badge.description | escape }}"
+      aria-label="{{ include.badge.name | escape }}">
+  <i class="{{ include.badge.icon }}"></i>
+  <span class="visually-hidden">{{ include.badge.name }}</span>
+</span>

--- a/web/assets/css/main.scss
+++ b/web/assets/css/main.scss
@@ -1591,3 +1591,157 @@ pre {
     }
   }
 }
+
+// ----------------------------------------------------------------------
+// Badges & Achievements (issue #106)
+// ----------------------------------------------------------------------
+//
+// Tier colours mirror the metal-medal convention (Bronze / Silver /
+// Gold). The "single" tier is a neutral primary so single-shot badges
+// like "First Project" don't look like an unawarded grey.
+//
+// The .kr-badge prefix avoids any clash with Bootstrap's .badge utility
+// — those share the project hub's small tag chips, and we don't want our
+// trophy icons inheriting their padding.
+
+.kr-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  line-height: 1;
+  position: relative;
+  // Sit on top of cards when adornments overlap an avatar.
+  vertical-align: middle;
+  text-align: center;
+  // Subtle inner shadow gives a "minted" feel without an SVG.
+  box-shadow: inset 0 -2px 4px rgba(0, 0, 0, 0.18),
+              0 1px 2px rgba(0, 0, 0, 0.15);
+  color: #fff;
+  transition: transform 120ms ease-out;
+
+  i {
+    line-height: 1;
+  }
+
+  &:hover {
+    transform: scale(1.08);
+  }
+}
+
+.kr-badge--sm {
+  width: 1.4rem;
+  height: 1.4rem;
+  font-size: 0.75rem;
+}
+.kr-badge--md {
+  width: 2.25rem;
+  height: 2.25rem;
+  font-size: 1.1rem;
+}
+.kr-badge--lg {
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.6rem;
+}
+
+.kr-badge--bronze {
+  background: linear-gradient(135deg, #cd7f32 0%, #a0561a 100%);
+}
+.kr-badge--silver {
+  background: linear-gradient(135deg, #c0c0c0 0%, #8a8a8a 100%);
+  color: #fff;
+}
+.kr-badge--gold {
+  background: linear-gradient(135deg, #ffd54a 0%, #c9a227 100%);
+  color: #4a3700;
+  // Make the gold glow a little — it's the trophy tier.
+  box-shadow: inset 0 -2px 4px rgba(0, 0, 0, 0.18),
+              0 0 6px rgba(255, 213, 74, 0.5);
+}
+.kr-badge--single {
+  // Single-tier badges (e.g. "First Project") use the brand orange so
+  // they read as a friendly first-time award, not as "you only earned
+  // bronze".
+  background: linear-gradient(135deg, #ff8a3d 0%, #d96510 100%);
+}
+
+// Toast container used by /assets/js/badge-toast.js. Fixed to the bottom
+// right so it doesn't collide with the chat widget on the left side.
+#kr-badge-toast-container {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1080; // above Bootstrap modals' backdrop (1050)
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 22rem;
+  pointer-events: none; // wrapper passes through; individual toasts re-enable
+}
+
+.kr-badge-toast {
+  pointer-events: auto;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  animation: kr-badge-toast-in 320ms ease-out;
+}
+
+.kr-badge-toast__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.kr-badge-toast__title {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.kr-badge-toast__desc {
+  font-size: 0.85rem;
+  color: #555;
+}
+
+@keyframes kr-badge-toast-in {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+// Gallery page tile (web/badges/index.html) — earned vs locked state.
+.kr-badge-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.5rem;
+  background: #fff;
+  height: 100%;
+  transition: transform 120ms ease-out, box-shadow 120ms ease-out;
+}
+.kr-badge-tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+.kr-badge-tile--locked .kr-badge {
+  filter: grayscale(100%);
+  opacity: 0.45;
+}
+.kr-badge-tile__name {
+  margin-top: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+.kr-badge-tile__desc {
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}

--- a/web/assets/js/badge-toast.js
+++ b/web/assets/js/badge-toast.js
@@ -1,0 +1,94 @@
+/**
+ * Badge toast notification helper — issue #106.
+ *
+ * Pages that mutate state which can award badges (e.g. project create)
+ * receive a `newly_awarded_badges` array on the response body. They call
+ * BadgeToast.show(badges) and we render a stack of dismissible toasts in
+ * the bottom-right corner.
+ *
+ * The helper is intentionally tiny and vanilla — no Bootstrap-Toast
+ * dependency — because the toast container is its own .kr-badge-toast
+ * scope in main.scss and we want to avoid pulling Bootstrap's JS toast
+ * collection on every page that might award a badge.
+ *
+ * Public API:
+ *   BadgeToast.show([{slug, name, description, icon, tier}, ...])
+ *   BadgeToast.fromResponse(responseBody)  // convenience for fetch().json()
+ */
+(function () {
+  'use strict';
+
+  var CONTAINER_ID = 'kr-badge-toast-container';
+  var TOAST_LIFESPAN_MS = 6000;
+
+  function ensureContainer() {
+    var el = document.getElementById(CONTAINER_ID);
+    if (el) return el;
+    el = document.createElement('div');
+    el.id = CONTAINER_ID;
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.textContent = text == null ? '' : String(text);
+    return div.innerHTML;
+  }
+
+  function renderToast(badge) {
+    var tier = badge.tier || 'single';
+    var node = document.createElement('div');
+    node.className = 'kr-badge-toast';
+    node.setAttribute('role', 'status');
+    node.innerHTML =
+      '<span class="kr-badge kr-badge--' + tier + ' kr-badge--md">' +
+        '<i class="' + escapeHtml(badge.icon || 'fa-solid fa-trophy') + '"></i>' +
+      '</span>' +
+      '<div class="kr-badge-toast__body">' +
+        '<div class="kr-badge-toast__title">You earned a new badge!</div>' +
+        '<div class="kr-badge-toast__desc">' +
+          '<strong>' + escapeHtml(badge.name) + '</strong>' +
+          (badge.description ? ' — ' + escapeHtml(badge.description) : '') +
+        '</div>' +
+      '</div>';
+
+    // Click to dismiss — gives the user manual control if the toast
+    // hangs around while they read it.
+    node.addEventListener('click', function () {
+      remove(node);
+    });
+
+    return node;
+  }
+
+  function remove(node) {
+    if (!node || !node.parentNode) return;
+    node.style.transition = 'opacity 250ms ease-out, transform 250ms ease-out';
+    node.style.opacity = '0';
+    node.style.transform = 'translateY(8px)';
+    setTimeout(function () {
+      if (node.parentNode) node.parentNode.removeChild(node);
+    }, 260);
+  }
+
+  function show(badges) {
+    if (!badges || !badges.length) return;
+    var container = ensureContainer();
+    badges.forEach(function (b) {
+      var node = renderToast(b);
+      container.appendChild(node);
+      setTimeout(function () { remove(node); }, TOAST_LIFESPAN_MS);
+    });
+  }
+
+  function fromResponse(responseBody) {
+    if (!responseBody) return;
+    // Server may return the field at the top level (project / make create)
+    // or nested under .newly_awarded (POST /api/badges/evaluate/...).
+    var newly = responseBody.newly_awarded_badges || responseBody.newly_awarded;
+    show(newly || []);
+  }
+
+  window.BadgeToast = { show: show, fromResponse: fromResponse };
+})();

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -139,6 +139,12 @@
       }
       updateStatusBadge(currentProject.status);
       showSaveStatus('saved', 'Saved');
+      // Issue #106: surface any badges awarded by this save (typically
+      // only on the initial create, but the API may award one on a PUT
+      // too if e.g. setting status -> completed crosses a threshold).
+      if (window.BadgeToast && currentProject) {
+        BadgeToast.fromResponse(currentProject);
+      }
     } catch (e) {
       console.error('Save failed:', e);
       showSaveStatus('error', 'Save failed');

--- a/web/badges/index.html
+++ b/web/badges/index.html
@@ -1,0 +1,165 @@
+---
+title: Badges & Achievements
+description: Browse the full badge catalogue and track which ones you have earned.
+layout: content
+hide_likes_and_comments: true
+thanks: false
+---
+
+<link rel="stylesheet" href="/assets/css/main.css?v={{ site.time | date: '%s' }}">
+
+<div class="container">
+  <h1><i class="fa-solid fa-trophy me-3 text-warning"></i> {{ page.title }}</h1>
+  <p class="lead">{{ page.description }}</p>
+
+  <p class="text-muted">
+    Earn badges automatically by publishing projects, sharing remixes,
+    and engaging with the community. Each tiered family progresses from
+    Bronze through Silver to Gold.
+  </p>
+
+  <div id="badge-status-banner" class="alert alert-info d-none" role="status"></div>
+
+  <!-- Badge gallery; populated by JS below. -->
+  <div id="badge-gallery"></div>
+
+  <div id="badge-error" class="alert alert-warning d-none">
+    Could not load the badge catalogue right now. Please try again later.
+  </div>
+</div>
+
+<script src="/assets/js/badge-toast.js?v={{ site.time | date: '%s' }}"></script>
+<script>
+(function () {
+  'use strict';
+  var API = 'https://projects.kevsrobots.com';
+  var gallery = document.getElementById('badge-gallery');
+  var banner = document.getElementById('badge-status-banner');
+  var errorBox = document.getElementById('badge-error');
+
+  function esc(text) {
+    var div = document.createElement('div');
+    div.textContent = text == null ? '' : String(text);
+    return div.innerHTML;
+  }
+
+  function getUsername() {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var parts = cookies[i].trim().split('=');
+      if (parts[0] === 'username' && parts[1]) {
+        return decodeURIComponent(parts[1]);
+      }
+    }
+    return null;
+  }
+
+  function tileHtml(badge, earned) {
+    var tier = badge.tier || 'single';
+    var lockedClass = earned ? '' : ' kr-badge-tile--locked';
+    var earnedHint = earned
+      ? '<div class="small text-success mt-1"><i class="fas fa-check"></i> Earned</div>'
+      : '';
+    return (
+      '<div class="col">' +
+        '<div class="kr-badge-tile' + lockedClass + '">' +
+          '<span class="kr-badge kr-badge--' + tier + ' kr-badge--lg" ' +
+                'title="' + esc(badge.name) + '">' +
+            '<i class="' + esc(badge.icon) + '"></i>' +
+          '</span>' +
+          '<div class="kr-badge-tile__name">' + esc(badge.name) + '</div>' +
+          '<div class="kr-badge-tile__desc">' + esc(badge.description) + '</div>' +
+          earnedHint +
+        '</div>' +
+      '</div>'
+    );
+  }
+
+  function groupByCategory(catalog) {
+    var grouped = {};
+    catalog.forEach(function (b) {
+      var k = b.category || 'misc';
+      if (!grouped[k]) grouped[k] = [];
+      grouped[k].push(b);
+    });
+    // Order tiers within a family bronze -> silver -> gold -> single.
+    var tierOrder = { bronze: 1, silver: 2, gold: 3, single: 0 };
+    Object.keys(grouped).forEach(function (k) {
+      grouped[k].sort(function (a, b) {
+        return (tierOrder[a.tier] || 9) - (tierOrder[b.tier] || 9);
+      });
+    });
+    return grouped;
+  }
+
+  function categoryTitle(slug) {
+    // Light prettifier — turn "prolific_maker" into "Prolific Maker".
+    return slug.replace(/_/g, ' ').replace(/\b\w/g, function (c) {
+      return c.toUpperCase();
+    });
+  }
+
+  function render(catalog, earnedSlugs) {
+    var grouped = groupByCategory(catalog);
+    var html = '';
+    // Stable ordering by category name, with "first_project" pinned first
+    // since it's the welcome badge.
+    var keys = Object.keys(grouped).sort(function (a, b) {
+      if (a === 'first_project') return -1;
+      if (b === 'first_project') return 1;
+      return a.localeCompare(b);
+    });
+    keys.forEach(function (k) {
+      html += '<section class="mb-4">';
+      html += '<h3 class="h5 text-uppercase text-muted mb-3">' + esc(categoryTitle(k)) + '</h3>';
+      html += '<div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3">';
+      grouped[k].forEach(function (b) {
+        html += tileHtml(b, earnedSlugs.indexOf(b.slug) !== -1);
+      });
+      html += '</div>';
+      html += '</section>';
+    });
+    gallery.innerHTML = html;
+  }
+
+  function showBanner(message, kind) {
+    banner.className = 'alert alert-' + (kind || 'info');
+    banner.textContent = message;
+    banner.classList.remove('d-none');
+  }
+
+  async function load() {
+    try {
+      var catalogResp = await fetch(API + '/api/badges');
+      if (!catalogResp.ok) throw new Error('catalog fetch failed');
+      var catalog = await catalogResp.json();
+
+      var username = getUsername();
+      var earnedSlugs = [];
+      if (username) {
+        try {
+          var earnedResp = await fetch(API + '/api/users/' + encodeURIComponent(username) + '/badges');
+          if (earnedResp.ok) {
+            earnedSlugs = (await earnedResp.json()).map(function (b) { return b.slug; });
+            showBanner(
+              'You have earned ' + earnedSlugs.length + ' of ' + catalog.length + ' badges, ' + username + '.',
+              'success'
+            );
+          }
+        } catch (e) {
+          // Non-fatal — just render the catalog without earned highlights.
+        }
+      } else {
+        showBanner('Log in to track your earned badges.', 'info');
+      }
+
+      render(catalog, earnedSlugs);
+    } catch (e) {
+      console.error('Badge gallery load failed:', e);
+      errorBox.classList.remove('d-none');
+    }
+  }
+
+  load();
+})();
+</script>

--- a/web/projects/editor.html
+++ b/web/projects/editor.html
@@ -318,6 +318,7 @@ description: Create or edit a project
 <script src="/assets/js/image-viewer.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/circuit-components.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/circuit-editor.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/badge-toast.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-editor.js?v={{ site.time | date: '%s' }}"></script>
 <script>
 // Editor TOC — live-updates from markdown source as the user types

--- a/web/projects/hub.md
+++ b/web/projects/hub.md
@@ -89,6 +89,7 @@ thanks: false
 <script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-interactions.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-search.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/badge-toast.js?v={{ site.time | date: '%s' }}"></script>
 <script>
 (function() {
   const API = 'https://projects.kevsrobots.com';
@@ -198,7 +199,7 @@ thanks: false
                 </div>
               </div>
               <div class="card-footer bg-transparent border-0 d-flex justify-content-between align-items-center">
-                <small class="text-muted">by ${esc(p.author_username)} &middot; ${new Date(p.created_at).toLocaleDateString()}</small>
+                <small class="text-muted">by ${esc(p.author_username)}<span class="ms-1 d-none" data-author-gold="${esc(p.author_username)}"></span> &middot; ${new Date(p.created_at).toLocaleDateString()}</small>
                 <small class="text-muted d-flex gap-2 align-items-center">
                   <span id="card-makes-${p.id}" class="d-none"><i class="fas fa-hammer"></i> <span data-count></span></span>
                   <span id="card-likes-${p.id}"><i class="far fa-heart"></i> </span>
@@ -232,6 +233,25 @@ thanks: false
             if (!wrap) return;
             wrap.querySelector('[data-count]').textContent = makes.length;
             wrap.classList.remove('d-none');
+          })
+          .catch(function () {});
+      });
+
+      // Issue #106: project card adornment — when an author has any
+      // gold-tier badge, show a small trophy icon next to their name.
+      // One fetch per unique author, cached for the page lifetime.
+      var uniqueAuthors = Array.from(new Set(projects.map(function (p) { return p.author_username; })));
+      uniqueAuthors.forEach(function (author) {
+        fetch(API + '/api/users/' + encodeURIComponent(author) + '/badges')
+          .then(function (r) { return r.ok ? r.json() : []; })
+          .then(function (badges) {
+            var goldBadge = (badges || []).find(function (b) { return b.tier === 'gold'; });
+            if (!goldBadge) return;
+            var slots = document.querySelectorAll('[data-author-gold="' + author.replace(/"/g, '\\"') + '"]');
+            slots.forEach(function (slot) {
+              slot.innerHTML = '<i class="fa-solid fa-trophy text-warning" title="' + esc(goldBadge.name) + '" data-bs-toggle="tooltip"></i>';
+              slot.classList.remove('d-none');
+            });
           })
           .catch(function () {});
       });

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -429,6 +429,7 @@ description: View project details
 <script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/image-viewer.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-interactions.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/badge-toast.js?v={{ site.time | date: '%s' }}"></script>
 <script>
 (function() {
   const API = 'https://projects.kevsrobots.com';
@@ -1358,9 +1359,12 @@ description: View project details
         return r.json().then(function (j) { throw new Error(j.detail || 'Failed to post'); });
       }
       return r.json();
-    }).then(function () {
+    }).then(function (body) {
       closeModal('i-made-this-modal');
       fetchMakes(project);
+      // Issue #106: surface any badges the poster earned (e.g. crossing
+      // a future "first make" threshold).
+      if (window.BadgeToast) BadgeToast.fromResponse(body);
     }).catch(function (e) {
       err.textContent = e.message || 'Failed to post make.';
       err.classList.remove('d-none');


### PR DESCRIPTION
## Summary
Implements the full badges & achievements system per #106 — 22 seeded badges across 8 categories with tiered bronze/silver/gold progression, automatic evaluation on relevant events, public catalog endpoint, and frontend display.

- **Backend**: new `badge_definitions` + `user_badges` tables (handled by `create_all`, no ALTER needed), evaluator hooked into project create / remix / make create routes, self-or-admin re-evaluation endpoint.
- **Frontend**: `/badges/` gallery page, reusable badge include, toast notifications when badges are earned, gold-tier author adornments on project cards.
- **22 badges seeded**: `first_project`, and tiered bronze/silver/gold variants of `prolific_maker`, `popular_project`, `community_builder`, `engaged_member`, `well_liked`, `streak`, `remixer`.
- **Tests**: 14 new test cases. Full suite 92/92 passing.

## Notes
- `engaged_member` (comments) and `well_liked` (likes) badges sit dormant until counter sources are wired in — tracked in follow-up issue #142 (Chatter-side comment count, page-counter likes).
- "Featured Creator" badge wiring is left to #115's PR (cross-feature dependency, noted in both issues).

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)