### PR TITLE
feat(parts): community reports + merge proposals (#123)

### DIFF
--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -40,6 +40,7 @@ from .routers import (
     makes,
     moderation,
     parts,
+    parts_moderation,
     projects,
     remixes,
     staff_picks,
@@ -113,6 +114,13 @@ def create_app() -> FastAPI:
     app.include_router(links.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
+    # Issue #123: parts catalog moderation (reports + community merges).
+    # MUST be mounted BEFORE parts.router because that router's
+    # ``GET /api/parts/{slug}`` would otherwise eat
+    # ``/api/parts/merge-proposals`` (it'd resolve {slug}="merge-proposals"
+    # and 404). Mounting the moderation routes first lets FastAPI match
+    # the more-specific literal paths before the catch-all slug capture.
+    app.include_router(parts_moderation.router)
     app.include_router(parts.router)
     app.include_router(makes.router)
     # Issue #108: project remixes (fork & attribution).

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -492,6 +492,111 @@ class UserActivity(Base):
     )
 
 
+# --- Parts moderation: reports + merge proposals (issue #123, Phase 3) ---
+#
+# Two parallel community-moderation surfaces sit on top of the Phase 1/2
+# catalog:
+#
+#   * ``part_reports`` — anyone logged-in can flag a part as wrong / spam /
+#     duplicate / other. An admin works through the queue at
+#     ``/admin/parts/`` and accepts or dismisses each report. There is no
+#     account-age gate on reporting: we'd rather see noise from new
+#     accounts than miss spam they're trying to flag. The
+#     ``(part_id, resolved_at)`` index makes the "open reports for this
+#     part" and "queue of unresolved reports" queries cheap.
+#
+#   * ``part_merge_proposals`` + ``part_merge_votes`` — anyone with a
+#     14-day-old account can propose merging part A into part B, and any
+#     14-day-old account can vote approve / reject on the proposal. Auto-
+#     merge fires when the thresholds in
+#     ``routers/parts_moderation._check_merge_threshold`` are met. The
+#     proposer can withdraw their own proposal; admins can withdraw any.
+#     One open proposal per (source, target) pair is enforced at the
+#     application layer (the obvious partial-unique-index on
+#     ``WHERE resolved_at IS NULL`` is Postgres-only; we keep the gate in
+#     Python so SQLite tests behave identically).
+#
+# Brand-new tables — no ALTER helper needed; ``create_all`` builds them
+# on every Postgres deployment. SQLite tests pick them up the same way.
+
+
+class PartReport(Base):
+    __tablename__ = "part_reports"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part_id: Mapped[int] = mapped_column(
+        ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    reporter_username: Mapped[str] = mapped_column(String(100), nullable=False)
+    # reason: "spam" | "wrong" | "duplicate" | "other"
+    reason: Mapped[str] = mapped_column(String(20), nullable=False)
+    note: Mapped[Optional[str]] = mapped_column(String(500))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    resolved_by: Mapped[Optional[str]] = mapped_column(String(100))
+    # resolution: "accepted" | "dismissed" (NULL while open)
+    resolution: Mapped[Optional[str]] = mapped_column(String(20))
+
+    __table_args__ = (
+        # Speeds up both the admin queue (open reports: resolved_at IS NULL)
+        # and the per-part "do I have an open report against this?" probe.
+        Index("ix_part_reports_part_resolved", "part_id", "resolved_at"),
+    )
+
+
+class PartMergeProposal(Base):
+    __tablename__ = "part_merge_proposals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    source_part_id: Mapped[int] = mapped_column(
+        ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    target_part_id: Mapped[int] = mapped_column(
+        ForeignKey("parts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    proposer_username: Mapped[str] = mapped_column(String(100), nullable=False)
+    rationale: Mapped[str] = mapped_column(String(2000), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    # outcome: "merged" | "rejected" | "withdrawn" (NULL while open)
+    outcome: Mapped[Optional[str]] = mapped_column(String(20))
+
+    __table_args__ = (
+        # Sort the open-proposals list newest-first; the same index covers
+        # "all resolved proposals, recent first" too.
+        Index("ix_part_merge_proposals_resolved_created", "resolved_at", "created_at"),
+    )
+
+
+class PartMergeVote(Base):
+    __tablename__ = "part_merge_votes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    proposal_id: Mapped[int] = mapped_column(
+        ForeignKey("part_merge_proposals.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    voter_username: Mapped[str] = mapped_column(String(100), nullable=False)
+    # vote: "approve" | "reject"
+    vote: Mapped[str] = mapped_column(String(10), nullable=False)
+    voted_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        # One vote per voter per proposal — changing your mind UPDATEs the
+        # existing row (handled in the router).
+        UniqueConstraint(
+            "proposal_id", "voter_username", name="uq_part_merge_votes_proposal_voter"
+        ),
+    )
+
+
 class PartRevision(Base):
     __tablename__ = "part_revisions"
 

--- a/stacks/projects-api/projects_api/routers/parts_moderation.py
+++ b/stacks/projects-api/projects_api/routers/parts_moderation.py
@@ -1,0 +1,783 @@
+"""Parts moderation: reports + community merge proposals (issue #123).
+
+Sits beside the main ``parts.py`` router as a separate module because the
+moderation surface is wide enough (8 endpoints + a non-trivial auto-merge
+helper) that bolting it onto ``parts.py`` would push that file past 1k
+lines. The choice is purely cosmetic — both modules share the same
+``/api/parts`` prefix from the caller's perspective.
+
+Two sub-features:
+
+* **Reports** — anyone logged-in can flag a part with reason
+  ``spam | wrong | duplicate | other``. No 14-day account-age gate
+  applies here: noise from new accounts is cheaper than missing spam
+  they're trying to flag. One open report per (user, part) is enforced
+  in :func:`report_part`. Admins resolve from
+  ``GET /api/admin/parts/reports`` and ``PATCH …/reports/{id}``.
+
+* **Merge proposals** — anyone with a 14-day-old account can propose
+  merging ``source`` into ``target``. Anyone with a 14-day-old account
+  can vote ``approve`` or ``reject``; voters can change their mind by
+  re-POSTing (the unique constraint on ``(proposal_id, voter_username)``
+  upserts).
+
+Auto-merge rule (see :func:`_check_merge_threshold`)
+----------------------------------------------------
+A proposal triggers ``outcome=merged`` automatically when ALL of:
+
+1. ``approves >= 5``
+2. ``approves >= 2 * rejects`` (lopsided in favour)
+3. ``now - created_at >= 48h`` — gives the community a window to
+   express dissent before the vote auto-resolves.
+
+When that fires, :func:`_perform_merge` does the actual rewiring:
+
+* Every ``project_bom_items.part_id == source.id`` is repointed to
+  ``target.id`` and the two parts' ``usage_count`` is recomputed.
+* ``part_relations`` rows on either side of the source are rewritten
+  to the target (skipping any that would self-link or collide with an
+  existing relation on the target).
+* ``part_aliases`` rows are reparented to the target. The source's slug
+  and name are also added as aliases so future searches still find the
+  merged part.
+* ``part_suppliers`` rows are reparented (no dedup — duplicate URLs are
+  rare and harmless).
+* ``part_talk_threads`` rows are reparented **only if the table exists**
+  on this DB (issue #122 may not have landed yet on every deploy).
+* The source ``Part`` is then deleted; the FK on bom rows is already
+  pointing at the target so the cascade is clean.
+
+The 48h gate uses ``created_at`` rather than the first-vote timestamp
+because the proposer themselves is the implicit first approve in spirit
+— we want the door open for objections, not just for affirmations to
+pile up quickly.
+
+Cross-issue safety
+------------------
+This file references tables that may or may not exist on the live DB
+yet (e.g. ``part_talk_threads`` from issue #122 lands on a parallel
+branch). Every such read is wrapped in :func:`_table_exists` so a
+Postgres deploy that doesn't have the table yet doesn't 500 here.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import and_, delete, func, or_, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import get_current_user, get_current_user_aged, require_admin
+from ..db import get_session
+from ..models import (
+    Part,
+    PartAlias,
+    PartMergeProposal,
+    PartMergeVote,
+    PartRelation,
+    PartReport,
+    PartSupplier,
+    ProjectBOMItem,
+)
+from ..schemas import (
+    PART_MERGE_VOTES,
+    PART_REPORT_REASONS,
+    PART_REPORT_RESOLUTIONS,
+    PartMergePartRef,
+    PartMergeProposalCreate,
+    PartMergeProposalListResponse,
+    PartMergeProposalResponse,
+    PartMergeVoteCreate,
+    PartMergeVoteResponse,
+    PartReportCreate,
+    PartReportListResponse,
+    PartReportPartRef,
+    PartReportResolve,
+    PartReportResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["parts-moderation"])
+
+
+# --- helpers -----------------------------------------------------------
+
+
+MERGE_AUTO_APPROVES = 5  # absolute floor of approve votes
+MERGE_AUTO_RATIO = 2  # approves must be >= ratio * rejects
+MERGE_AUTO_MIN_AGE = timedelta(hours=48)
+
+
+def _now_naive_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _get_part_by_slug(session: AsyncSession, slug: str) -> Part:
+    part = await session.scalar(select(Part).where(Part.slug == slug))
+    if part is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Part not found")
+    return part
+
+
+def _part_ref(part: Part) -> PartMergePartRef:
+    return PartMergePartRef(
+        id=part.id, slug=part.slug, name=part.name, status=part.status
+    )
+
+
+def _report_part_ref(part: Part) -> PartReportPartRef:
+    return PartReportPartRef(
+        id=part.id, slug=part.slug, name=part.name, status=part.status
+    )
+
+
+async def _table_exists(session: AsyncSession, table_name: str) -> bool:
+    """Cross-dialect table-existence probe.
+
+    Used to guard reads against tables that come from other in-flight
+    issues (e.g. issue #122's ``part_talk_threads``) — they may not be
+    on the live DB yet. Postgres uses ``information_schema``; SQLite
+    uses ``sqlite_master``. On any dialect we don't know, return False
+    and let the caller skip that step.
+    """
+    bind = session.get_bind()
+    dialect = bind.dialect.name if bind is not None else ""
+    try:
+        if dialect == "postgresql":
+            row = await session.execute(
+                text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = current_schema() AND table_name = :t"
+                ),
+                {"t": table_name},
+            )
+        else:
+            # SQLite (used by tests) — sqlite_master always exists.
+            row = await session.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:t"),
+                {"t": table_name},
+            )
+        return row.first() is not None
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("table_exists probe failed for %s: %s", table_name, exc)
+        return False
+
+
+async def _count_votes(
+    session: AsyncSession, proposal_id: int
+) -> tuple[int, int]:
+    """Return ``(approves, rejects)`` for a proposal."""
+    rows = (
+        await session.execute(
+            select(PartMergeVote.vote, func.count(PartMergeVote.id))
+            .where(PartMergeVote.proposal_id == proposal_id)
+            .group_by(PartMergeVote.vote)
+        )
+    ).all()
+    approves = 0
+    rejects = 0
+    for vote_kind, n in rows:
+        if vote_kind == "approve":
+            approves = int(n)
+        elif vote_kind == "reject":
+            rejects = int(n)
+    return approves, rejects
+
+
+async def _proposal_response(
+    session: AsyncSession, proposal: PartMergeProposal
+) -> PartMergeProposalResponse:
+    source = await session.get(Part, proposal.source_part_id)
+    target = await session.get(Part, proposal.target_part_id)
+    approves, rejects = await _count_votes(session, proposal.id)
+    # If a side of the merge has been deleted (e.g. after an admin force-
+    # delete), surface a synthetic ref so the UI doesn't crash. Real
+    # source/target rows are the common case.
+    if source is None:
+        source_ref = PartMergePartRef(
+            id=proposal.source_part_id, slug="", name="(deleted)", status="merged"
+        )
+    else:
+        source_ref = _part_ref(source)
+    if target is None:
+        target_ref = PartMergePartRef(
+            id=proposal.target_part_id, slug="", name="(deleted)", status="merged"
+        )
+    else:
+        target_ref = _part_ref(target)
+    return PartMergeProposalResponse(
+        id=proposal.id,
+        proposer_username=proposal.proposer_username,
+        rationale=proposal.rationale,
+        created_at=proposal.created_at,
+        resolved_at=proposal.resolved_at,
+        outcome=proposal.outcome,
+        source=source_ref,
+        target=target_ref,
+        approves=approves,
+        rejects=rejects,
+    )
+
+
+# --- Reports -----------------------------------------------------------
+
+
+@router.post(
+    "/api/parts/{slug}/report",
+    response_model=PartReportResponse,
+    status_code=201,
+)
+async def report_part(
+    slug: str,
+    body: PartReportCreate,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> PartReportResponse:
+    """Flag a part. No 14-day account-age gate here (see module docstring)."""
+    part = await _get_part_by_slug(session, slug)
+    if body.reason not in PART_REPORT_REASONS:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"Reason must be one of {PART_REPORT_REASONS}",
+        )
+
+    # One open report per user-per-part. Re-opening after an admin
+    # resolved a prior report is fine — only ``resolved_at IS NULL``
+    # blocks the new write.
+    existing = await session.scalar(
+        select(PartReport.id).where(
+            PartReport.part_id == part.id,
+            PartReport.reporter_username == user,
+            PartReport.resolved_at.is_(None),
+        )
+    )
+    if existing is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="You already have an open report on this part",
+        )
+
+    note = (body.note or "").strip() or None
+    report = PartReport(
+        part_id=part.id,
+        reporter_username=user,
+        reason=body.reason,
+        note=note,
+        created_at=_now_naive_utc(),
+    )
+    session.add(report)
+    await session.commit()
+    await session.refresh(report)
+    return PartReportResponse(
+        id=report.id,
+        part_id=report.part_id,
+        reporter_username=report.reporter_username,
+        reason=report.reason,
+        note=report.note,
+        created_at=report.created_at,
+        resolved_at=report.resolved_at,
+        resolved_by=report.resolved_by,
+        resolution=report.resolution,
+    )
+
+
+@router.get(
+    "/api/admin/parts/reports",
+    response_model=PartReportListResponse,
+)
+async def list_part_reports(
+    status_filter: str = Query(default="open", alias="status", pattern=r"^(open|resolved)$"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    admin: str = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> PartReportListResponse:
+    """Admin queue: open reports (default) or already-resolved history."""
+    base = select(PartReport)
+    count_q = select(func.count(PartReport.id))
+    if status_filter == "open":
+        base = base.where(PartReport.resolved_at.is_(None))
+        count_q = count_q.where(PartReport.resolved_at.is_(None))
+    else:
+        base = base.where(PartReport.resolved_at.is_not(None))
+        count_q = count_q.where(PartReport.resolved_at.is_not(None))
+
+    total = int((await session.execute(count_q)).scalar_one() or 0)
+    base = (
+        base.order_by(PartReport.created_at.desc(), PartReport.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await session.scalars(base)).all()
+
+    # Bulk-fetch the parts so we don't N+1 the queue render.
+    part_ids = sorted({r.part_id for r in rows})
+    parts_by_id: dict[int, Part] = {}
+    if part_ids:
+        parts = (
+            await session.scalars(select(Part).where(Part.id.in_(part_ids)))
+        ).all()
+        parts_by_id = {p.id: p for p in parts}
+
+    items: list[PartReportResponse] = []
+    for r in rows:
+        part = parts_by_id.get(r.part_id)
+        items.append(
+            PartReportResponse(
+                id=r.id,
+                part_id=r.part_id,
+                reporter_username=r.reporter_username,
+                reason=r.reason,
+                note=r.note,
+                created_at=r.created_at,
+                resolved_at=r.resolved_at,
+                resolved_by=r.resolved_by,
+                resolution=r.resolution,
+                part=_report_part_ref(part) if part is not None else None,
+            )
+        )
+    return PartReportListResponse(items=items, total=total)
+
+
+@router.patch(
+    "/api/admin/parts/reports/{report_id}",
+    response_model=PartReportResponse,
+)
+async def resolve_part_report(
+    report_id: int,
+    body: PartReportResolve,
+    admin: str = Depends(require_admin),
+    session: AsyncSession = Depends(get_session),
+) -> PartReportResponse:
+    """Admin: accept or dismiss a report.
+
+    Idempotent on already-resolved rows: re-PATCHing flips the resolution
+    in place but keeps the original ``resolved_at`` / ``resolved_by`` so
+    we don't lose the audit trail. (In practice the UI only offers this
+    action on open reports.)
+    """
+    report = await session.get(PartReport, report_id)
+    if report is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Report not found")
+    if body.resolution not in PART_REPORT_RESOLUTIONS:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"resolution must be one of {PART_REPORT_RESOLUTIONS}",
+        )
+
+    if report.resolved_at is None:
+        report.resolved_at = _now_naive_utc()
+        report.resolved_by = admin
+    report.resolution = body.resolution
+
+    await session.commit()
+    await session.refresh(report)
+
+    part = await session.get(Part, report.part_id)
+    return PartReportResponse(
+        id=report.id,
+        part_id=report.part_id,
+        reporter_username=report.reporter_username,
+        reason=report.reason,
+        note=report.note,
+        created_at=report.created_at,
+        resolved_at=report.resolved_at,
+        resolved_by=report.resolved_by,
+        resolution=report.resolution,
+        part=_report_part_ref(part) if part is not None else None,
+    )
+
+
+# --- Merge proposals ---------------------------------------------------
+
+
+@router.post(
+    "/api/parts/{slug}/merge-proposal",
+    response_model=PartMergeProposalResponse,
+    status_code=201,
+)
+async def propose_merge(
+    slug: str,
+    body: PartMergeProposalCreate,
+    user: str = Depends(get_current_user_aged),
+    session: AsyncSession = Depends(get_session),
+) -> PartMergeProposalResponse:
+    """Propose merging the part identified by URL slug INTO ``target_slug``.
+
+    14-day account-age gate (via :func:`get_current_user_aged`). The
+    source part is identified by the URL slug, target by the body field.
+    """
+    source = await _get_part_by_slug(session, slug)
+    target_slug = (body.target_slug or "").strip()
+    if not target_slug:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, detail="target_slug is required"
+        )
+    if target_slug == source.slug:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Cannot merge a part into itself",
+        )
+    target = await session.scalar(select(Part).where(Part.slug == target_slug))
+    if target is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Target part not found"
+        )
+    if target.id == source.id:
+        # Defensive — same as the slug check above, in case of slug aliasing.
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="Cannot merge a part into itself",
+        )
+
+    # One open proposal per (source, target) ordered pair.
+    existing = await session.scalar(
+        select(PartMergeProposal.id).where(
+            PartMergeProposal.source_part_id == source.id,
+            PartMergeProposal.target_part_id == target.id,
+            PartMergeProposal.resolved_at.is_(None),
+        )
+    )
+    if existing is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="An open merge proposal already exists for this pair",
+        )
+
+    proposal = PartMergeProposal(
+        source_part_id=source.id,
+        target_part_id=target.id,
+        proposer_username=user,
+        rationale=body.rationale.strip(),
+        created_at=_now_naive_utc(),
+    )
+    session.add(proposal)
+    await session.commit()
+    await session.refresh(proposal)
+    return await _proposal_response(session, proposal)
+
+
+@router.get(
+    "/api/parts/merge-proposals",
+    response_model=PartMergeProposalListResponse,
+)
+async def list_merge_proposals(
+    status_filter: str = Query(
+        default="open", alias="status", pattern=r"^(open|resolved)$"
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> PartMergeProposalListResponse:
+    """Public list. ``status=open`` (default) shows unresolved proposals
+    newest-first; ``status=resolved`` shows merged / rejected / withdrawn."""
+    base = select(PartMergeProposal)
+    count_q = select(func.count(PartMergeProposal.id))
+    if status_filter == "open":
+        base = base.where(PartMergeProposal.resolved_at.is_(None))
+        count_q = count_q.where(PartMergeProposal.resolved_at.is_(None))
+    else:
+        base = base.where(PartMergeProposal.resolved_at.is_not(None))
+        count_q = count_q.where(PartMergeProposal.resolved_at.is_not(None))
+    total = int((await session.execute(count_q)).scalar_one() or 0)
+
+    base = (
+        base.order_by(
+            PartMergeProposal.created_at.desc(), PartMergeProposal.id.desc()
+        )
+        .limit(limit)
+        .offset(offset)
+    )
+    proposals = (await session.scalars(base)).all()
+    items: list[PartMergeProposalResponse] = []
+    for p in proposals:
+        items.append(await _proposal_response(session, p))
+    return PartMergeProposalListResponse(items=items, total=total)
+
+
+@router.get(
+    "/api/parts/merge-proposals/{proposal_id}",
+    response_model=PartMergeProposalResponse,
+)
+async def get_merge_proposal(
+    proposal_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> PartMergeProposalResponse:
+    proposal = await session.get(PartMergeProposal, proposal_id)
+    if proposal is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Proposal not found"
+        )
+    return await _proposal_response(session, proposal)
+
+
+@router.post(
+    "/api/parts/merge-proposals/{proposal_id}/vote",
+    response_model=PartMergeVoteResponse,
+)
+async def vote_on_merge_proposal(
+    proposal_id: int,
+    body: PartMergeVoteCreate,
+    user: str = Depends(get_current_user_aged),
+    session: AsyncSession = Depends(get_session),
+) -> PartMergeVoteResponse:
+    """Approve or reject — re-POSTing flips the existing vote in place.
+
+    The 14-day account-age gate applies. The proposer is allowed to vote
+    on their own proposal (it's the only way for them to formally
+    register an approval; the proposal itself isn't auto-counted as one).
+    """
+    proposal = await session.get(PartMergeProposal, proposal_id)
+    if proposal is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Proposal not found"
+        )
+    if proposal.resolved_at is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="Proposal already resolved — voting is closed",
+        )
+    if body.vote not in PART_MERGE_VOTES:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"vote must be one of {PART_MERGE_VOTES}",
+        )
+
+    existing = await session.scalar(
+        select(PartMergeVote).where(
+            PartMergeVote.proposal_id == proposal.id,
+            PartMergeVote.voter_username == user,
+        )
+    )
+    now = _now_naive_utc()
+    if existing is None:
+        session.add(
+            PartMergeVote(
+                proposal_id=proposal.id,
+                voter_username=user,
+                vote=body.vote,
+                voted_at=now,
+            )
+        )
+    else:
+        existing.vote = body.vote
+        existing.voted_at = now
+
+    await session.commit()
+    await session.refresh(proposal)
+
+    # Check threshold AFTER the vote landed.
+    triggered = await _check_merge_threshold(session, proposal)
+    approves, rejects = await _count_votes(session, proposal.id)
+    return PartMergeVoteResponse(
+        proposal_id=proposal.id,
+        voter_username=user,
+        vote=body.vote,
+        approves=approves,
+        rejects=rejects,
+        outcome=proposal.outcome,
+        resolved_at=proposal.resolved_at,
+    )
+
+
+@router.delete(
+    "/api/parts/merge-proposals/{proposal_id}",
+    status_code=204,
+)
+async def withdraw_merge_proposal(
+    proposal_id: int,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    """Withdraw a proposal. Allowed for the proposer OR any admin.
+
+    Idempotent on already-resolved proposals: returns 204 even if there
+    was nothing to withdraw, so the UI's "I changed my mind" button is
+    safe to double-click.
+    """
+    from ..config import get_settings
+
+    proposal = await session.get(PartMergeProposal, proposal_id)
+    if proposal is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Proposal not found"
+        )
+
+    if proposal.resolved_at is not None:
+        return None
+
+    settings = get_settings()
+    is_admin = user in settings.admin_usernames_list
+    if proposal.proposer_username != user and not is_admin:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail="Only the proposer or an admin can withdraw a proposal",
+        )
+
+    proposal.outcome = "withdrawn"
+    proposal.resolved_at = _now_naive_utc()
+    await session.commit()
+    return None
+
+
+# --- Auto-merge ---------------------------------------------------------
+
+
+async def _check_merge_threshold(
+    session: AsyncSession, proposal: PartMergeProposal
+) -> bool:
+    """Evaluate the auto-merge rule. Returns True if the merge fired.
+
+    Rule (documented at the top of the module):
+
+        approves >= 5
+        AND approves >= 2 * rejects
+        AND now - created_at >= 48h
+    """
+    if proposal.resolved_at is not None:
+        return False
+    approves, rejects = await _count_votes(session, proposal.id)
+    if approves < MERGE_AUTO_APPROVES:
+        return False
+    if approves < MERGE_AUTO_RATIO * rejects:
+        return False
+    age = _now_naive_utc() - (
+        proposal.created_at if proposal.created_at is not None else _now_naive_utc()
+    )
+    if age < MERGE_AUTO_MIN_AGE:
+        return False
+    await _perform_merge(session, proposal)
+    return True
+
+
+async def _perform_merge(
+    session: AsyncSession, proposal: PartMergeProposal
+) -> None:
+    """Run the actual merge: reparent everything, then delete the source.
+
+    Order matters: we reparent the foreign-keyed children FIRST (BOM
+    rows, relations, aliases, suppliers, talk threads) and only then
+    delete the source ``Part``. The BOM rows use ``ON DELETE SET NULL``
+    so technically a leftover would survive a source-part delete, but
+    rewiring beforehand keeps the BOM rows pointing at the correct
+    target (which is the whole point of the merge).
+    """
+    source_id = proposal.source_part_id
+    target_id = proposal.target_part_id
+
+    # Defensive: refuse to merge if either side has vanished.
+    source = await session.get(Part, source_id)
+    target = await session.get(Part, target_id)
+    if source is None or target is None:
+        proposal.outcome = "rejected"
+        proposal.resolved_at = _now_naive_utc()
+        await session.commit()
+        return
+
+    # 1. BOM rows: repoint part_id and refresh usage counts.
+    await session.execute(
+        update(ProjectBOMItem)
+        .where(ProjectBOMItem.part_id == source_id)
+        .values(part_id=target_id)
+    )
+
+    # 2. Part relations: rewrite both sides. Skip rows that would self-
+    # link to the target after the rewrite, or that would collide with
+    # an existing relation on the target.
+    existing_target_rels: set[tuple[int, int]] = set()
+    rel_rows = (
+        await session.scalars(
+            select(PartRelation).where(
+                or_(
+                    PartRelation.part_id == target_id,
+                    PartRelation.related_id == target_id,
+                )
+            )
+        )
+    ).all()
+    for r in rel_rows:
+        a, b = (r.part_id, r.related_id) if r.part_id < r.related_id else (r.related_id, r.part_id)
+        existing_target_rels.add((a, b))
+
+    source_rels = (
+        await session.scalars(
+            select(PartRelation).where(
+                or_(
+                    PartRelation.part_id == source_id,
+                    PartRelation.related_id == source_id,
+                )
+            )
+        )
+    ).all()
+    for rel in source_rels:
+        other = rel.related_id if rel.part_id == source_id else rel.part_id
+        if other == target_id:
+            # Would self-link the target after the rewrite — drop.
+            await session.delete(rel)
+            continue
+        new_a, new_b = (target_id, other) if target_id < other else (other, target_id)
+        if (new_a, new_b) in existing_target_rels:
+            await session.delete(rel)
+            continue
+        rel.part_id = new_a
+        rel.related_id = new_b
+        existing_target_rels.add((new_a, new_b))
+
+    # 3. Aliases: reparent + add the source's slug + name as aliases so
+    # search still finds the merged result.
+    await session.execute(
+        update(PartAlias)
+        .where(PartAlias.part_id == source_id)
+        .values(part_id=target_id)
+    )
+    for alias_str in {source.slug, source.name}:
+        alias_str = (alias_str or "").strip()
+        if not alias_str:
+            continue
+        already = await session.scalar(
+            select(PartAlias.id).where(
+                PartAlias.part_id == target_id,
+                func.lower(PartAlias.alias) == alias_str.lower(),
+            )
+        )
+        if already is None:
+            session.add(PartAlias(part_id=target_id, alias=alias_str))
+
+    # 4. Suppliers — straight reparent.
+    await session.execute(
+        update(PartSupplier)
+        .where(PartSupplier.part_id == source_id)
+        .values(part_id=target_id)
+    )
+
+    # 5. Talk threads (issue #122, may not exist yet).
+    if await _table_exists(session, "part_talk_threads"):
+        try:
+            await session.execute(
+                text(
+                    'UPDATE part_talk_threads SET part_id = :target '
+                    'WHERE part_id = :source AND (closed IS NULL OR closed = :is_open)'
+                ),
+                {"target": target_id, "source": source_id, "is_open": False},
+            )
+        except Exception as exc:  # pragma: no cover — column shape may vary
+            logger.warning("Reparent of talk threads failed: %s", exc)
+
+    # 6. Recompute usage counts.
+    target_count = await session.scalar(
+        select(func.count(func.distinct(ProjectBOMItem.project_id))).where(
+            ProjectBOMItem.part_id == target_id
+        )
+    )
+    target.usage_count = int(target_count or 0)
+
+    # 7. Delete the source — child rows have already moved.
+    await session.delete(source)
+
+    proposal.outcome = "merged"
+    proposal.resolved_at = _now_naive_utc()
+    await session.commit()

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -618,6 +618,109 @@ class PartDetail(BaseModel):
     family_parts: list[PartRelatedRef] = Field(default_factory=list)
 
 
+# --- Parts moderation (issue #123, Phase 3) ------------------------------
+
+
+PART_REPORT_REASONS = ("spam", "wrong", "duplicate", "other")
+PART_REPORT_RESOLUTIONS = ("accepted", "dismissed")
+PART_MERGE_VOTES = ("approve", "reject")
+
+
+class PartReportCreate(BaseModel):
+    """Body of POST /api/parts/{slug}/report."""
+
+    reason: str = Field(..., pattern=r"^(spam|wrong|duplicate|other)$")
+    note: Optional[str] = Field(None, max_length=500)
+
+
+class PartReportPartRef(BaseModel):
+    """Minimal part reference embedded in admin queue rows."""
+
+    id: int
+    slug: str
+    name: str
+    status: str
+
+
+class PartReportResponse(BaseModel):
+    id: int
+    part_id: int
+    reporter_username: str
+    reason: str
+    note: Optional[str] = None
+    created_at: datetime
+    resolved_at: Optional[datetime] = None
+    resolved_by: Optional[str] = None
+    resolution: Optional[str] = None
+    # Embedded for admin queue rendering — None on the user-facing
+    # ``POST /report`` reply since the caller already knows the part.
+    part: Optional[PartReportPartRef] = None
+
+
+class PartReportListResponse(BaseModel):
+    items: list[PartReportResponse] = Field(default_factory=list)
+    total: int = 0
+
+
+class PartReportResolve(BaseModel):
+    """Body of PATCH /api/admin/parts/reports/{id}."""
+
+    resolution: str = Field(..., pattern=r"^(accepted|dismissed)$")
+
+
+class PartMergeProposalCreate(BaseModel):
+    """Body of POST /api/parts/{slug}/merge-proposal."""
+
+    target_slug: str = Field(..., min_length=1, max_length=120)
+    rationale: str = Field(..., min_length=10, max_length=2000)
+
+
+class PartMergePartRef(BaseModel):
+    """Embedded source/target on a proposal."""
+
+    id: int
+    slug: str
+    name: str
+    status: str
+
+
+class PartMergeProposalResponse(BaseModel):
+    id: int
+    proposer_username: str
+    rationale: str
+    created_at: datetime
+    resolved_at: Optional[datetime] = None
+    outcome: Optional[str] = None
+    source: PartMergePartRef
+    target: PartMergePartRef
+    approves: int = 0
+    rejects: int = 0
+
+
+class PartMergeProposalListResponse(BaseModel):
+    items: list[PartMergeProposalResponse] = Field(default_factory=list)
+    total: int = 0
+
+
+class PartMergeVoteCreate(BaseModel):
+    """Body of POST /api/parts/merge-proposals/{id}/vote."""
+
+    vote: str = Field(..., pattern=r"^(approve|reject)$")
+
+
+class PartMergeVoteResponse(BaseModel):
+    proposal_id: int
+    voter_username: str
+    vote: str
+    approves: int
+    rejects: int
+    # When auto-merge fires on this vote, the proposal flips to
+    # ``outcome=merged`` and we surface that in the response so the UI can
+    # show a "merged!" toast without polling.
+    outcome: Optional[str] = None
+    resolved_at: Optional[datetime] = None
+
+
 # --- Featured projects + staff picks (issue #115) ------------------------
 
 

--- a/stacks/projects-api/tests/test_part_merges.py
+++ b/stacks/projects-api/tests/test_part_merges.py
@@ -1,0 +1,363 @@
+"""Tests for the parts catalog merge proposals (issue #123).
+
+Covers:
+* propose (happy path + self-merge rejected + unknown target 404)
+* withdraw (proposer / admin)
+* vote insert + update (changing your mind)
+* 48h gate + threshold-driven auto-merge
+* threshold rule (5 approves, 2:1 ratio, 48h age)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
+
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture(autouse=True)
+def _old_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend every account is 5 years old by default."""
+    from projects_api import auth as auth_module
+
+    async def _fake_age(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=365 * 5)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _fake_age)
+    auth_module._clear_account_age_cache()
+
+
+@pytest.fixture(autouse=True)
+def _admin_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_USERNAMES", "admin")
+
+
+async def _make_part(client, name: str, *, author: str = "alice") -> dict:
+    resp = await client.post(
+        "/api/parts", json={"name": name}, headers=make_auth_header(author)
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _propose(client, source_slug: str, target_slug: str, *, proposer: str = "alice") -> dict:
+    resp = await client.post(
+        f"/api/parts/{source_slug}/merge-proposal",
+        json={"target_slug": target_slug, "rationale": "These are the same part with different SKUs"},
+        headers=make_auth_header(proposer),
+    )
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_propose_merge_happy_path(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+
+    resp = await _propose(client, src["slug"], tgt["slug"])
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["source"]["slug"] == src["slug"]
+    assert body["target"]["slug"] == tgt["slug"]
+    assert body["approves"] == 0
+    assert body["rejects"] == 0
+    assert body["outcome"] is None
+
+
+@pytest.mark.asyncio
+async def test_self_merge_rejected(client) -> None:
+    p = await _make_part(client, "Lonely")
+    resp = await _propose(client, p["slug"], p["slug"])
+    assert resp.status_code == 400
+    assert "itself" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_propose_requires_account_age(client, monkeypatch) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+
+    from projects_api import auth as auth_module
+
+    async def _young(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=3)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _young)
+    auth_module._clear_account_age_cache()
+
+    resp = await _propose(client, src["slug"], tgt["slug"], proposer="bob")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_propose_unknown_target_404(client) -> None:
+    src = await _make_part(client, "Widget")
+    resp = await client.post(
+        f"/api/parts/{src['slug']}/merge-proposal",
+        json={"target_slug": "does-not-exist", "rationale": "x" * 20},
+        headers=make_auth_header("alice"),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_open_proposal_409(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    r1 = await _propose(client, src["slug"], tgt["slug"])
+    assert r1.status_code == 201
+    r2 = await _propose(client, src["slug"], tgt["slug"], proposer="bob")
+    assert r2.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_list_proposals_public_and_filters(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"])
+    pid = create.json()["id"]
+
+    # Public list (no auth)
+    resp = await client.get("/api/parts/merge-proposals")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["id"] == pid
+
+    # Single-proposal endpoint also public.
+    one = await client.get(f"/api/parts/merge-proposals/{pid}")
+    assert one.status_code == 200
+    assert one.json()["id"] == pid
+
+
+@pytest.mark.asyncio
+async def test_vote_insert_and_update(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"])
+    pid = create.json()["id"]
+
+    # First vote
+    r1 = await client.post(
+        f"/api/parts/merge-proposals/{pid}/vote",
+        json={"vote": "approve"},
+        headers=make_auth_header("bob"),
+    )
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["approves"] == 1
+    assert r1.json()["rejects"] == 0
+
+    # Same voter changes their mind -> updates the existing row.
+    r2 = await client.post(
+        f"/api/parts/merge-proposals/{pid}/vote",
+        json={"vote": "reject"},
+        headers=make_auth_header("bob"),
+    )
+    assert r2.status_code == 200
+    assert r2.json()["approves"] == 0
+    assert r2.json()["rejects"] == 1
+
+
+@pytest.mark.asyncio
+async def test_withdraw_by_proposer(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"], proposer="alice")
+    pid = create.json()["id"]
+
+    # Non-proposer non-admin can't withdraw.
+    forbidden = await client.delete(
+        f"/api/parts/merge-proposals/{pid}",
+        headers=make_auth_header("bob"),
+    )
+    assert forbidden.status_code == 403
+
+    # Proposer can.
+    ok = await client.delete(
+        f"/api/parts/merge-proposals/{pid}",
+        headers=make_auth_header("alice"),
+    )
+    assert ok.status_code == 204
+
+    detail = await client.get(f"/api/parts/merge-proposals/{pid}")
+    assert detail.json()["outcome"] == "withdrawn"
+    assert detail.json()["resolved_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_withdraw_by_admin(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"], proposer="alice")
+    pid = create.json()["id"]
+    ok = await client.delete(
+        f"/api/parts/merge-proposals/{pid}",
+        headers=make_auth_header("admin"),
+    )
+    assert ok.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_voting_blocked_after_resolve(client) -> None:
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"], proposer="alice")
+    pid = create.json()["id"]
+    await client.delete(
+        f"/api/parts/merge-proposals/{pid}",
+        headers=make_auth_header("alice"),
+    )
+    blocked = await client.post(
+        f"/api/parts/merge-proposals/{pid}/vote",
+        json={"vote": "approve"},
+        headers=make_auth_header("bob"),
+    )
+    assert blocked.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_threshold_blocked_by_48h_age(client, session) -> None:
+    """Five approves on a brand-new proposal don't trigger — the 48h age
+    gate is still in force."""
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"])
+    pid = create.json()["id"]
+
+    for voter in ("v1", "v2", "v3", "v4", "v5"):
+        r = await client.post(
+            f"/api/parts/merge-proposals/{pid}/vote",
+            json={"vote": "approve"},
+            headers=make_auth_header(voter),
+        )
+        assert r.status_code == 200
+
+    detail = await client.get(f"/api/parts/merge-proposals/{pid}")
+    assert detail.json()["outcome"] is None  # NOT auto-merged
+    assert detail.json()["approves"] == 5
+
+
+@pytest.mark.asyncio
+async def test_threshold_triggers_auto_merge(client, session) -> None:
+    """Five approves on a >48h-old proposal triggers the merge."""
+    from projects_api.models import PartMergeProposal
+
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"])
+    pid = create.json()["id"]
+
+    # Backdate the proposal so it clears the 48h gate.
+    proposal = await session.get(PartMergeProposal, pid)
+    proposal.created_at = datetime.utcnow() - timedelta(hours=49)
+    await session.commit()
+
+    last = None
+    for voter in ("v1", "v2", "v3", "v4", "v5"):
+        last = await client.post(
+            f"/api/parts/merge-proposals/{pid}/vote",
+            json={"vote": "approve"},
+            headers=make_auth_header(voter),
+        )
+        assert last.status_code == 200
+
+    # The fifth vote (the one that hit threshold) should report the merge
+    # outcome inline.
+    assert last is not None
+    body = last.json()
+    assert body["outcome"] == "merged", body
+    assert body["resolved_at"] is not None
+
+    # Source part is gone; target is still there.
+    src_gone = await client.get(f"/api/parts/{src['slug']}")
+    assert src_gone.status_code == 404
+    tgt_alive = await client.get(f"/api/parts/{tgt['slug']}")
+    assert tgt_alive.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_threshold_blocked_by_2_to_1_ratio(client, session) -> None:
+    """5 approves with 3 rejects fails the ratio (5 < 2*3) even past 48h."""
+    from projects_api.models import PartMergeProposal
+
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+    create = await _propose(client, src["slug"], tgt["slug"])
+    pid = create.json()["id"]
+
+    proposal = await session.get(PartMergeProposal, pid)
+    proposal.created_at = datetime.utcnow() - timedelta(hours=49)
+    await session.commit()
+
+    # Front-load the rejects so the ratio gate is already failing by the
+    # time the 5th approve lands. (If we approve first, the proposal
+    # auto-merges on vote #5 before any rejects arrive.)
+    for v in ("r1", "r2", "r3"):
+        await client.post(
+            f"/api/parts/merge-proposals/{pid}/vote",
+            json={"vote": "reject"},
+            headers=make_auth_header(v),
+        )
+    for v in ("a1", "a2", "a3", "a4", "a5"):
+        await client.post(
+            f"/api/parts/merge-proposals/{pid}/vote",
+            json={"vote": "approve"},
+            headers=make_auth_header(v),
+        )
+
+    detail = await client.get(f"/api/parts/merge-proposals/{pid}")
+    body = detail.json()
+    assert body["outcome"] is None  # not merged — ratio blocks it
+    assert body["approves"] == 5
+    assert body["rejects"] == 3
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_moves_bom_rows(client, session) -> None:
+    """When a merge fires, BOM rows that referenced source now reference target."""
+    from projects_api.models import PartMergeProposal, ProjectBOMItem
+
+    src = await _make_part(client, "Pi Pico H")
+    tgt = await _make_part(client, "Pi Pico")
+
+    # Wire up a project + BOM row pointing at source.
+    proj = await client.post(
+        "/api/projects",
+        json={"title": "Demo project"},
+        headers=make_auth_header("alice"),
+    )
+    project_id = proj.json()["id"]
+    bom = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={"name": "Pi Pico H", "quantity": 1, "part_id": src["id"]},
+        headers=make_auth_header("alice"),
+    )
+    assert bom.status_code == 201
+    bom_id = bom.json()["id"]
+
+    create = await _propose(client, src["slug"], tgt["slug"])
+    pid = create.json()["id"]
+    proposal = await session.get(PartMergeProposal, pid)
+    proposal.created_at = datetime.utcnow() - timedelta(hours=49)
+    await session.commit()
+
+    for voter in ("v1", "v2", "v3", "v4", "v5"):
+        await client.post(
+            f"/api/parts/merge-proposals/{pid}/vote",
+            json={"vote": "approve"},
+            headers=make_auth_header(voter),
+        )
+
+    # BOM row now points at the target.
+    row = await session.get(ProjectBOMItem, bom_id)
+    assert row.part_id == tgt["id"], "BOM row should now reference the merge target"
+
+    # Target's usage_count should have been recomputed to include the
+    # moved row.
+    detail = await client.get(f"/api/parts/{tgt['slug']}")
+    assert detail.json()["usage_count"] == 1

--- a/stacks/projects-api/tests/test_part_reports.py
+++ b/stacks/projects-api/tests/test_part_reports.py
@@ -1,0 +1,200 @@
+"""Tests for the parts catalog reports surface (issue #123).
+
+The 14-day account-age gate does NOT apply to reporting — any logged-in
+user can flag a part. We still patch ``fetch_account_created_at`` so the
+helper that creates the part (POST /api/parts, which IS age-gated) works.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture(autouse=True)
+def _old_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend every account is 5 years old by default."""
+    from projects_api import auth as auth_module
+
+    async def _fake_age(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=365 * 5)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _fake_age)
+    auth_module._clear_account_age_cache()
+
+
+@pytest.fixture(autouse=True)
+def _admin_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``admin`` an admin so the admin endpoints don't 403."""
+    monkeypatch.setenv("ADMIN_USERNAMES", "admin")
+
+
+async def _make_part(client, name: str = "Widget") -> dict:
+    resp = await client.post(
+        "/api/parts", json={"name": name}, headers=make_auth_header("alice")
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_report_part_creates_row(client) -> None:
+    part = await _make_part(client)
+
+    resp = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "spam", "note": "Looks like a copy-paste"},
+        headers=make_auth_header("bob"),
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["part_id"] == part["id"]
+    assert data["reporter_username"] == "bob"
+    assert data["reason"] == "spam"
+    assert data["note"] == "Looks like a copy-paste"
+    assert data["resolved_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_report_rejects_unknown_reason(client) -> None:
+    part = await _make_part(client)
+    resp = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "bogus"},
+        headers=make_auth_header("bob"),
+    )
+    # Pydantic regex rejects -> 422 from validation
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_one_open_report_per_user_per_part(client) -> None:
+    """A second report from the same user on the same part is 409 while
+    the first is unresolved."""
+    part = await _make_part(client)
+
+    r1 = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "wrong"},
+        headers=make_auth_header("bob"),
+    )
+    assert r1.status_code == 201
+
+    r2 = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "spam"},
+        headers=make_auth_header("bob"),
+    )
+    assert r2.status_code == 409
+    assert "open report" in r2.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_different_users_can_both_report(client) -> None:
+    part = await _make_part(client)
+    for user in ("bob", "carol"):
+        r = await client.post(
+            f"/api/parts/{part['slug']}/report",
+            json={"reason": "duplicate"},
+            headers=make_auth_header(user),
+        )
+        assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_report_requires_auth(client) -> None:
+    part = await _make_part(client)
+    resp = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "spam"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_admin_queue_lists_open_reports(client) -> None:
+    part = await _make_part(client, "Pi Pico")
+    await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "spam"},
+        headers=make_auth_header("bob"),
+    )
+
+    # Non-admin gets 403
+    forbidden = await client.get(
+        "/api/admin/parts/reports", headers=make_auth_header("bob")
+    )
+    assert forbidden.status_code == 403
+
+    # Admin sees the open report with the embedded part info.
+    queue = await client.get(
+        "/api/admin/parts/reports", headers=make_auth_header("admin")
+    )
+    assert queue.status_code == 200, queue.text
+    body = queue.json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["part"]["slug"] == part["slug"]
+    assert item["part"]["name"] == "Pi Pico"
+    assert item["reason"] == "spam"
+
+
+@pytest.mark.asyncio
+async def test_admin_resolve_marks_resolved(client) -> None:
+    part = await _make_part(client)
+    create = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "wrong"},
+        headers=make_auth_header("bob"),
+    )
+    report_id = create.json()["id"]
+
+    resolve = await client.patch(
+        f"/api/admin/parts/reports/{report_id}",
+        json={"resolution": "accepted"},
+        headers=make_auth_header("admin"),
+    )
+    assert resolve.status_code == 200, resolve.text
+    body = resolve.json()
+    assert body["resolved_at"] is not None
+    assert body["resolved_by"] == "admin"
+    assert body["resolution"] == "accepted"
+
+    # Queue with status=open should now be empty; status=resolved shows it.
+    open_q = await client.get(
+        "/api/admin/parts/reports?status=open", headers=make_auth_header("admin")
+    )
+    assert open_q.json()["total"] == 0
+    resolved_q = await client.get(
+        "/api/admin/parts/reports?status=resolved",
+        headers=make_auth_header("admin"),
+    )
+    assert resolved_q.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_resolved_report_lets_user_file_a_new_one(client) -> None:
+    """After admin resolves a report, the same user may file a fresh one."""
+    part = await _make_part(client)
+    first = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "wrong"},
+        headers=make_auth_header("bob"),
+    )
+    report_id = first.json()["id"]
+    await client.patch(
+        f"/api/admin/parts/reports/{report_id}",
+        json={"resolution": "dismissed"},
+        headers=make_auth_header("admin"),
+    )
+    again = await client.post(
+        f"/api/parts/{part['slug']}/report",
+        json={"reason": "spam", "note": "another go"},
+        headers=make_auth_header("bob"),
+    )
+    assert again.status_code == 201

--- a/web/_data/nav_admin.yml
+++ b/web/_data/nav_admin.yml
@@ -7,6 +7,9 @@
 - name: Project moderation
   link: /admin/projects/moderation/
   icon: fas fa-shield-halved
+- name: Parts moderation
+  link: /admin/parts/
+  icon: fas fa-flag
 - name: Featured projects
   link: /admin/projects/featured/
   icon: fas fa-star

--- a/web/admin/parts/index.html
+++ b/web/admin/parts/index.html
@@ -1,0 +1,178 @@
+---
+title: Parts moderation
+layout: default
+description: Admin queue for community-reported parts (issue #123)
+permalink: /admin/parts/
+---
+
+{% include nav_admin.html %}
+
+<script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
+
+<style>
+  .kr-report-row { border-left: 3px solid transparent; }
+  .kr-report-row.is-spam      { border-left-color: #dc3545; }
+  .kr-report-row.is-wrong     { border-left-color: #ffc107; }
+  .kr-report-row.is-duplicate { border-left-color: #0dcaf0; }
+  .kr-report-row.is-other     { border-left-color: #6c757d; }
+  .kr-reason-pill { font-size: 0.75rem; }
+</style>
+
+<div class="container-fluid py-4">
+  <h1><i class="fas fa-flag me-3 text-danger"></i> Parts moderation</h1>
+  <p class="text-muted">Community-flagged parts. Accept to acknowledge the report (the part can then be edited or deleted by hand), or dismiss if the flag was unfounded.</p>
+
+  <div id="loading" class="text-center py-5">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+
+  <div id="access-denied" class="d-none">
+    <div class="alert alert-danger mt-4">
+      <i class="fas fa-lock me-2"></i> You do not have permission to access this page.
+    </div>
+  </div>
+
+  <div id="content" class="d-none">
+    <ul class="nav nav-pills mb-3" id="status-tabs">
+      <li class="nav-item"><button type="button" class="nav-link active" data-status="open">Open <span class="badge bg-light text-dark ms-1" id="badge-open">0</span></button></li>
+      <li class="nav-item"><button type="button" class="nav-link" data-status="resolved">Resolved</button></li>
+    </ul>
+
+    <div id="empty" class="text-center py-5 d-none">
+      <i class="fas fa-circle-check fa-3x text-success mb-3"></i>
+      <h4>Inbox zero</h4>
+      <p class="text-muted">There are no open reports right now.</p>
+    </div>
+
+    <div id="list" class="vstack gap-3"></div>
+  </div>
+</div>
+
+<script>
+(function () {
+  const API = 'https://projects.kevsrobots.com';
+  let currentStatus = 'open';
+
+  function esc(t) { const d = document.createElement('div'); d.textContent = t == null ? '' : String(t); return d.innerHTML; }
+  function fmtTime(s) { try { return new Date(s).toLocaleString(); } catch (_) { return ''; } }
+
+  function reasonBadgeClass(reason) {
+    switch (reason) {
+      case 'spam': return 'bg-danger';
+      case 'wrong': return 'bg-warning text-dark';
+      case 'duplicate': return 'bg-info text-dark';
+      default: return 'bg-secondary';
+    }
+  }
+
+  function renderRow(r) {
+    const partLink = r.part
+      ? `<a href="/parts/view.html?slug=${encodeURIComponent(r.part.slug)}" target="_blank" class="fw-semibold text-decoration-none">${esc(r.part.name)}</a>`
+      : `<span class="text-muted fst-italic">part #${r.part_id} (deleted)</span>`;
+    const isResolved = !!r.resolved_at;
+    return `
+      <div class="card kr-report-row is-${esc(r.reason)}" data-id="${r.id}">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-2">
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+              ${partLink}
+              <span class="badge ${reasonBadgeClass(r.reason)} kr-reason-pill">${esc(r.reason)}</span>
+            </div>
+            <div class="small text-muted">
+              ${isResolved ? `<span class="badge bg-${r.resolution === 'accepted' ? 'success' : 'secondary'} me-1">${esc(r.resolution || 'resolved')}</span>` : ''}
+              ${fmtTime(r.created_at)}
+            </div>
+          </div>
+          <div class="small text-muted mb-2">
+            Reporter: <strong>${esc(r.reporter_username)}</strong>
+            ${isResolved ? ` &middot; resolved by <strong>${esc(r.resolved_by || '')}</strong> on ${fmtTime(r.resolved_at)}` : ''}
+          </div>
+          ${r.note ? `<div class="border-start ps-2 mb-2" style="white-space:pre-wrap;">${esc(r.note)}</div>` : '<div class="text-muted fst-italic small mb-2">No note provided.</div>'}
+          ${isResolved ? '' : `
+            <div class="d-flex flex-wrap gap-2">
+              <button type="button" class="btn btn-sm btn-success resolve-btn" data-id="${r.id}" data-resolution="accepted"><i class="fas fa-check me-1"></i> Accept</button>
+              <button type="button" class="btn btn-sm btn-outline-secondary resolve-btn" data-id="${r.id}" data-resolution="dismissed"><i class="fas fa-times me-1"></i> Dismiss</button>
+            </div>
+            <div class="resolve-feedback small mt-2"></div>
+          `}
+        </div>
+      </div>
+    `;
+  }
+
+  async function loadList() {
+    const listEl = document.getElementById('list');
+    const emptyEl = document.getElementById('empty');
+    emptyEl.classList.add('d-none');
+    listEl.innerHTML = '';
+    try {
+      const resp = await ProjectAuth.apiFetch(API + '/api/admin/parts/reports?status=' + currentStatus + '&limit=200');
+      if (resp.status === 401 || resp.status === 403) {
+        document.getElementById('loading').classList.add('d-none');
+        document.getElementById('content').classList.add('d-none');
+        document.getElementById('access-denied').classList.remove('d-none');
+        return;
+      }
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const body = await resp.json();
+      document.getElementById('loading').classList.add('d-none');
+      document.getElementById('content').classList.remove('d-none');
+      if (currentStatus === 'open') {
+        document.getElementById('badge-open').textContent = body.total || 0;
+      }
+      if (!body.items || body.items.length === 0) {
+        emptyEl.classList.remove('d-none');
+        return;
+      }
+      listEl.innerHTML = body.items.map(renderRow).join('');
+      wireActions();
+    } catch (e) {
+      document.getElementById('loading').classList.add('d-none');
+      document.getElementById('content').classList.remove('d-none');
+      emptyEl.classList.remove('d-none');
+      document.querySelector('#empty h4').textContent = 'Could not load reports';
+      document.querySelector('#empty p').textContent = e.message || String(e);
+    }
+  }
+
+  function wireActions() {
+    document.querySelectorAll('.resolve-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.id;
+        const resolution = btn.dataset.resolution;
+        const card = btn.closest('[data-id]');
+        const fb = card.querySelector('.resolve-feedback');
+        fb.textContent = '';
+        try {
+          const resp = await ProjectAuth.apiFetch(API + '/api/admin/parts/reports/' + id, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ resolution }),
+          });
+          if (!resp.ok) {
+            let detail = 'HTTP ' + resp.status;
+            try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+            fb.innerHTML = '<span class="text-danger">' + esc(detail) + '</span>';
+            return;
+          }
+          // Optimistic: refresh the queue.
+          loadList();
+        } catch (e) {
+          fb.innerHTML = '<span class="text-danger">Network error: ' + esc(e.message || e) + '</span>';
+        }
+      });
+    });
+  }
+
+  document.querySelectorAll('#status-tabs button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#status-tabs button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      currentStatus = btn.dataset.status;
+      loadList();
+    });
+  });
+
+  loadList();
+})();
+</script>

--- a/web/parts/merges.html
+++ b/web/parts/merges.html
@@ -1,0 +1,215 @@
+---
+title: Parts merge proposals
+layout: content
+description: Open community proposals to merge duplicate parts in the catalog
+permalink: /parts/merges
+---
+
+{% include nav_projects.html %}
+
+<link rel="stylesheet" href="/assets/css/project-editor.css?v={{ site.time | date: '%s' }}">
+
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
+    <div>
+      <h1 class="mb-1"><i class="fas fa-code-merge me-3 text-warning"></i> Merge proposals</h1>
+      <p class="text-muted mb-0">Community-driven proposals to merge duplicate parts. Five approvals with a 2:1 ratio after 48 hours triggers the merge automatically.</p>
+    </div>
+    <div>
+      <a href="/parts/" class="btn btn-sm btn-outline-secondary"><i class="fas fa-arrow-left me-1"></i> Back to catalog</a>
+    </div>
+  </div>
+
+  <ul class="nav nav-pills mb-3" id="status-tabs" role="tablist">
+    <li class="nav-item"><button type="button" class="nav-link active" data-status="open">Open</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-status="resolved">Resolved</button></li>
+  </ul>
+
+  <div id="loading" class="text-center py-5">
+    <div class="spinner-border text-primary" role="status"></div>
+  </div>
+
+  <div id="empty" class="text-center py-5 d-none">
+    <i class="fas fa-circle-check fa-3x text-success mb-3"></i>
+    <h4>No proposals here</h4>
+    <p class="text-muted">Open a proposal from any part's page using the &ldquo;Propose merge&rdquo; button.</p>
+  </div>
+
+  <div id="proposals-list" class="vstack gap-3 d-none"></div>
+</div>
+
+<script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
+<script>
+(function () {
+  const API = 'https://projects.kevsrobots.com';
+  let isLoggedIn = false;
+  let currentUser = null;
+  let currentStatus = 'open';
+
+  function esc(t) { const d = document.createElement('div'); d.textContent = t == null ? '' : String(t); return d.innerHTML; }
+  function fmtTime(s) { try { return new Date(s).toLocaleString(); } catch (_) { return ''; } }
+
+  function statusBadge(status) {
+    if (status === 'verified') return '<span class="badge bg-success ms-1">verified</span>';
+    if (status === 'draft') return '<span class="badge bg-secondary ms-1">draft</span>';
+    return '';
+  }
+
+  function outcomeBadge(outcome) {
+    if (outcome === 'merged') return '<span class="badge bg-success">merged</span>';
+    if (outcome === 'rejected') return '<span class="badge bg-danger">rejected</span>';
+    if (outcome === 'withdrawn') return '<span class="badge bg-secondary">withdrawn</span>';
+    return '<span class="badge bg-info text-dark">open</span>';
+  }
+
+  function ageHours(createdAt) {
+    if (!createdAt) return 0;
+    try {
+      const ms = Date.now() - new Date(createdAt).getTime();
+      return Math.max(0, Math.floor(ms / 3_600_000));
+    } catch (_) { return 0; }
+  }
+
+  function renderCard(p) {
+    const age = ageHours(p.created_at);
+    const ageBadge = age >= 48
+      ? `<span class="badge bg-light text-dark">${age}h old &middot; 48h gate cleared</span>`
+      : `<span class="badge bg-light text-dark">${age}h old &middot; ${48 - age}h until 48h gate</span>`;
+    const isOpen = !p.resolved_at;
+    const isProposer = currentUser && p.proposer_username === currentUser;
+    const actions = isOpen && isLoggedIn ? `
+      <div class="d-flex flex-wrap gap-2 mt-3">
+        <button type="button" class="btn btn-sm btn-success vote-btn" data-id="${p.id}" data-vote="approve"><i class="fas fa-thumbs-up me-1"></i> Approve</button>
+        <button type="button" class="btn btn-sm btn-outline-danger vote-btn" data-id="${p.id}" data-vote="reject"><i class="fas fa-thumbs-down me-1"></i> Reject</button>
+        ${isProposer ? `<button type="button" class="btn btn-sm btn-outline-secondary withdraw-btn" data-id="${p.id}"><i class="fas fa-times me-1"></i> Withdraw</button>` : ''}
+        <span class="form-text ms-auto small">Voting requires a 14-day-old account.</span>
+      </div>` : '';
+    return `
+      <div class="card" data-proposal-id="${p.id}">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-2">
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+              <a href="/parts/view.html?slug=${encodeURIComponent(p.source.slug)}" class="fw-semibold text-decoration-none">${esc(p.source.name)}</a>${statusBadge(p.source.status)}
+              <i class="fas fa-long-arrow-alt-right text-muted"></i>
+              <a href="/parts/view.html?slug=${encodeURIComponent(p.target.slug)}" class="fw-semibold text-decoration-none">${esc(p.target.name)}</a>${statusBadge(p.target.status)}
+            </div>
+            <div>${outcomeBadge(p.outcome)}</div>
+          </div>
+          <div class="small text-muted mb-2">
+            <i class="fas fa-user me-1"></i> ${esc(p.proposer_username)} &middot;
+            <i class="fas fa-calendar me-1"></i> ${fmtTime(p.created_at)}
+          </div>
+          <div class="mb-2" style="white-space:pre-wrap;">${esc(p.rationale)}</div>
+          <div class="d-flex flex-wrap gap-2">
+            <span class="badge bg-success-subtle text-success-emphasis"><i class="fas fa-thumbs-up me-1"></i> ${p.approves} approve</span>
+            <span class="badge bg-danger-subtle text-danger-emphasis"><i class="fas fa-thumbs-down me-1"></i> ${p.rejects} reject</span>
+            ${isOpen ? ageBadge : ''}
+          </div>
+          ${actions}
+          <div class="vote-feedback small mt-2"></div>
+        </div>
+      </div>
+    `;
+  }
+
+  async function loadList() {
+    const loadEl = document.getElementById('loading');
+    const emptyEl = document.getElementById('empty');
+    const listEl = document.getElementById('proposals-list');
+    loadEl.classList.remove('d-none');
+    emptyEl.classList.add('d-none');
+    listEl.classList.add('d-none');
+    listEl.innerHTML = '';
+    try {
+      const resp = await fetch(API + '/api/parts/merge-proposals?status=' + currentStatus + '&limit=100');
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const body = await resp.json();
+      loadEl.classList.add('d-none');
+      if (!body.items || body.items.length === 0) {
+        emptyEl.classList.remove('d-none');
+        return;
+      }
+      listEl.innerHTML = body.items.map(renderCard).join('');
+      listEl.classList.remove('d-none');
+      wireCardActions(body.items);
+    } catch (e) {
+      loadEl.classList.add('d-none');
+      emptyEl.classList.remove('d-none');
+      document.querySelector('#empty h4').textContent = 'Could not load proposals';
+      document.querySelector('#empty p').textContent = e.message || String(e);
+    }
+  }
+
+  function wireCardActions() {
+    document.querySelectorAll('.vote-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.id;
+        const vote = btn.dataset.vote;
+        const card = btn.closest('[data-proposal-id]');
+        const fb = card.querySelector('.vote-feedback');
+        fb.textContent = '';
+        try {
+          const resp = await ProjectAuth.apiFetch(API + '/api/parts/merge-proposals/' + id + '/vote', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vote }),
+          });
+          if (!resp.ok) {
+            let detail = 'HTTP ' + resp.status;
+            try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+            fb.innerHTML = '<span class="text-danger">' + esc(detail) + '</span>';
+            return;
+          }
+          const body = await resp.json();
+          fb.innerHTML = '<span class="text-success">Vote recorded.</span>';
+          if (body.outcome === 'merged') {
+            fb.innerHTML += ' <span class="badge bg-success ms-2">This proposal just auto-merged!</span>';
+          }
+          // Refresh the row's tally.
+          setTimeout(loadList, 600);
+        } catch (e) {
+          fb.innerHTML = '<span class="text-danger">Network error: ' + esc(e.message || e) + '</span>';
+        }
+      });
+    });
+    document.querySelectorAll('.withdraw-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        if (!window.confirm('Withdraw this proposal? It will be closed and cannot be reopened.')) return;
+        const id = btn.dataset.id;
+        try {
+          const resp = await ProjectAuth.apiFetch(API + '/api/parts/merge-proposals/' + id, { method: 'DELETE' });
+          if (resp.status === 204) {
+            loadList();
+          } else {
+            alert('Could not withdraw (HTTP ' + resp.status + ').');
+          }
+        } catch (e) {
+          alert('Network error: ' + (e.message || e));
+        }
+      });
+    });
+  }
+
+  document.querySelectorAll('#status-tabs button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#status-tabs button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      currentStatus = btn.dataset.status;
+      loadList();
+    });
+  });
+
+  async function init() {
+    try {
+      const me = await ProjectAuth.apiFetch(API + '/api/auth/me');
+      if (me.ok) {
+        const body = await me.json();
+        isLoggedIn = true;
+        currentUser = body && body.username ? body.username : null;
+      }
+    } catch (_) {}
+    loadList();
+  }
+  init();
+})();
+</script>

--- a/web/parts/view.html
+++ b/web/parts/view.html
@@ -97,8 +97,80 @@ description: View a part in the catalog
             <div id="part-login-container" class="d-grid mt-3 d-none">
               <a href="/login" class="btn btn-sm btn-outline-secondary"><i class="fas fa-sign-in-alt me-1"></i> Log in to edit</a>
             </div>
+            <hr id="part-mod-divider" class="d-none my-3">
+            <div id="part-mod-container" class="d-grid gap-2 d-none">
+              <button type="button" id="propose-merge-btn" class="btn btn-sm btn-outline-warning" data-bs-toggle="modal" data-bs-target="#merge-modal"><i class="fas fa-code-merge me-1"></i> Propose merge</button>
+              <button type="button" id="report-part-btn" class="btn btn-sm btn-outline-danger" data-bs-toggle="modal" data-bs-target="#report-modal"><i class="fas fa-flag me-1"></i> Report this part</button>
+              <a href="/parts/merges.html" class="small text-muted text-decoration-none mt-1"><i class="fas fa-list me-1"></i> View all merge proposals</a>
+            </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Report modal (issue #123) -->
+<div class="modal fade" id="report-modal" tabindex="-1" aria-labelledby="report-modal-label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="report-modal-label"><i class="fas fa-flag me-2 text-danger"></i> Report part</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">Help us keep the catalog clean. Reports go to a moderator queue.</p>
+        <div id="report-error" class="alert alert-danger d-none"></div>
+        <div id="report-success" class="alert alert-success d-none">Thanks &mdash; a moderator will review your report.</div>
+        <div class="mb-3">
+          <label for="report-reason" class="form-label">Reason</label>
+          <select id="report-reason" class="form-select">
+            <option value="wrong">Wrong information</option>
+            <option value="duplicate">Duplicate of another part</option>
+            <option value="spam">Spam or vandalism</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="report-note" class="form-label">Note (optional)</label>
+          <textarea id="report-note" class="form-control" rows="3" maxlength="500" placeholder="Anything that helps the moderator..."></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="report-submit"><i class="fas fa-flag me-1"></i> Submit report</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Merge proposal modal (issue #123) -->
+<div class="modal fade" id="merge-modal" tabindex="-1" aria-labelledby="merge-modal-label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="merge-modal-label"><i class="fas fa-code-merge me-2 text-warning"></i> Propose merge</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted">Propose merging <strong id="merge-source-name"></strong> into another part. The community votes &mdash; if 5+ approvals come in with strong support after 48 hours, the merge runs automatically and BOM links repoint to the target.</p>
+        <div id="merge-error" class="alert alert-danger d-none"></div>
+        <div id="merge-success" class="alert alert-success d-none">Proposal submitted &mdash; <a id="merge-success-link" href="/parts/merges.html">view it on the merge proposals page</a>.</div>
+        <div class="mb-3 position-relative">
+          <label for="merge-target-input" class="form-label">Merge into</label>
+          <input type="text" id="merge-target-input" class="form-control" placeholder="Search by name or SKU..." autocomplete="off">
+          <div id="merge-target-results" class="list-group position-absolute w-100 d-none" style="top:100%;left:0;z-index:1000;max-height:240px;overflow-y:auto;"></div>
+          <div id="merge-target-picked" class="form-text d-none">Picked: <strong id="merge-target-name"></strong> <a href="#" id="merge-target-clear" class="ms-2 small">change</a></div>
+        </div>
+        <div class="mb-3">
+          <label for="merge-rationale" class="form-label">Rationale</label>
+          <textarea id="merge-rationale" class="form-control" rows="3" minlength="10" maxlength="2000" placeholder="Why should these merge? e.g. 'Same chip, different vendor SKU.'"></textarea>
+          <div class="form-text">10&ndash;2000 characters.</div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-warning" id="merge-submit"><i class="fas fa-code-merge me-1"></i> Submit proposal</button>
       </div>
     </div>
   </div>
@@ -293,6 +365,12 @@ description: View a part in the catalog
         document.getElementById('part-edit-container').classList.remove('d-none');
         document.getElementById('part-edit-link').href = '/parts/edit.html?slug=' + encodeURIComponent(slug);
         document.getElementById('part-history-btn').href = '/parts/history.html?slug=' + encodeURIComponent(slug);
+        // Issue #123: show report + propose-merge actions to logged-in users.
+        // The API enforces the 14-day gate on merge proposals; reports work
+        // for any logged-in user.
+        document.getElementById('part-mod-divider').classList.remove('d-none');
+        document.getElementById('part-mod-container').classList.remove('d-none');
+        document.getElementById('merge-source-name').textContent = part.name || slug;
       } else {
         document.getElementById('part-login-container').classList.remove('d-none');
       }
@@ -301,6 +379,157 @@ description: View a part in the catalog
     }
   }
 
+  // --- Issue #123: Report modal wiring -------------------------------
+  function setupReportModal() {
+    const submitBtn = document.getElementById('report-submit');
+    if (!submitBtn) return;
+    submitBtn.addEventListener('click', async () => {
+      const errEl = document.getElementById('report-error');
+      const okEl = document.getElementById('report-success');
+      errEl.classList.add('d-none');
+      okEl.classList.add('d-none');
+      const reason = document.getElementById('report-reason').value;
+      const note = document.getElementById('report-note').value.trim();
+      submitBtn.disabled = true;
+      try {
+        const resp = await ProjectAuth.apiFetch(API + '/api/parts/' + encodeURIComponent(slug) + '/report', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason, note: note || null }),
+        });
+        if (resp.status === 201) {
+          okEl.classList.remove('d-none');
+          document.getElementById('report-note').value = '';
+          return;
+        }
+        let detail = 'Could not file report (HTTP ' + resp.status + ').';
+        try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+        errEl.textContent = detail;
+        errEl.classList.remove('d-none');
+      } catch (e) {
+        errEl.textContent = 'Network error: ' + (e.message || e);
+        errEl.classList.remove('d-none');
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  }
+
+  // --- Issue #123: Merge proposal modal wiring -----------------------
+  function setupMergeModal() {
+    const input = document.getElementById('merge-target-input');
+    const resultsEl = document.getElementById('merge-target-results');
+    const pickedEl = document.getElementById('merge-target-picked');
+    const pickedName = document.getElementById('merge-target-name');
+    const clearLink = document.getElementById('merge-target-clear');
+    const submitBtn = document.getElementById('merge-submit');
+    if (!submitBtn) return;
+
+    let targetSlug = null;
+    let searchTimer = null;
+
+    function clearPick() {
+      targetSlug = null;
+      pickedEl.classList.add('d-none');
+      pickedName.textContent = '';
+      input.value = '';
+      input.classList.remove('d-none');
+    }
+
+    clearLink && clearLink.addEventListener('click', (e) => {
+      e.preventDefault();
+      clearPick();
+      input.focus();
+    });
+
+    function renderResults(hits) {
+      const filtered = (hits || []).filter(h => h.slug !== slug);
+      if (filtered.length === 0) {
+        resultsEl.innerHTML = '<div class="list-group-item small text-muted">No matches.</div>';
+        resultsEl.classList.remove('d-none');
+        return;
+      }
+      resultsEl.innerHTML = filtered.slice(0, 10).map(h => `
+        <button type="button" class="list-group-item list-group-item-action small" data-slug="${esc(h.slug)}" data-name="${esc(h.name)}">
+          <strong>${esc(h.name)}</strong>
+          ${h.sku ? `<span class="text-muted ms-2">${esc(h.sku)}</span>` : ''}
+        </button>
+      `).join('');
+      resultsEl.querySelectorAll('button').forEach(b => {
+        b.addEventListener('click', () => {
+          targetSlug = b.dataset.slug;
+          pickedName.textContent = b.dataset.name;
+          pickedEl.classList.remove('d-none');
+          input.classList.add('d-none');
+          resultsEl.classList.add('d-none');
+        });
+      });
+      resultsEl.classList.remove('d-none');
+    }
+
+    input.addEventListener('input', () => {
+      clearTimeout(searchTimer);
+      const q = input.value.trim();
+      if (!q) { resultsEl.classList.add('d-none'); return; }
+      searchTimer = setTimeout(async () => {
+        try {
+          const resp = await fetch(API + '/api/parts?q=' + encodeURIComponent(q) + '&limit=12');
+          if (!resp.ok) return;
+          renderResults(await resp.json());
+        } catch (_) {}
+      }, 200);
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!resultsEl.contains(e.target) && e.target !== input) {
+        resultsEl.classList.add('d-none');
+      }
+    });
+
+    submitBtn.addEventListener('click', async () => {
+      const errEl = document.getElementById('merge-error');
+      const okEl = document.getElementById('merge-success');
+      errEl.classList.add('d-none');
+      okEl.classList.add('d-none');
+      const rationale = document.getElementById('merge-rationale').value.trim();
+      if (!targetSlug) {
+        errEl.textContent = 'Pick a target part first.';
+        errEl.classList.remove('d-none');
+        return;
+      }
+      if (rationale.length < 10) {
+        errEl.textContent = 'Rationale must be at least 10 characters.';
+        errEl.classList.remove('d-none');
+        return;
+      }
+      submitBtn.disabled = true;
+      try {
+        const resp = await ProjectAuth.apiFetch(API + '/api/parts/' + encodeURIComponent(slug) + '/merge-proposal', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ target_slug: targetSlug, rationale }),
+        });
+        if (resp.status === 201) {
+          okEl.classList.remove('d-none');
+          document.getElementById('merge-rationale').value = '';
+          clearPick();
+          return;
+        }
+        let detail = 'Could not submit proposal (HTTP ' + resp.status + ').';
+        try { const err = await resp.json(); if (err && err.detail) detail = err.detail; } catch (_) {}
+        errEl.textContent = detail;
+        errEl.classList.remove('d-none');
+      } catch (e) {
+        errEl.textContent = 'Network error: ' + (e.message || e);
+        errEl.classList.remove('d-none');
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  }
+
+  setupReportModal();
+  setupMergeModal();
   load();
 })();
 </script>


### PR DESCRIPTION
## Summary
Phase 3 of the parts catalog: community-driven moderation. Anyone logged in can flag parts as wrong / spam / duplicate; mature users can propose merges that pass by community vote.

### Backend
- **New tables** (no migration helpers — `create_all` handles new tables):
  - `part_reports` — `part_id`, `reporter_username`, `reason` (`spam|wrong|duplicate|other`), `note`, resolved fields.
  - `part_merge_proposals` — `source_part_id`, `target_part_id`, `proposer_username`, `rationale`, resolved fields. Unique on (source, target) while unresolved.
  - `part_merge_votes` — `proposal_id`, `voter_username`, `vote` (`approve|reject`). Unique on (proposal, voter).
- **New router** `routers/parts_moderation.py` — 8 endpoints + `_check_merge_threshold` + `_perform_merge` helpers. Mounted **before** `parts.router` so `/api/parts/merge-proposals` doesn't get eaten by the `/api/parts/{slug}` catch-all.
- **Auto-merge rule:** `approves >= 5 AND approves >= 2*rejects AND proposal_age >= 48h`. The 48h gate uses `created_at` so dissent has a fixed window regardless of approval velocity. Documented in the module docstring.
- **Talk-thread reparenting** during merge is guarded by `_table_exists("part_talk_threads")` — works whether #122 has landed or not.

### Frontend
- `web/parts/view.html` — Report button + Propose-merge button, two Bootstrap modals, JS wiring.
- `web/parts/merges.html` (new) — public open/resolved tabs, approve/reject/withdraw, vote tally.
- `web/admin/parts/index.html` (new) — admin queue with accept/dismiss actions. "Parts moderation" added to `nav_admin.yml`.

### Tests
- 22 new (8 `test_part_reports.py` + 14 `test_part_merges.py`). Full suite **277 passing**.

### Skipped (out of agent scope)
- 24h dedup window on reports — used the simpler "one open report per user per part" gate.
- Source-part redirect banner / `merged_into:<id>` status — we delete the source after rewiring BOM rows, cleaner with FK CASCADE.
- "Hide verified badge after 2 reports" — that demote rule belongs to #122's lifecycle work.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)