### PR TITLE
feat(home): featured projects widget on welcome page (#153)

### DIFF
--- a/web/_includes/featured_projects_home.html
+++ b/web/_includes/featured_projects_home.html
@@ -1,0 +1,53 @@
+<!-- Featured projects widget for the welcome page (issue #153).
+     Renders up to 6 admin-curated projects in a Bootstrap grid.
+     Curation lives in /admin/projects/featured/ (already shipped in
+     #115/#155); this widget is read-only and consumes the public
+     GET /api/projects/featured endpoint.
+
+     Fails closed: if the projects API is unreachable or returns an
+     empty list, the entire section stays hidden — never an empty
+     placeholder on the home page. -->
+
+<link rel="stylesheet" href="/assets/css/featured-projects.css?v={{ site.time | date: '%s' }}">
+
+<section id="home-featured-section" class="row mt-3 m-0 p-3 mb-3 rounded-1 bg-light d-none">
+  <div class="col-12">
+    <div class="d-flex align-items-center justify-content-between mb-3 flex-wrap gap-2">
+      <div>
+        <h2 class="mb-0"><i class="fas fa-star text-warning me-3"></i>Featured Projects</h2>
+        <p class="text-muted mb-0">Hand-picked by the team.</p>
+      </div>
+      <a href="/projects/staff-picks/" class="btn btn-outline-dark btn-sm">
+        Browse Staff Picks <i class="fas fa-arrow-right ms-1"></i>
+      </a>
+    </div>
+
+    <div id="home-featured-grid" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3"></div>
+  </div>
+</section>
+
+<script src="/assets/js/featured-projects.js?v={{ site.time | date: '%s' }}"></script>
+<script>
+(function () {
+  'use strict';
+  var section = document.getElementById('home-featured-section');
+  var grid = document.getElementById('home-featured-grid');
+  if (!section || !grid || !window.FeaturedProjects) return;
+
+  window.FeaturedProjects.load({ limit: 6 })
+    .then(function (items) {
+      if (!Array.isArray(items) || items.length === 0) {
+        // Empty list — leave the section hidden; nothing to show.
+        return;
+      }
+      grid.innerHTML = items.map(function (p) {
+        return '<div class="col">' + window.FeaturedProjects.cardHtml(p) + '</div>';
+      }).join('');
+      section.classList.remove('d-none');
+    })
+    .catch(function () {
+      // Network / API error — keep the section hidden so a broken API
+      // never breaks the home page. Intentionally no console.error.
+    });
+})();
+</script>

--- a/web/_includes/welcome_page.html
+++ b/web/_includes/welcome_page.html
@@ -2,6 +2,7 @@
     <div class="col-12">{% include welcome_section.html %}</div>
     <div class="col-12">{% include robots_banner.html %}</div>
     <div class="col-12">{% include tags_and_recent.html %}</div>
+    <div class="col-12">{% include featured_projects_home.html %}</div>
     <div class="col-12">{% include blog_section.html %}</div>
     <div class="col-12">{% include how_it_works_section.html %}</div>
     <div class="col-12">{% include robots_section.html %}</div>

--- a/web/assets/css/featured-projects.css
+++ b/web/assets/css/featured-projects.css
@@ -126,6 +126,28 @@
   overflow: hidden;
 }
 
+/* Home-page featured projects widget (issue #153).
+ * The widget uses a Bootstrap grid instead of the carousel's horizontal
+ * shelf, so the same .project-thumb / .featured-note rules need to
+ * apply outside the .featured-carousel-card wrapper. */
+#home-featured-grid .project-thumb {
+  height: 180px;
+  object-fit: cover;
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+#home-featured-grid .featured-note {
+  font-size: 0.8rem;
+  font-style: italic;
+  color: #6c757d;
+  margin-top: 0.25rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Admin feature toggle row -------------------------------------------- */
 
 .admin-feature-row .feature-note-input {

--- a/web/assets/js/featured-projects.js
+++ b/web/assets/js/featured-projects.js
@@ -7,6 +7,9 @@
  *     image wrapper.
  *   - badge(note): returns the inline "Staff Pick" badge for the view
  *     page header. Encodes ``note`` for the tooltip safely.
+ *   - cardHtml(project): returns the inner card HTML for a single
+ *     featured project (no wrapper). Shared by the hub carousel and the
+ *     home-page widget (issue #153) so both stay in visual lock-step.
  *   - mountCarousel(container, projects): renders a scrollable shelf of
  *     featured cards into a container. Returns true when at least one
  *     card was rendered so the caller can `classList.remove('d-none')`
@@ -63,7 +66,10 @@
     return 'background:linear-gradient(135deg,hsl(' + hue + ',70%,55%),hsl(' + ((hue + 60) % 360) + ',70%,45%));';
   }
 
-  function carouselCardHtml(project) {
+  // Inner card HTML for one featured project (no outer wrapper). Shared
+  // between the hub carousel and the home-page widget (issue #153) so the
+  // visual treatment stays consistent in both surfaces.
+  function cardHtml(project) {
     // Issue #152: prefer canonical /projects/<owner>/<slug> URL when the
     // FeaturedProjectResponse surfaced a slug.
     var href = (project.slug && project.author_username)
@@ -72,20 +78,22 @@
     var note = project.featured_note ? '<div class="featured-note">' + esc(project.featured_note) + '</div>' : '';
     var author = project.author_username ? esc(project.author_username) : '';
     return (
-      '<div class="featured-carousel-card">' +
-        '<a href="' + href + '" class="text-decoration-none">' +
-          '<div class="card border-0 shadow-sm card-hover">' +
-            ribbon('Featured') +
-            '<div class="project-thumb" style="' + cardThumbStyle(project) + '"></div>' +
-            '<div class="card-body">' +
-              '<div class="fw-bold text-dark text-truncate" title="' + esc(project.title) + '">' + esc(project.title) + '</div>' +
-              (author ? '<div class="small text-muted">by ' + author + '</div>' : '') +
-              note +
-            '</div>' +
+      '<a href="' + href + '" class="text-decoration-none">' +
+        '<div class="card h-100 border-0 shadow-sm card-hover">' +
+          ribbon('Featured') +
+          '<div class="project-thumb" style="' + cardThumbStyle(project) + '"></div>' +
+          '<div class="card-body">' +
+            '<div class="fw-bold text-dark text-truncate" title="' + esc(project.title) + '">' + esc(project.title) + '</div>' +
+            (author ? '<div class="small text-muted">by ' + author + '</div>' : '') +
+            note +
           '</div>' +
-        '</a>' +
-      '</div>'
+        '</div>' +
+      '</a>'
     );
+  }
+
+  function carouselCardHtml(project) {
+    return '<div class="featured-carousel-card">' + cardHtml(project) + '</div>';
   }
 
   function mountCarousel(container, projects) {
@@ -120,6 +128,7 @@
     DEFAULT_API: DEFAULT_API,
     ribbon: ribbon,
     badge: badge,
+    cardHtml: cardHtml,
     mountCarousel: mountCarousel,
     load: load
   };


### PR DESCRIPTION
## Summary
Adds a "Featured Projects" section to the home page (`/`) — fetches up to 6 admin-curated featured projects from `GET /api/projects/featured` and renders them as a card grid above the blog section.

### Changes
- **`web/_includes/featured_projects_home.html`** (new) — widget markup + inline fetch. Bootstrap `row-cols-1/md-2/lg-3 g-3`, header with `fa-star me-3` icon + subtitle, "Browse Staff Picks" CTA.
- **`web/_includes/welcome_page.html`** — inserts the include between `tags_and_recent` and `blog_section`.
- **`web/assets/js/featured-projects.js`** — extracted shared `FeaturedProjects.cardHtml(project)`; the existing hub carousel `carouselCardHtml` now wraps `cardHtml`. Visuals on the carousel unchanged.
- **`web/assets/css/featured-projects.css`** — added `#home-featured-grid` selectors so gradient/cover-image thumbs and the italic editor note (previously scoped to the carousel) also apply on the home grid.

### Behaviour
- Cards link to canonical `/projects/<owner>/<slug>` URLs when the response includes a slug (#152), fall back to `?id=` otherwise.
- Empty list or fetch failure → section silently hides; no broken layout on the home page.
- Reuses `projectThumbnail()` from `project-gradient.js` for the no-cover-image fallback.

### Admin curate UI
Already shipped via #115 + #155: `/admin/projects/featured/` exposes the toggle + current-featured list, and is in `nav_admin.yml`. No new admin work needed.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)