### PR TITLE
feat(badges): wire likes-received counter to Chatter, gate comments (#142)

### DIFF
--- a/stacks/projects-api/projects_api/badge_counter_cache.py
+++ b/stacks/projects-api/projects_api/badge_counter_cache.py
@@ -1,0 +1,103 @@
+"""TTL cache for badge-counter values fetched from external services.
+
+Issue #142: ``_count_likes_received`` and ``_count_comments`` in
+``badges.py`` need to call Chatter to get live numbers. Without a cache,
+every project-create would fan out an HTTP call to Chatter per project
+the user owns (likes are queried per-URL), which is wasteful given that
+badge thresholds rarely change second-to-second.
+
+Design
+------
+
+* In-process dict keyed by ``(username, kind)`` where ``kind`` is the
+  badge ``threshold_type`` (``"likes_received"`` or ``"comments"``).
+* Each entry stores ``(value, fetched_at_monotonic)``.
+* On lookup:
+    - MISS (no entry): call the fetch coroutine, store, return.
+    - HIT within TTL: return cached value, no fetch.
+    - HIT but stale: re-fetch; if the fetch raises or returns ``None``,
+      return the stale value rather than 0 (graceful degradation per the
+      issue's acceptance criteria — "if either external service is down,
+      evaluation returns the previously-cached value rather than 500-ing").
+* TTL comes from ``settings.badge_counter_cache_ttl_seconds`` (default
+  300s) and is read on every call so a tweak via env var takes effect
+  without a restart of this module.
+
+Scope
+-----
+
+Projects-api runs as a single container per Pi today and the badge
+catalog is small, so a process-local dict is sufficient. If we ever
+scale to multiple workers per Pi or want cross-Pi consistency the cache
+can be swapped for Redis with the same coroutine signature; no caller
+needs to change.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Awaitable, Callable, Optional
+
+from .config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+# (username, kind) -> (value, fetched_at_monotonic)
+_CACHE: dict[tuple[str, str], tuple[int, float]] = {}
+
+
+FetchFn = Callable[[], Awaitable[Optional[int]]]
+
+
+async def get_cached_counter(
+    username: str,
+    kind: str,
+    fetch: FetchFn,
+) -> int:
+    """Return the cached counter value, fetching via ``fetch`` if needed.
+
+    ``fetch`` is a zero-arg coroutine that returns the freshly-computed
+    integer, or ``None`` if the external lookup failed. The cache uses
+    ``time.monotonic`` so timestamps are immune to wall-clock jumps.
+
+    Stale-on-error semantics: if a refresh fails (``fetch`` raises or
+    returns ``None``), the previous cached value is returned. If there
+    is no previous value and the fetch fails, the cache stays empty and
+    we return 0 — this is the "first call ever, service down" case;
+    nothing better we can do.
+    """
+    settings = get_settings()
+    ttl = max(0, int(settings.badge_counter_cache_ttl_seconds))
+    now = time.monotonic()
+    key = (username, kind)
+    cached = _CACHE.get(key)
+
+    if cached is not None and (now - cached[1]) < ttl:
+        return cached[0]
+
+    # Either MISS or stale — try to refresh.
+    try:
+        fresh = await fetch()
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.warning(
+            "Badge counter fetch raised for (%s, %s): %s — using stale value",
+            username, kind, exc,
+        )
+        fresh = None
+
+    if fresh is None:
+        if cached is not None:
+            # Graceful degradation: return last good value without
+            # advancing the timestamp, so we'll try again next call.
+            return cached[0]
+        return 0
+
+    _CACHE[key] = (int(fresh), now)
+    return int(fresh)
+
+
+def clear_badge_counter_cache() -> None:
+    """Drop all cached counter values. Intended for tests."""
+    _CACHE.clear()

--- a/stacks/projects-api/projects_api/badges.py
+++ b/stacks/projects-api/projects_api/badges.py
@@ -17,13 +17,22 @@ Data sources used by the evaluator
 ----------------------------------
 
 projects-api owns ``projects``, ``makes``, ``downloads`` and remix
-attribution. It does NOT own comments or likes — those live in Chatter /
-the page-counter service. To keep this PR additive and synchronous, the
-"comments" and "likes" badges are *defined* (so the gallery shows them as
-goals) but their evaluator simply counts what we have access to; both
-return 0 today so those badges are never awarded yet. They will start
-being awarded automatically once the comments / likes data lands in
-projects-api or once we add a cross-service lookup.
+attribution. Comments and likes live in Chatter, not in projects-api.
+As of issue #142 the evaluator reads those counters from Chatter over
+HTTP via a 5-minute TTL cache (see ``badge_counter_cache``):
+
+* **likes_received** — for each non-archived project the user owns we
+  hit ``GET {chatter}/interact/likes/{encoded_url}`` (same shape the
+  frontend ``getLikeCount`` uses) and sum ``count``. Per-URL failures
+  are treated as 0; total fan-out is bounded to 5 in-flight requests.
+
+* **comments** — Chatter does NOT yet expose a per-user comment-count
+  endpoint. The counter is gated on the
+  ``CHATTER_USER_COMMENTS_ENDPOINT`` config: when empty (default) it
+  returns 0 and the Engaged Member badges remain dormant; when set to a
+  path template like ``"/api/users/{username}/comments_count"`` it
+  fetches and returns ``count`` from that endpoint. Flipping the env
+  var is the only change needed once the Chatter endpoint ships.
 
 Tiered families
 ---------------
@@ -38,15 +47,20 @@ threshold check.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Optional
+from urllib.parse import quote
 
+import httpx
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .badge_counter_cache import get_cached_counter
+from .config import get_settings
 from .models import BadgeDefinition, Download, Make, Project, UserBadge
 from .schemas import EarnedBadgeResponse
 
@@ -407,17 +421,184 @@ async def _count_remixes_created(session: AsyncSession, username: str) -> int:
     return int(val or 0)
 
 
+# Hard cap on simultaneous in-flight per-project like-count requests so a
+# user with 50+ projects doesn't fan out 50 concurrent HTTP calls during a
+# single evaluate_user() run.
+_LIKES_FETCH_CONCURRENCY = 5
+
+
+def _project_like_url_key(project_id: int) -> str:
+    """The exact string the frontend uses as the like-count key.
+
+    See ``web/assets/js/project-search.js`` (hub cards) and
+    ``web/projects/view.html`` — both build the key as
+    ``'projects/view.html?id=' + p.id`` with no leading slash and no
+    domain. Chatter stores likes against that key, so we MUST use the
+    same shape here or we'll read a different bucket and always see 0.
+    """
+    return f"projects/view.html?id={project_id}"
+
+
+async def _fetch_likes_for_url(
+    http: httpx.AsyncClient,
+    base_url: str,
+    project_url_key: str,
+) -> int:
+    """GET ``{base_url}/interact/likes/{encoded}`` and return ``count``.
+
+    Per-URL failures (HTTP 5xx, parsing, timeout) are downgraded to 0 so
+    one flaky project doesn't poison the whole sum. The caller is
+    responsible for treating a complete Chatter outage (every call
+    raises) via the cache layer's stale-on-error fallback.
+    """
+    encoded = quote(project_url_key, safe="")
+    url = f"{base_url.rstrip('/')}/interact/likes/{encoded}"
+    try:
+        resp = await http.get(url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Chatter likes lookup failed for %s: %s", project_url_key, exc)
+        raise
+    if resp.status_code != 200:
+        logger.warning(
+            "Chatter likes lookup returned %s for %s — treating as 0",
+            resp.status_code, project_url_key,
+        )
+        return 0
+    try:
+        data = resp.json()
+    except ValueError:
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    return int(data.get("count") or 0)
+
+
+async def _fetch_likes_received(session: AsyncSession, username: str) -> Optional[int]:
+    """Sum likes across all of ``username``'s non-archived projects.
+
+    Returns ``None`` if Chatter is fully unreachable (every per-project
+    call raised) — the cache layer uses ``None`` as the signal to fall
+    back to the previously-cached value. Returns an int (possibly 0)
+    otherwise.
+    """
+    project_ids = (
+        await session.scalars(
+            select(Project.id).where(
+                Project.author_username == username,
+                Project.status != "archived",
+                Project.is_blocked.is_(False),
+            )
+        )
+    ).all()
+    if not project_ids:
+        return 0
+
+    settings = get_settings()
+    base_url = settings.chatter_base_url
+    sem = asyncio.Semaphore(_LIKES_FETCH_CONCURRENCY)
+
+    async with httpx.AsyncClient(timeout=3.0) as http:
+        async def one(pid: int) -> tuple[bool, int]:
+            """Return (succeeded, count). succeeded=False if the HTTP
+            request raised so the caller can decide what 'service down'
+            means in aggregate."""
+            async with sem:
+                try:
+                    count = await _fetch_likes_for_url(
+                        http, base_url, _project_like_url_key(pid)
+                    )
+                    return True, count
+                except Exception:  # noqa: BLE001
+                    return False, 0
+
+        results = await asyncio.gather(*(one(pid) for pid in project_ids))
+
+    if not any(ok for ok, _ in results):
+        # Every single per-project call raised — treat as Chatter being
+        # fully down and signal the cache to use the stale value.
+        logger.warning(
+            "Chatter likes fully unreachable for user %s (%d projects)",
+            username, len(project_ids),
+        )
+        return None
+
+    return sum(count for _ok, count in results)
+
+
+async def _fetch_user_comments_count(username: str) -> Optional[int]:
+    """Ask Chatter how many comments ``username`` has posted overall.
+
+    Returns 0 when ``chatter_user_comments_endpoint`` is unset (the
+    default, current production state — no such endpoint exists on
+    Chatter yet). Returns the parsed integer when the endpoint is
+    configured and responds 200 with ``{"count": int}``. Returns
+    ``None`` on network failure so the cache falls back to the stale
+    value.
+    """
+    settings = get_settings()
+    template = settings.chatter_user_comments_endpoint
+    if not template:
+        # Endpoint not configured — current production reality. Engaged
+        # Member badges remain dormant by design until Chatter ships a
+        # per-user comments-count endpoint and ops sets this env var.
+        return 0
+
+    path = template.format(username=quote(username, safe=""))
+    url = f"{settings.chatter_base_url.rstrip('/')}{path}"
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as http:
+            resp = await http.get(url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Chatter comments-count lookup failed for %s: %s", username, exc)
+        return None
+    if resp.status_code != 200:
+        logger.warning(
+            "Chatter comments-count returned %s for %s", resp.status_code, username,
+        )
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    raw = data.get("count")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 async def _count_comments(session: AsyncSession, username: str) -> int:
-    # No local comments table — comments live in Chatter. Return 0 so the
-    # Engaged Member badges are defined-but-never-awarded for now. When a
-    # comments source lands, swap this for the real count.
-    return 0
+    """Comments-posted counter for the Engaged Member badges.
+
+    Reads through the badge counter cache (5 min TTL). The underlying
+    fetch hits a Chatter endpoint whose path is configured via
+    ``chatter_user_comments_endpoint``; when unset (default) the fetch
+    returns 0 and these badges remain dormant.
+    """
+    return await get_cached_counter(
+        username,
+        "comments",
+        lambda: _fetch_user_comments_count(username),
+    )
 
 
 async def _count_likes_received(session: AsyncSession, username: str) -> int:
-    # No local likes table — likes are tracked by the page-counter service.
-    # Same treatment as comments above.
-    return 0
+    """Likes-received counter for the Well Liked badges.
+
+    Reads through the badge counter cache (5 min TTL). The underlying
+    fetch lists the user's non-archived projects from the local DB then
+    fans out (bounded concurrency) to Chatter's per-URL like-count
+    endpoint, summing the results.
+    """
+    return await get_cached_counter(
+        username,
+        "likes_received",
+        lambda: _fetch_likes_received(session, username),
+    )
 
 
 async def _consecutive_months_with_project(

--- a/stacks/projects-api/projects_api/config.py
+++ b/stacks/projects-api/projects_api/config.py
@@ -41,6 +41,19 @@ class Settings(BaseSettings):
     # account-age gate to look up `account_created_at` from `/api/me`.
     chatter_base_url: str = "https://chatter.kevsrobots.com"
 
+    # Path template (under chatter_base_url) for fetching the total number
+    # of comments a given user has posted across the community. Empty by
+    # default because Chatter does not currently expose such an endpoint
+    # (see badges.py `_count_comments`). When Chatter ships one, set this
+    # to e.g. "/api/users/{username}/comments_count" and the Engaged Member
+    # badges will start awarding automatically — no code change needed.
+    chatter_user_comments_endpoint: str = ""
+
+    # TTL (seconds) for the in-process per-(username, kind) badge counter
+    # cache that wraps external HTTP lookups. 5 minutes balances badge
+    # awarding latency against fan-out load on Chatter.
+    badge_counter_cache_ttl_seconds: int = 300
+
     # NAS storage
     nas_host: str = "192.168.1.79"
     nas_username: Optional[str] = None

--- a/stacks/projects-api/tests/test_badge_counters.py
+++ b/stacks/projects-api/tests/test_badge_counters.py
@@ -1,0 +1,301 @@
+"""Tests for the external badge counters wired in issue #142.
+
+Covers:
+* Likes-received sums across the user's projects.
+* A single project's Chatter call failing (5xx) is treated as 0 but
+  doesn't kill the rest of the sum.
+* The cache prevents a second HTTP call within TTL.
+* When Chatter is fully down and the cache has a stale value, the stale
+  value is returned (graceful degradation).
+* Comments counter returns 0 with no HTTP call when the config endpoint
+  is empty (current production state).
+* Comments counter calls the configured endpoint when set and parses
+  the count.
+* Threshold-crossing integration: with mocked likes returning >= 10,
+  Alice crosses ``well_liked_bronze`` after ``evaluate_user``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+import pytest
+
+from projects_api import badge_counter_cache, badges as badges_module
+from projects_api.badge_counter_cache import clear_badge_counter_cache
+from projects_api.badges import (
+    _count_comments,
+    _count_likes_received,
+    evaluate_user,
+    seed_badge_definitions,
+)
+from projects_api.models import Project
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for ``httpx.AsyncClient`` used in tests.
+
+    Routes are matched by full URL substring; the first matching rule
+    wins. Each rule may be a callable (called with the URL — useful for
+    raising) or a ``_FakeResponse``.
+    """
+
+    def __init__(self, routes: list[tuple[str, Any]]) -> None:
+        self._routes = routes
+        self.calls: list[str] = []
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def get(self, url: str) -> _FakeResponse:
+        self.calls.append(url)
+        for needle, rule in self._routes:
+            if needle in url:
+                if callable(rule):
+                    return rule(url)
+                return rule
+        raise AssertionError(f"No fake route matched {url}")
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeAsyncClient) -> None:
+    """Replace ``httpx.AsyncClient`` inside badges.py with ``fake``.
+
+    We patch the symbol on the badges module specifically (not globally
+    on httpx) so unrelated httpx usage in the rest of the test suite is
+    untouched. The fake ignores the timeout kwarg badges.py passes.
+    """
+
+    def _factory(*_args: Any, **_kwargs: Any) -> _FakeAsyncClient:
+        return fake
+
+    monkeypatch.setattr(badges_module.httpx, "AsyncClient", _factory)
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter_cache() -> None:
+    """Drop the in-process counter cache before every test in this file."""
+    clear_badge_counter_cache()
+    yield
+    clear_badge_counter_cache()
+
+
+# ---------------------------------------------------------------------------
+# Likes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_likes_sums_across_projects(session, monkeypatch) -> None:
+    """Three projects, Chatter returns 3 / 4 / 5 — total should be 12."""
+    from sqlalchemy import select as _select
+
+    for title in ("A", "B", "C"):
+        session.add(Project(title=title, status="wip", author_username="alice"))
+    await session.commit()
+    project_ids = (
+        await session.scalars(
+            _select(Project.id).where(Project.author_username == "alice")
+        )
+    ).all()
+    assert len(project_ids) == 3
+
+    # URLs from badges.py are percent-encoded so `=` becomes `%3D`.
+    counts = {f"id%3D{pid}": n for pid, n in zip(project_ids, [3, 4, 5])}
+
+    def _route(url: str) -> _FakeResponse:
+        for key, count in counts.items():
+            if key in url:
+                return _FakeResponse(200, {"count": count})
+        return _FakeResponse(200, {"count": 0})
+
+    fake = _FakeAsyncClient([("/interact/likes/", _route)])
+    _install_fake_client(monkeypatch, fake)
+
+    total = await _count_likes_received(session, "alice")
+    assert total == 12
+    # One call per project.
+    assert len(fake.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_likes_single_500_does_not_kill_sum(session, monkeypatch) -> None:
+    """One project's Chatter call 500s — the other two still sum."""
+    from sqlalchemy import select as _select
+
+    for title in ("A", "B", "C"):
+        session.add(Project(title=title, status="wip", author_username="alice"))
+    await session.commit()
+    project_ids = (
+        await session.scalars(
+            _select(Project.id).where(Project.author_username == "alice")
+        )
+    ).all()
+    p_ok1, p_bad, p_ok2 = sorted(project_ids)
+
+    def _route(url: str) -> _FakeResponse:
+        if f"id%3D{p_bad}" in url:
+            return _FakeResponse(500, {})
+        return _FakeResponse(200, {"count": 7})
+
+    fake = _FakeAsyncClient([("/interact/likes/", _route)])
+    _install_fake_client(monkeypatch, fake)
+
+    total = await _count_likes_received(session, "alice")
+    # 7 + 0 (the 500) + 7 = 14
+    assert total == 14
+
+
+@pytest.mark.asyncio
+async def test_likes_cache_hit_avoids_http(session, monkeypatch) -> None:
+    """Second call within TTL must not touch the network."""
+    session.add(Project(title="A", status="wip", author_username="alice"))
+    await session.commit()
+
+    fake = _FakeAsyncClient([
+        ("/interact/likes/", _FakeResponse(200, {"count": 9})),
+    ])
+    _install_fake_client(monkeypatch, fake)
+
+    first = await _count_likes_received(session, "alice")
+    assert first == 9
+    assert len(fake.calls) == 1
+
+    # Second call: cache should serve, fake stays untouched.
+    second = await _count_likes_received(session, "alice")
+    assert second == 9
+    assert len(fake.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_likes_stale_returned_when_chatter_down(session, monkeypatch) -> None:
+    """First call seeds the cache; then Chatter goes fully down and the
+    cache expires — the stale value must still be returned rather than 0."""
+    session.add(Project(title="A", status="wip", author_username="alice"))
+    await session.commit()
+
+    fake_ok = _FakeAsyncClient([
+        ("/interact/likes/", _FakeResponse(200, {"count": 42})),
+    ])
+    _install_fake_client(monkeypatch, fake_ok)
+
+    first = await _count_likes_received(session, "alice")
+    assert first == 42
+
+    # Force the cache to look stale by patching the cache module's
+    # settings reader to return TTL=0 (so any cached entry is considered
+    # expired and a re-fetch is attempted).
+    from projects_api import config as config_module
+
+    real_get = config_module.get_settings
+
+    def _zero_ttl_settings():
+        return real_get().model_copy(update={"badge_counter_cache_ttl_seconds": 0})
+
+    monkeypatch.setattr(badge_counter_cache, "get_settings", _zero_ttl_settings)
+
+    # Now Chatter is unreachable: every call raises.
+    def _boom(url: str) -> _FakeResponse:
+        raise httpx.ConnectError("connection refused")
+
+    fake_down = _FakeAsyncClient([("/interact/likes/", _boom)])
+    _install_fake_client(monkeypatch, fake_down)
+
+    second = await _count_likes_received(session, "alice")
+    assert second == 42, "should return stale cached value, not 0"
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comments_default_returns_zero_no_http(session, monkeypatch) -> None:
+    """With ``chatter_user_comments_endpoint`` unset (default), the counter
+    returns 0 without ever touching the network."""
+    called: list[str] = []
+
+    def _track(url: str) -> _FakeResponse:
+        called.append(url)
+        return _FakeResponse(200, {"count": 999})
+
+    fake = _FakeAsyncClient([("", _track)])
+    _install_fake_client(monkeypatch, fake)
+
+    n = await _count_comments(session, "alice")
+    assert n == 0
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_comments_calls_configured_endpoint(session, monkeypatch) -> None:
+    """When ``chatter_user_comments_endpoint`` is set, the counter calls
+    it with the username substituted in and returns the parsed count."""
+    from projects_api import config as config_module
+
+    real_get = config_module.get_settings
+
+    def _with_endpoint():
+        s = real_get()
+        return s.model_copy(update={
+            "chatter_user_comments_endpoint": "/api/users/{username}/comments_count",
+            "badge_counter_cache_ttl_seconds": 300,
+        })
+
+    monkeypatch.setattr(badges_module, "get_settings", _with_endpoint)
+    monkeypatch.setattr(badge_counter_cache, "get_settings", _with_endpoint)
+
+    fake = _FakeAsyncClient([
+        ("/api/users/alice/comments_count", _FakeResponse(200, {"count": 17})),
+    ])
+    _install_fake_client(monkeypatch, fake)
+
+    n = await _count_comments(session, "alice")
+    assert n == 17
+    assert any("alice/comments_count" in c for c in fake.calls)
+
+
+# ---------------------------------------------------------------------------
+# Integration with evaluate_user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_well_liked_bronze_awarded_when_likes_cross_threshold(
+    session, monkeypatch
+) -> None:
+    """Mocked Chatter returns 10 likes for Alice's one project — running
+    the evaluator should award ``well_liked_bronze`` (threshold 10)."""
+    await seed_badge_definitions(session)
+
+    session.add(Project(title="A", status="wip", author_username="alice"))
+    await session.commit()
+
+    fake = _FakeAsyncClient([
+        ("/interact/likes/", _FakeResponse(200, {"count": 10})),
+    ])
+    _install_fake_client(monkeypatch, fake)
+
+    awarded = await evaluate_user(session, "alice")
+    slugs = {b.slug for b in awarded}
+    assert "well_liked_bronze" in slugs
+    # And the silver tier (50) should NOT have been awarded with only 10.
+    assert "well_liked_silver" not in slugs


### PR DESCRIPTION
## Summary
Wires the dormant `engaged_member_*` and `well_liked_*` badges from #106 to real counter sources, with a 5-minute TTL cache and stale-on-error fallback.

- **Likes-received**: aggregates per-project likes via Chatter's existing `/interact/likes/{encoded_url}` endpoint (the same source the frontend uses in `web/assets/js/project-interactions.js`). Concurrency-capped fan-out — graceful when individual per-URL calls 500.
- **Comments**: flag-gated behind a new `chatter_user_comments_endpoint` config field. Empty (default) → behaviour unchanged (returns 0). Set to a URL template like `/api/users/{username}/comments_count` → real counts via Chatter. The `engaged_member_*` badges stay dormant by design until the Chatter-side endpoint ships (tracked separately).
- **Cache layer**: new `badge_counter_cache.py`. In-memory `(username, kind) → (count, monotonic_ts)` with TTL from `settings.badge_counter_cache_ttl_seconds` (default 300s). Stale-on-error means Chatter going down doesn't 500 the eval path.
- **Tests**: 7 new test cases in `tests/test_badge_counters.py`. Full suite 167/167 passing.

## Notes
- Issue body originally said likes live in page-counter at `:8005` — that was incorrect; the page-counter service tracks views only. Both counter sources actually live in Chatter. The implementation reflects reality.
- The Chatter-side `/api/users/{username}/comments_count` endpoint **must still be added** on the Chatter codebase (separate repo). Once it ships and `CHATTER_USER_COMMENTS_ENDPOINT` is set in projects-api's env, the Engaged Member badges start awarding automatically.
- No DB migrations, no frontend changes — purely backend & additive.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)