### PR TITLE
feat(parts/projects): per-supplier pricing + auto-update on linked BOM rows (#167)

### DIFF
--- a/stacks/projects-api/projects_api/db.py
+++ b/stacks/projects-api/projects_api/db.py
@@ -534,6 +534,121 @@ async def add_supplier_country_if_missing() -> None:
             ))
 
 
+async def add_supplier_pricing_if_missing() -> None:
+    """Additive migration for the supplier-pricing feature.
+
+    Adds ``unit_cost`` (Float, nullable) + ``currency_code`` (CHAR(3),
+    nullable) to the existing ``part_suppliers`` table when they do not
+    already exist. SQLAlchemy's ``create_all`` does not ALTER existing
+    tables, so this lightweight idempotent helper keeps existing Postgres
+    deployments in sync. Safe to run on every startup; no-op when the
+    columns are already present. Postgres-only — SQLite tests use a
+    fresh in-memory DB which already includes the new columns.
+
+    Mirrors ``add_supplier_country_if_missing`` (issue #149) — both touch
+    part_suppliers and follow the same probe-then-ALTER pattern.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.begin() as conn:
+        table_check = await conn.execute(text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = 'part_suppliers'"
+        ))
+        if table_check.first() is None:
+            # Brand-new deployment — create_all builds the table with every
+            # column already present.
+            return
+
+        existing = await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'part_suppliers'"
+        ))
+        cols = {row[0] for row in existing.fetchall()}
+
+        if "unit_cost" not in cols:
+            logger.warning(
+                "Adding part_suppliers.unit_cost column (supplier-pricing-feature)"
+            )
+            await conn.execute(text(
+                'ALTER TABLE "part_suppliers" ADD COLUMN "unit_cost" '
+                'DOUBLE PRECISION'
+            ))
+        if "currency_code" not in cols:
+            logger.warning(
+                "Adding part_suppliers.currency_code column (supplier-pricing-feature)"
+            )
+            await conn.execute(text(
+                'ALTER TABLE "part_suppliers" ADD COLUMN "currency_code" CHAR(3)'
+            ))
+
+
+async def add_bom_supplier_id_if_missing() -> None:
+    """Additive migration for the supplier-pricing feature.
+
+    Adds ``supplier_id`` (FK -> part_suppliers.id ON DELETE SET NULL) to
+    the existing ``project_bom_items`` table when it does not already
+    exist. Without this, every SELECT / INSERT on the BOM table 500s
+    after a redeploy that ships the new ORM model.
+
+    Two-step pattern mirrors ``add_bom_part_id_if_missing`` (issue #121):
+    add the bare column first so the migration succeeds even if
+    ``part_suppliers`` doesn't exist yet (legacy DBs where the parts
+    catalog landed in a later migration pass), then conditionally add
+    the FK constraint only if the target table is present. Idempotent —
+    safe to run on every startup. Postgres-only; SQLite tests use a
+    fresh in-memory DB built by ``create_all``.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.begin() as conn:
+        table_check = await conn.execute(text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = 'project_bom_items'"
+        ))
+        if table_check.first() is None:
+            return
+
+        existing = await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'project_bom_items'"
+        ))
+        cols = {row[0] for row in existing.fetchall()}
+
+        if "supplier_id" not in cols:
+            logger.warning(
+                "Adding project_bom_items.supplier_id column "
+                "(supplier-pricing-feature)"
+            )
+            # Step 1: bare column, no FK — succeeds even if part_suppliers
+            # hasn't been created yet on this legacy DB.
+            await conn.execute(text(
+                'ALTER TABLE "project_bom_items" ADD COLUMN "supplier_id" INTEGER'
+            ))
+            # Step 2: add the FK constraint only if the target table
+            # exists. On the same startup pass ``create_all`` will have
+            # built ``part_suppliers`` for fresh deployments, but on the
+            # legacy-without-parts case we leave the constraint off and
+            # rely on the resolver to silently treat any stale id as NULL.
+            suppliers_check = await conn.execute(text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = current_schema() AND table_name = 'part_suppliers'"
+            ))
+            if suppliers_check.first() is not None:
+                await conn.execute(text(
+                    'ALTER TABLE "project_bom_items" ADD CONSTRAINT '
+                    '"fk_project_bom_items_supplier_id" FOREIGN KEY '
+                    '("supplier_id") REFERENCES "part_suppliers" (id) '
+                    'ON DELETE SET NULL'
+                ))
+            await conn.execute(text(
+                'CREATE INDEX IF NOT EXISTS "ix_project_bom_items_supplier_id" '
+                'ON "project_bom_items" ("supplier_id")'
+            ))
+
+
 async def add_bom_currency_if_missing() -> None:
     """Additive migration for issue #149 (BOM currency codes).
 

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -16,6 +16,7 @@ from .config import get_settings
 from .db import (
     add_bom_currency_if_missing,
     add_bom_part_id_if_missing,
+    add_bom_supplier_id_if_missing,
     add_part_category_family_if_missing,
     add_part_status_columns_if_missing,
     add_project_featured_columns_if_missing,
@@ -23,6 +24,7 @@ from .db import (
     add_remix_columns_if_missing,
     add_supplier_country_if_missing,
     add_supplier_health_columns_if_missing,
+    add_supplier_pricing_if_missing,
     add_user_currency_preference_if_missing,
     add_user_disabled_columns_if_missing,
     add_user_profile_columns_if_missing,
@@ -92,6 +94,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # existing tables (part_suppliers / project_bom_items).
     await add_supplier_country_if_missing()
     await add_bom_currency_if_missing()
+    # Supplier-pricing feature: per-supplier unit_cost + currency_code on
+    # part_suppliers, and supplier_id FK on project_bom_items. Must run
+    # after ``add_supplier_country_if_missing`` so both column-additions
+    # land in the same lifespan pass; ordering between them doesn't
+    # matter (both helpers are independent ALTERs against different
+    # columns on the same table).
+    await add_supplier_pricing_if_missing()
+    await add_bom_supplier_id_if_missing()
     # Issue #122 Phase 2: supplier link-health columns + lifecycle columns.
     await add_supplier_health_columns_if_missing()
     await add_part_status_columns_if_missing()

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -140,6 +140,21 @@ class ProjectBOMItem(Base):
     part_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("parts.id", ondelete="SET NULL"), nullable=True, index=True
     )
+    # Supplier-pricing feature: optional link to a specific PartSupplier
+    # row. When set AND the supplier has a non-NULL ``unit_cost``, the BOM
+    # ``_to_response`` enrichment treats the supplier as the live price
+    # source — ``effective_unit_cost`` / ``effective_currency_code`` come
+    # from the supplier rather than this row, and ``price_source`` is
+    # ``"supplier"``. When unset or stale (supplier deleted → SET NULL)
+    # the row's own ``unit_cost`` + ``currency_code`` are used as the
+    # fallback. Independent of ``part_id`` only insofar as supplier rows
+    # are owned by parts, but the resolver doesn't assume they agree —
+    # if they ever diverge the supplier wins for pricing.
+    supplier_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("part_suppliers.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
 
 class ProjectLink(Base):
@@ -440,6 +455,16 @@ class PartSupplier(Base):
     # "global / unknown" — legacy rows pre-#149 have NULL. Validated via
     # the Pydantic ``pattern`` on ``PartSupplierInput``.
     country_code: Mapped[Optional[str]] = mapped_column(String(2))
+    # Supplier-pricing feature: the price this supplier is currently
+    # advertising for the part, in ``currency_code``. Nullable for legacy
+    # rows + suppliers that haven't been priced yet. When a BOM row links
+    # to this supplier via ``ProjectBOMItem.supplier_id`` the BOM
+    # ``_to_response`` enrichment uses these two fields as the price
+    # source — see ``routers/bom.py``. Validated via the Pydantic
+    # ``unit_cost`` (>= 0) + ``currency_code`` (^[A-Z]{3}$) constraints
+    # on ``PartSupplierInput``.
+    unit_cost: Mapped[Optional[float]] = mapped_column(Float)
+    currency_code: Mapped[Optional[str]] = mapped_column(String(3))
 
 
 # --- Parts talk pages (issue #122, Phase 2) ------------------------------

--- a/stacks/projects-api/projects_api/routers/bom.py
+++ b/stacks/projects-api/projects_api/routers/bom.py
@@ -73,15 +73,75 @@ async def _fetch_parts_meta(
     }
 
 
+async def _fetch_supplier_pricing(
+    session: AsyncSession, supplier_ids: list[int]
+) -> dict[int, tuple[Optional[float], Optional[str]]]:
+    """Batch-load (unit_cost, currency_code) for the given supplier ids.
+
+    Returns a dict keyed by supplier_id; missing keys mean the supplier
+    no longer exists (ON DELETE SET NULL would normally clear the FK,
+    but the resolver is defensive in case the row is stale for any
+    other reason). The caller folds this into ``_to_response`` so the
+    BOM list endpoint stays at O(1) extra query per request regardless
+    of how many rows reference suppliers — important because a project
+    with 50 BOM rows each linked to a different supplier must not
+    issue 50 separate SELECTs (N+1).
+
+    SQL pattern: a single ``WHERE id IN (:ids)`` against
+    ``part_suppliers`` is one round-trip and uses the PK index. The
+    cost is bounded by ``len(supplier_ids)`` regardless of which
+    project we're loading.
+    """
+    if not supplier_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(
+                PartSupplier.id, PartSupplier.unit_cost, PartSupplier.currency_code
+            ).where(PartSupplier.id.in_(supplier_ids))
+        )
+    ).all()
+    return {sid: (cost, code) for sid, cost, code in rows}
+
+
 def _to_response(
     item: ProjectBOMItem,
     parts_meta: dict[int, tuple[Optional[str], Optional[str]]],
+    supplier_pricing: dict[int, tuple[Optional[float], Optional[str]]],
 ) -> BOMItemResponse:
-    """Build a BOMItemResponse, decorating with part slug / supplier."""
+    """Build a BOMItemResponse, decorating with part slug / supplier.
+
+    Resolution order for the effective price (supplier-pricing feature):
+
+      1. If the row has a ``supplier_id`` AND the supplier still exists
+         AND the supplier has a non-NULL ``unit_cost``: use the
+         supplier's live values. ``price_source = "supplier"``.
+      2. Otherwise (no supplier link, supplier deleted under us, or
+         supplier has no price recorded): fall back to the row's own
+         ``unit_cost`` + ``currency_code``. ``price_source = "row"``.
+
+    A stale ``supplier_id`` pointing at a deleted supplier behaves
+    identically to having no link at all — ON DELETE SET NULL on the FK
+    will eventually NULL it out, but until then the resolver silently
+    falls through to the row values rather than 500ing.
+    """
     slug = None
     primary_supplier = None
     if item.part_id is not None:
         slug, primary_supplier = parts_meta.get(item.part_id, (None, None))
+
+    effective_unit_cost: Optional[float] = item.unit_cost
+    effective_currency_code: Optional[str] = item.currency_code
+    price_source = "row"
+    if item.supplier_id is not None:
+        sup_cost, sup_currency = supplier_pricing.get(
+            item.supplier_id, (None, None)
+        )
+        if sup_cost is not None:
+            effective_unit_cost = sup_cost
+            effective_currency_code = sup_currency
+            price_source = "supplier"
+
     return BOMItemResponse(
         id=item.id,
         name=item.name,
@@ -94,6 +154,10 @@ def _to_response(
         part_id=item.part_id,
         part_slug=slug,
         part_primary_supplier_url=primary_supplier,
+        supplier_id=item.supplier_id,
+        effective_unit_cost=effective_unit_cost,
+        effective_currency_code=effective_currency_code,
+        price_source=price_source,
     )
 
 
@@ -128,7 +192,32 @@ async def list_bom(
     ).all()
     part_ids = [i.part_id for i in items if i.part_id is not None]
     parts_meta = await _fetch_parts_meta(session, list(set(part_ids)))
-    return [_to_response(i, parts_meta) for i in items]
+    # Batch-load supplier prices in one round-trip — see
+    # ``_fetch_supplier_pricing`` for the N+1 mitigation rationale. A
+    # 50-row BOM linked to 50 different suppliers still issues exactly
+    # one extra SELECT, not 50.
+    supplier_ids = [i.supplier_id for i in items if i.supplier_id is not None]
+    supplier_pricing = await _fetch_supplier_pricing(
+        session, list(set(supplier_ids))
+    )
+    return [_to_response(i, parts_meta, supplier_pricing) for i in items]
+
+
+async def _validate_supplier_id(
+    session: AsyncSession, supplier_id: Optional[int]
+) -> Optional[int]:
+    """Return ``supplier_id`` if the supplier exists, else None.
+
+    Same validate-or-drop pattern as ``part_id`` on the BOM endpoints —
+    a stale or unknown id shouldn't make the request 4xx because the
+    user might be saving other field changes at the same time. The
+    resolver in ``_to_response`` is also defensive against this case so
+    the row stays useful even if the supplier disappears mid-edit.
+    """
+    if supplier_id is None:
+        return None
+    existing = await session.get(PartSupplier, supplier_id)
+    return supplier_id if existing is not None else None
 
 
 @router.post("", response_model=BOMItemResponse, status_code=201)
@@ -149,6 +238,9 @@ async def add_bom_item(
         if existing is None:
             payload["part_id"] = None
             part_id = None
+    payload["supplier_id"] = await _validate_supplier_id(
+        session, payload.get("supplier_id")
+    )
     item = ProjectBOMItem(project_id=project_id, **payload)
     session.add(item)
     await session.flush()
@@ -157,7 +249,10 @@ async def add_bom_item(
     await session.commit()
     await session.refresh(item)
     parts_meta = await _fetch_parts_meta(session, [item.part_id] if item.part_id else [])
-    return _to_response(item, parts_meta)
+    supplier_pricing = await _fetch_supplier_pricing(
+        session, [item.supplier_id] if item.supplier_id else []
+    )
+    return _to_response(item, parts_meta, supplier_pricing)
 
 
 @router.put("/{item_id}", response_model=BOMItemResponse)
@@ -180,6 +275,9 @@ async def update_bom_item(
         if existing is None:
             payload["part_id"] = None
             new_part_id = None
+    payload["supplier_id"] = await _validate_supplier_id(
+        session, payload.get("supplier_id")
+    )
     for field, value in payload.items():
         setattr(item, field, value)
     await session.flush()
@@ -191,7 +289,10 @@ async def update_bom_item(
     await session.commit()
     await session.refresh(item)
     parts_meta = await _fetch_parts_meta(session, [item.part_id] if item.part_id else [])
-    return _to_response(item, parts_meta)
+    supplier_pricing = await _fetch_supplier_pricing(
+        session, [item.supplier_id] if item.supplier_id else []
+    )
+    return _to_response(item, parts_meta, supplier_pricing)
 
 
 @router.delete("/{item_id}", status_code=204)

--- a/stacks/projects-api/projects_api/routers/parts.py
+++ b/stacks/projects-api/projects_api/routers/parts.py
@@ -148,17 +148,23 @@ def _supplier_response(s: PartSupplier) -> PartSupplierResponse:
         is_broken=bool(s.is_broken),
         consecutive_failures=int(s.consecutive_failures or 0),
         country_code=s.country_code,
+        unit_cost=s.unit_cost,
+        currency_code=s.currency_code,
     )
 
 
 def _suppliers_to_json(suppliers: list[PartSupplier]) -> list[dict]:
     # Issue #149: persist country_code into the denormalised revision
-    # snapshot so history stays consistent.
+    # snapshot so history stays consistent. Supplier-pricing feature:
+    # also snapshot unit_cost + currency_code so price changes show up
+    # in the next revision (and can be restored).
     return [
         {
             "name": s.supplier_name,
             "url": s.url,
             "country_code": s.country_code,
+            "unit_cost": s.unit_cost,
+            "currency_code": s.currency_code,
         }
         for s in suppliers
     ]
@@ -483,9 +489,20 @@ def _supplier_signature(suppliers: list[dict]) -> list[tuple]:
 
     Issue #149: include ``country_code`` so editing just the country (and
     nothing else) is recognised as a real change and writes a revision.
+
+    Supplier-pricing feature: also include ``unit_cost`` +
+    ``currency_code`` so a pure price change (no other field touched)
+    still triggers a new revision and ends up in ``suppliers_json`` for
+    the audit trail.
     """
     return [
-        (s.get("name"), s.get("url"), s.get("country_code"))
+        (
+            s.get("name"),
+            s.get("url"),
+            s.get("country_code"),
+            s.get("unit_cost"),
+            s.get("currency_code"),
+        )
         for s in suppliers
     ]
 
@@ -528,6 +545,8 @@ async def update_part(
                 "name": (s.name or None),
                 "url": s.url,
                 "country_code": (s.country_code or None),
+                "unit_cost": s.unit_cost,
+                "currency_code": (s.currency_code or None),
             }
             for s in body.suppliers
         ]
@@ -629,6 +648,8 @@ async def update_part(
                     supplier_name=entry.get("name"),
                     url=entry.get("url"),
                     country_code=entry.get("country_code"),
+                    unit_cost=entry.get("unit_cost"),
+                    currency_code=entry.get("currency_code"),
                 )
             )
 
@@ -685,6 +706,8 @@ async def get_revision(
             name=s.get("name"),
             url=s.get("url", ""),
             country_code=s.get("country_code"),
+            unit_cost=s.get("unit_cost"),
+            currency_code=s.get("currency_code"),
         )
         for s in suppliers_raw
         if s.get("url")
@@ -790,6 +813,8 @@ async def restore_revision(
                 supplier_name=entry.get("name"),
                 url=entry.get("url"),
                 country_code=entry.get("country_code"),
+                unit_cost=entry.get("unit_cost"),
+                currency_code=entry.get("currency_code"),
             )
         )
 

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -182,6 +182,15 @@ class BOMItemCreate(BaseModel):
     supplier_url: Optional[str] = None
     sort_order: int = 0
     part_id: Optional[int] = None
+    # Supplier-pricing feature: optional link to a specific PartSupplier
+    # row. When set AND the supplier has a non-NULL ``unit_cost``, the
+    # supplier's price is the source of truth for the BOM row's display
+    # (see ``effective_unit_cost`` on the response). When NULL or stale
+    # the row's own ``unit_cost`` + ``currency_code`` are used. Same
+    # validate-or-drop pattern as ``part_id``: a non-existent
+    # ``supplier_id`` is silently set to NULL rather than 400ing, so the
+    # frontend can save the rest of the row.
+    supplier_id: Optional[int] = None
 
 
 class BOMItemResponse(BaseModel):
@@ -199,6 +208,18 @@ class BOMItemResponse(BaseModel):
     # supplier if the row's own ``supplier_url`` is empty.
     part_slug: Optional[str] = None
     part_primary_supplier_url: Optional[str] = None
+    # Supplier-pricing feature: the supplier the row is linked to, if
+    # any, plus the *resolved* price the frontend should render. When
+    # ``supplier_id`` points at a supplier with a non-NULL ``unit_cost``,
+    # ``effective_unit_cost`` / ``effective_currency_code`` mirror the
+    # supplier's live values and ``price_source`` is ``"supplier"``.
+    # Otherwise the row's own ``unit_cost`` / ``currency_code`` are
+    # echoed back and ``price_source`` is ``"row"``. The frontend just
+    # reads ``effective_*`` and renders — no client-side resolution.
+    supplier_id: Optional[int] = None
+    effective_unit_cost: Optional[float] = None
+    effective_currency_code: Optional[str] = None
+    price_source: str = "row"
 
 
 class LinkCreate(BaseModel):
@@ -375,6 +396,13 @@ class PartSupplierInput(BaseModel):
     # letters; the dropdown on the edit page only offers a curated list
     # plus "other / unknown" → NULL.
     country_code: Optional[str] = Field(None, pattern=r"^[A-Z]{2}$")
+    # Supplier-pricing feature: per-supplier price + currency. NULL means
+    # "no price recorded yet" — projects that link a BOM row to this
+    # supplier still fall back to the row's own unit_cost in that case.
+    # The price feeds every BOM row that points at this supplier via
+    # ``ProjectBOMItem.supplier_id``, so editing it auto-propagates.
+    unit_cost: Optional[float] = Field(None, ge=0)
+    currency_code: Optional[str] = Field(None, pattern=r"^[A-Z]{3}$")
 
 
 class PartSupplierResponse(BaseModel):
@@ -390,6 +418,11 @@ class PartSupplierResponse(BaseModel):
     is_broken: bool = False
     consecutive_failures: int = 0
     country_code: Optional[str] = None
+    # Supplier-pricing feature: live price + currency. Surfaced on the
+    # public part page next to each supplier link and as the value that
+    # auto-fills BOM rows linked via ``supplier_id``.
+    unit_cost: Optional[float] = None
+    currency_code: Optional[str] = None
 
 
 class PartCreate(BaseModel):

--- a/stacks/projects-api/tests/test_supplier_pricing.py
+++ b/stacks/projects-api/tests/test_supplier_pricing.py
@@ -1,0 +1,628 @@
+"""Tests for the supplier-pricing feature.
+
+Moves price + currency onto ``PartSupplier`` so a BOM row can link to a
+specific supplier via ``ProjectBOMItem.supplier_id`` and read the price
+live. Editing the supplier price auto-updates every linked BOM row's
+``effective_unit_cost`` on the next read — no per-row mutation needed.
+
+Covers:
+  * Supplier create + update round-trips with the new ``unit_cost`` +
+    ``currency_code`` fields.
+  * Revision-snapshot audit trail picks up pure price edits.
+  * BOM ``supplier_id`` resolution + fallback rules.
+  * Auto-update behaviour after a supplier price change.
+  * Stale ``supplier_id`` (supplier deleted via ``ON DELETE SET NULL``)
+    silently falling back to row values.
+  * Auth + 14-day account-age gate on supplier edits.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture(autouse=True)
+def _old_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend every account is 5 years old so the age gate passes by
+    default. Individual tests can override by reaching into the auth
+    module and substituting a "young account" stub.
+    """
+    from projects_api import auth as auth_module
+
+    async def _fake_age(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=365 * 5)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _fake_age)
+    auth_module._clear_account_age_cache()
+
+
+# --- helpers ------------------------------------------------------------
+
+
+async def _create_part(client) -> dict:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/parts",
+        json={
+            "name": "Pricing Test Servo",
+            "supplier_url": "https://thepihut.com/things",
+            "supplier_name": "ThePiHut",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _set_suppliers(client, slug: str, suppliers: list[dict]) -> dict:
+    headers = make_auth_header()
+    resp = await client.put(
+        f"/api/parts/{slug}",
+        json={"suppliers": suppliers, "change_summary": "Set suppliers"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _create_project(client, title: str = "Pricing Project") -> int:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/projects", json={"title": title}, headers=headers
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# --- supplier round-trips ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supplier_price_round_trips(client) -> None:
+    """PUT a supplier with unit_cost + currency_code, GET it back."""
+    part = await _create_part(client)
+    slug = part["slug"]
+    data = await _set_suppliers(
+        client,
+        slug,
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/products/servo",
+                "country_code": "GB",
+                "unit_cost": 12.5,
+                "currency_code": "GBP",
+            },
+            {
+                "name": "Adafruit",
+                "url": "https://www.adafruit.com/product/169",
+                "country_code": "US",
+                "unit_cost": 14.99,
+                "currency_code": "USD",
+            },
+        ],
+    )
+    by_name = {s["name"]: s for s in data["suppliers"]}
+    assert by_name["Pimoroni"]["unit_cost"] == 12.5
+    assert by_name["Pimoroni"]["currency_code"] == "GBP"
+    assert by_name["Adafruit"]["unit_cost"] == 14.99
+    assert by_name["Adafruit"]["currency_code"] == "USD"
+
+    # GET round-trips them too.
+    resp = await client.get(f"/api/parts/{slug}")
+    assert resp.status_code == 200
+    by_name = {s["name"]: s for s in resp.json()["suppliers"]}
+    assert by_name["Pimoroni"]["unit_cost"] == 12.5
+    assert by_name["Pimoroni"]["currency_code"] == "GBP"
+
+
+@pytest.mark.asyncio
+async def test_supplier_without_price_serializes_nulls(client) -> None:
+    """A supplier saved without a price should round-trip as null —
+    not omit the keys, not 500."""
+    part = await _create_part(client)
+    resp = await client.get(f"/api/parts/{part['slug']}")
+    suppliers = resp.json()["suppliers"]
+    assert len(suppliers) == 1
+    assert "unit_cost" in suppliers[0]
+    assert "currency_code" in suppliers[0]
+    assert suppliers[0]["unit_cost"] is None
+    assert suppliers[0]["currency_code"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_currency", ["gbp", "GB", "XYZ123", "G1P"])
+async def test_supplier_bad_currency_rejected_422(
+    client, bad_currency: str
+) -> None:
+    headers = make_auth_header()
+    part = await _create_part(client)
+    resp = await client.put(
+        f"/api/parts/{part['slug']}",
+        json={
+            "suppliers": [
+                {
+                    "name": "Pimoroni",
+                    "url": "https://shop.pimoroni.com/x",
+                    "unit_cost": 10.0,
+                    "currency_code": bad_currency,
+                }
+            ],
+            "change_summary": "Bad currency",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_supplier_negative_price_rejected_422(client) -> None:
+    headers = make_auth_header()
+    part = await _create_part(client)
+    resp = await client.put(
+        f"/api/parts/{part['slug']}",
+        json={
+            "suppliers": [
+                {
+                    "name": "Pimoroni",
+                    "url": "https://shop.pimoroni.com/x",
+                    "unit_cost": -1.0,
+                    "currency_code": "GBP",
+                }
+            ],
+            "change_summary": "Bad price",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# --- revision audit trail ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_price_edit_records_revision(client) -> None:
+    """Editing only the price (no other field touched) must still write
+    a new revision whose ``suppliers_json`` snapshot includes the new
+    ``unit_cost`` + ``currency_code``.
+    """
+    part = await _create_part(client)
+    slug = part["slug"]
+    # First, set a price so we have something to change.
+    first = await _set_suppliers(
+        client,
+        slug,
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                "unit_cost": 10.0,
+                "currency_code": "GBP",
+            }
+        ],
+    )
+    rev_count_before = len(first["recent_revisions"])
+
+    # Now change ONLY the price.
+    second = await _set_suppliers(
+        client,
+        slug,
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                "unit_cost": 15.0,
+                "currency_code": "GBP",
+            }
+        ],
+    )
+    rev_count_after = len(second["recent_revisions"])
+    assert rev_count_after == rev_count_before + 1, (
+        "Pure price edit should create a revision"
+    )
+
+    # The newest revision's snapshot should include the new price.
+    rev_id = second["recent_revisions"][0]["id"]
+    rev = await client.get(f"/api/parts/{slug}/revisions/{rev_id}")
+    assert rev.status_code == 200
+    rev_data = rev.json()
+    assert len(rev_data["suppliers"]) == 1
+    assert rev_data["suppliers"][0]["unit_cost"] == 15.0
+    assert rev_data["suppliers"][0]["currency_code"] == "GBP"
+
+
+# --- BOM resolution rules -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bom_supplier_id_resolves_to_supplier_price(client) -> None:
+    """A BOM row linked via ``supplier_id`` returns the supplier's
+    price in ``effective_unit_cost`` / ``effective_currency_code`` and
+    ``price_source = "supplier"``."""
+    part = await _create_part(client)
+    data = await _set_suppliers(
+        client,
+        part["slug"],
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                "unit_cost": 12.5,
+                "currency_code": "GBP",
+            }
+        ],
+    )
+    supplier_id = data["suppliers"][0]["id"]
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Linked Servo",
+            "quantity": 2,
+            "unit_cost": 999.99,  # Row value should be ignored.
+            "currency_code": "USD",  # Row currency should be ignored.
+            "part_id": data["id"],
+            "supplier_id": supplier_id,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    row = resp.json()
+    assert row["supplier_id"] == supplier_id
+    assert row["effective_unit_cost"] == 12.5
+    assert row["effective_currency_code"] == "GBP"
+    assert row["price_source"] == "supplier"
+    # The row's own values are still echoed back for reference.
+    assert row["unit_cost"] == 999.99
+    assert row["currency_code"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_bom_supplier_id_with_no_price_falls_back_to_row(client) -> None:
+    """A supplier without a price recorded should not override the
+    row's own values — ``price_source`` should be ``"row"``."""
+    part = await _create_part(client)
+    data = await _set_suppliers(
+        client,
+        part["slug"],
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                # No unit_cost / currency_code.
+            }
+        ],
+    )
+    supplier_id = data["suppliers"][0]["id"]
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Linked Servo",
+            "quantity": 1,
+            "unit_cost": 7.5,
+            "currency_code": "GBP",
+            "supplier_id": supplier_id,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    row = resp.json()
+    assert row["supplier_id"] == supplier_id
+    assert row["effective_unit_cost"] == 7.5
+    assert row["effective_currency_code"] == "GBP"
+    assert row["price_source"] == "row"
+
+
+@pytest.mark.asyncio
+async def test_bom_without_supplier_id_uses_row_values(client) -> None:
+    """Regression: BOM rows that pre-date this feature (no
+    ``supplier_id`` at all) still render their own price with
+    ``price_source = "row"``."""
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Manual row",
+            "quantity": 3,
+            "unit_cost": 4.25,
+            "currency_code": "EUR",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    row = resp.json()
+    assert row["supplier_id"] is None
+    assert row["effective_unit_cost"] == 4.25
+    assert row["effective_currency_code"] == "EUR"
+    assert row["price_source"] == "row"
+
+
+# --- auto-update propagation --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_editing_supplier_price_propagates_to_linked_bom(client) -> None:
+    """Edit the supplier's price; every BOM row linked to that supplier
+    sees the new price on the next GET — no per-row mutation needed."""
+    part = await _create_part(client)
+    data = await _set_suppliers(
+        client,
+        part["slug"],
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                "unit_cost": 12.5,
+                "currency_code": "GBP",
+            }
+        ],
+    )
+    supplier_id = data["suppliers"][0]["id"]
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    create = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Linked Servo",
+            "quantity": 1,
+            "supplier_id": supplier_id,
+        },
+        headers=headers,
+    )
+    assert create.status_code == 201
+    item_id = create.json()["id"]
+
+    # Bump the supplier's price. No touch on the BOM row.
+    await _set_suppliers(
+        client,
+        part["slug"],
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                "unit_cost": 99.0,
+                "currency_code": "GBP",
+            }
+        ],
+    )
+
+    # The BOM list should reflect the new price.
+    bom = await client.get(f"/api/projects/{project_id}/bom")
+    assert bom.status_code == 200
+    rows = bom.json()
+    assert len(rows) == 1
+    assert rows[0]["id"] == item_id
+    assert rows[0]["effective_unit_cost"] == 99.0
+    assert rows[0]["price_source"] == "supplier"
+
+
+# --- stale supplier_id (ON DELETE SET NULL fallback) --------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_supplier_id_silently_falls_back(client) -> None:
+    """A BOM row holding a supplier_id that doesn't exist (e.g. because
+    the supplier was deleted under us and ON DELETE SET NULL hasn't
+    been enforced — or, equivalently, a value the client typed that
+    points at no row) must silently fall back to the row's own price.
+    No 500, no exception, no leaking the stale id into the
+    effective_* fields.
+
+    We exercise this via the validate-or-drop path on POST: a
+    supplier_id of 999_999 (no row exists) is dropped and the
+    resolver sees supplier_id=None — the same shape the FK SET NULL
+    cascade would produce on Postgres.
+    """
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Stale-linked",
+            "quantity": 1,
+            "unit_cost": 3.0,
+            "currency_code": "GBP",
+            "supplier_id": 999_999,  # No such supplier.
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    row = resp.json()
+    assert row["supplier_id"] is None
+    assert row["effective_unit_cost"] == 3.0
+    assert row["effective_currency_code"] == "GBP"
+    assert row["price_source"] == "row"
+
+    bom = await client.get(f"/api/projects/{project_id}/bom")
+    assert bom.status_code == 200
+    rows = bom.json()
+    assert len(rows) == 1
+    assert rows[0]["effective_unit_cost"] == 3.0
+    assert rows[0]["price_source"] == "row"
+
+
+@pytest.mark.asyncio
+async def test_resolver_handles_truly_stale_supplier_id(
+    sessionmaker_, client
+) -> None:
+    """Defence-in-depth: even if a stale supplier_id leaks past the
+    POST validator (e.g. because the supplier was deleted AFTER the
+    BOM row was saved and the FK SET NULL hasn't fired), the
+    ``_to_response`` resolver must not crash and must report
+    ``price_source = "row"``.
+
+    We force the stale state by writing supplier_id directly on the
+    ProjectBOMItem via the session — bypassing the router's validator
+    — and then deleting the supplier underneath it.
+    """
+    from projects_api.models import (
+        Part, PartSupplier, Project, ProjectBOMItem,
+    )
+
+    part = await _create_part(client)
+    data = await _set_suppliers(
+        client,
+        part["slug"],
+        [
+            {
+                "name": "Pimoroni",
+                "url": "https://shop.pimoroni.com/x",
+                "unit_cost": 12.5,
+                "currency_code": "GBP",
+            }
+        ],
+    )
+    supplier_id = data["suppliers"][0]["id"]
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    create = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Linked",
+            "quantity": 1,
+            "unit_cost": 4.0,
+            "currency_code": "GBP",
+            "supplier_id": supplier_id,
+        },
+        headers=headers,
+    )
+    assert create.status_code == 201
+    item_id = create.json()["id"]
+
+    # Now delete the supplier directly (bypass the router so we keep
+    # the BOM row's FK pointing at it — simulating the race window
+    # before ON DELETE SET NULL fires on Postgres, or any other path
+    # that leaves a dangling id).
+    from sqlalchemy import delete as sql_delete
+
+    async with sessionmaker_() as s:
+        await s.execute(
+            sql_delete(PartSupplier).where(PartSupplier.id == supplier_id)
+        )
+        await s.commit()
+
+    bom = await client.get(f"/api/projects/{project_id}/bom")
+    assert bom.status_code == 200
+    rows = bom.json()
+    assert len(rows) == 1
+    assert rows[0]["id"] == item_id
+    # supplier_id may still be the stale value on SQLite (no FK
+    # enforcement) — what matters is that the resolver falls back.
+    assert rows[0]["effective_unit_cost"] == 4.0
+    assert rows[0]["effective_currency_code"] == "GBP"
+    assert rows[0]["price_source"] == "row"
+
+
+@pytest.mark.asyncio
+async def test_unknown_supplier_id_in_post_silently_dropped(client) -> None:
+    """Posting a BOM row with a supplier_id that doesn't exist should
+    NOT 400 — drop the FK and save the rest of the row (matches the
+    ``part_id`` validate-or-drop pattern)."""
+    project_id = await _create_project(client)
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={
+            "name": "Ghost-linked row",
+            "quantity": 1,
+            "unit_cost": 1.0,
+            "currency_code": "GBP",
+            "supplier_id": 999_999,  # Does not exist.
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    row = resp.json()
+    assert row["supplier_id"] is None
+    assert row["effective_unit_cost"] == 1.0
+    assert row["price_source"] == "row"
+
+
+# --- auth + age gate ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supplier_edit_enforces_age_gate(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A young account (account < 14 days old) cannot edit suppliers,
+    just like every other parts wiki edit."""
+    part = await _create_part(client)
+    slug = part["slug"]
+
+    # Now flip the account-age stub to "3 days old" for this test only.
+    from projects_api import auth as auth_module
+
+    async def _young(username: str, token: str) -> Optional[datetime]:
+        return datetime.utcnow() - timedelta(days=3)
+
+    monkeypatch.setattr(auth_module, "fetch_account_created_at", _young)
+    auth_module._clear_account_age_cache()
+
+    headers = make_auth_header()
+    resp = await client.put(
+        f"/api/parts/{slug}",
+        json={
+            "suppliers": [
+                {
+                    "name": "Pimoroni",
+                    "url": "https://shop.pimoroni.com/x",
+                    "unit_cost": 5.0,
+                    "currency_code": "GBP",
+                }
+            ],
+            "change_summary": "Try to edit",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_supplier_edit_requires_auth(client) -> None:
+    part = await _create_part(client)
+    # No auth header.
+    resp = await client.put(
+        f"/api/parts/{part['slug']}",
+        json={
+            "suppliers": [
+                {
+                    "name": "Pimoroni",
+                    "url": "https://shop.pimoroni.com/x",
+                    "unit_cost": 5.0,
+                    "currency_code": "GBP",
+                }
+            ],
+            "change_summary": "No auth",
+        },
+    )
+    assert resp.status_code == 401, resp.text
+
+
+# --- migration helpers no-op on SQLite ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_supplier_pricing_helper_is_noop_on_sqlite() -> None:
+    """The migration helper short-circuits on non-Postgres dialects so
+    it can be called on every startup without harm."""
+    from projects_api.db import add_supplier_pricing_if_missing
+
+    await add_supplier_pricing_if_missing()
+
+
+@pytest.mark.asyncio
+async def test_bom_supplier_id_helper_is_noop_on_sqlite() -> None:
+    """Same for the BOM FK helper — must be a no-op on SQLite."""
+    from projects_api.db import add_bom_supplier_id_if_missing
+
+    await add_bom_supplier_id_if_missing()

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -1372,8 +1372,43 @@
     ).join('');
   }
 
+  // Supplier-pricing feature: cache part detail responses so a BOM
+  // table with N rows linked to the same part doesn't re-fetch the
+  // part N times. Cleared on every BOM reload so price edits land.
+  let partSuppliersCache = {};
+
+  async function fetchPartSuppliers(slug) {
+    if (!slug) return [];
+    if (partSuppliersCache[slug]) return partSuppliersCache[slug];
+    try {
+      const resp = await fetch(API + '/api/parts/' + encodeURIComponent(slug));
+      if (!resp.ok) return [];
+      const part = await resp.json();
+      const suppliers = Array.isArray(part.suppliers) ? part.suppliers : [];
+      partSuppliersCache[slug] = suppliers;
+      return suppliers;
+    } catch (_) { return []; }
+  }
+
+  function supplierSelectOptions(suppliers, selectedId) {
+    // The "— manual price —" option unlinks the row; selecting it
+    // re-enables the manual unit_cost + currency inputs.
+    const opts = ['<option value="">— manual price —</option>'];
+    suppliers.forEach(s => {
+      const priceHint = (s.unit_cost != null)
+        ? ` (${(s.currency_code || '').trim() ? s.currency_code + ' ' : ''}${Number(s.unit_cost).toFixed(2)})`
+        : '';
+      const sel = String(s.id) === String(selectedId) ? ' selected' : '';
+      opts.push(
+        `<option value="${escapeHtmlAttr(s.id)}"${sel}>${escapeHtmlAttr((s.name || s.url) + priceHint)}</option>`
+      );
+    });
+    return opts.join('');
+  }
+
   async function loadBOM() {
     if (!currentProject) return;
+    partSuppliersCache = {};  // force-refresh prices on every load
     const resp = await apiFetch(API + '/api/projects/' + currentProject.id + '/bom', { credentials: 'include' });
     const items = await resp.json();
     const tbody = document.getElementById('bom-body');
@@ -1382,33 +1417,69 @@
       const partPill = linked
         ? `<a class="bom-part-pill" href="/parts/view.html?slug=${encodeURIComponent(item.part_slug)}" title="Linked to parts catalog" target="_blank"><i class="fas fa-link"></i> /parts/${escapeHtmlAttr(item.part_slug)}</a>`
         : (item.part_id ? `<span class="bom-part-pill" title="Linked to parts catalog"><i class="fas fa-link"></i> part #${item.part_id}</span>` : '');
-      const supplierHint = item.part_id
-        ? `<small class="bom-supplier-hint">from parts catalog</small>` : '';
-      const supplierReadonly = item.part_id ? ' readonly' : '';
+      // Supplier-pricing feature: when the row links to a supplier
+      // that has a non-NULL price, ``price_source`` is ``"supplier"``
+      // and the row's own unit_cost / currency inputs are disabled —
+      // the supplier is the source of truth. Selecting "— manual
+      // price —" re-enables them.
+      const supplierLocked = item.price_source === 'supplier';
+      const costDisabled = supplierLocked ? ' disabled' : '';
+      const currencyDisabled = supplierLocked ? ' disabled' : '';
+      // The cost cell shows the effective price (so the user sees what
+      // the project page will render) but the underlying field
+      // remains unit_cost — when the supplier is unlinked we still
+      // round-trip the row's own value.
+      const displayCost = supplierLocked
+        ? (item.effective_unit_cost != null ? item.effective_unit_cost : 0)
+        : (item.unit_cost != null ? item.unit_cost : 0);
+      const displayCurrency = supplierLocked
+        ? (item.effective_currency_code || '')
+        : (item.currency_code || '');
+      const supplierAutoBadge = supplierLocked
+        ? `<small class="text-success ms-1"><i class="fas fa-link"></i> Auto</small>`
+        : '';
+      // The supplier cell switches shape based on whether the row is
+      // linked to a part. Linked → <select> populated from the part's
+      // suppliers (async-filled below). Unlinked → free-form URL
+      // input (the legacy behaviour).
+      const supplierCell = linked
+        ? `<select class="form-select form-select-sm bom-supplier-select" data-field="supplier_id" data-current-supplier-id="${escapeHtmlAttr(item.supplier_id || '')}" onchange="updateBOM(${item.id}, this)" title="Pick a supplier from the parts catalog">
+             <option value="">— loading suppliers… —</option>
+           </select>
+           <small class="bom-supplier-hint">price comes from chosen supplier</small>`
+        : `<input value="${escapeHtmlAttr(item.supplier_url || '')}" data-field="supplier_url" onchange="updateBOM(${item.id}, this)">`;
       return `
-      <tr data-bom-id="${item.id}" data-part-id="${item.part_id || ''}" data-part-slug="${escapeHtmlAttr(item.part_slug || '')}">
+      <tr data-bom-id="${item.id}" data-part-id="${item.part_id || ''}" data-part-slug="${escapeHtmlAttr(item.part_slug || '')}" data-supplier-id="${escapeHtmlAttr(item.supplier_id || '')}" data-price-source="${escapeHtmlAttr(item.price_source || 'row')}">
         <td class="bom-part-cell" style="position:relative">
           <input class="bom-part-input" value="${escapeHtmlAttr(item.name)}" data-field="name" autocomplete="off" placeholder="Type to search parts catalog..." onchange="updateBOM(${item.id}, this)">
           ${partPill}
         </td>
         <td><input type="number" value="${item.quantity}" data-field="quantity" style="width:50px" onchange="updateBOM(${item.id}, this)"></td>
         <td><input value="${escapeHtmlAttr(item.unit)}" data-field="unit" style="width:50px" onchange="updateBOM(${item.id}, this)"></td>
-        <td><input type="number" step="0.01" value="${item.unit_cost || 0}" data-field="unit_cost" style="width:70px" onchange="updateBOM(${item.id}, this)"></td>
+        <td><input type="number" step="0.01" value="${displayCost}" data-field="unit_cost" style="width:70px"${costDisabled} onchange="updateBOM(${item.id}, this)">${supplierAutoBadge}</td>
         <td>
-          <select class="form-select form-select-sm" data-field="currency_code" style="width:90px" onchange="updateBOM(${item.id}, this)" title="Currency for this unit cost">
-            ${bomCurrencyOptions(item.currency_code)}
+          <select class="form-select form-select-sm" data-field="currency_code" style="width:90px"${currencyDisabled} onchange="updateBOM(${item.id}, this)" title="Currency for this unit cost">
+            ${bomCurrencyOptions(displayCurrency)}
           </select>
         </td>
-        <td>
-          <input value="${escapeHtmlAttr(item.supplier_url || '')}" data-field="supplier_url"${supplierReadonly} onchange="updateBOM(${item.id}, this)">
-          ${supplierHint}
-        </td>
+        <td>${supplierCell}</td>
         <td><button class="btn btn-sm text-danger" onclick="deleteBOM(${item.id})"><i class="fas fa-times"></i></button></td>
       </tr>`;
     }).join('');
     updateBOMTotal(items);
     // Wire up the parts autosuggest on every Part-name input
     tbody.querySelectorAll('.bom-part-input').forEach(setupPartsAutosuggest);
+    // Async-fill the supplier <select>s for linked rows. Promises are
+    // independent per row and deduped via partSuppliersCache.
+    tbody.querySelectorAll('tr[data-part-slug]').forEach(async (row) => {
+      const slug = row.dataset.partSlug;
+      if (!slug) return;
+      const sel = row.querySelector('.bom-supplier-select');
+      if (!sel) return;
+      const suppliers = await fetchPartSuppliers(slug);
+      const currentId = sel.dataset.currentSupplierId || '';
+      sel.innerHTML = supplierSelectOptions(suppliers, currentId);
+    });
   }
 
   function updateBOMTotal(items) {
@@ -1420,7 +1491,8 @@
     const row = input.closest('tr');
     const data = {};
     // Issue #149: read both <input> and <select> fields so the currency
-    // dropdown is included in the PUT body.
+    // dropdown is included in the PUT body. Supplier-pricing feature:
+    // also pick up the supplier_id <select> when the row is linked.
     row.querySelectorAll('input, select').forEach(inp => {
       const field = inp.dataset.field;
       if (!field) return;
@@ -1431,6 +1503,13 @@
         const code = String(val || '').trim().toUpperCase();
         // Empty -> null so the server-side pattern doesn't fire on "".
         val = code || null;
+      }
+      else if (field === 'supplier_id') {
+        // Empty string means "— manual price —"; send null so the
+        // backend clears the FK and the row falls back to its own
+        // unit_cost + currency_code.
+        const num = parseInt(val);
+        val = Number.isFinite(num) ? num : null;
       }
       data[field] = val;
     });
@@ -1444,14 +1523,16 @@
         body: JSON.stringify(data),
       });
     } catch (e) { loadBOM(); return; }
-    // If an older backend rejects the new part_id or currency_code field,
-    // retry without those so the user's edit still saves. Treat 4xx as
-    // "field rejected"; 5xx is a real server error and we just let it
-    // fall through.
-    if (!resp.ok && resp.status >= 400 && resp.status < 500 && (partId || 'currency_code' in data)) {
+    // If an older backend rejects the new part_id / currency_code /
+    // supplier_id field, retry without those so the user's edit
+    // still saves. Treat 4xx as "field rejected"; 5xx is a real
+    // server error and we just let it fall through.
+    const newFields = partId || 'currency_code' in data || 'supplier_id' in data;
+    if (!resp.ok && resp.status >= 400 && resp.status < 500 && newFields) {
       const retryData = Object.assign({}, data);
       delete retryData.part_id;
       delete retryData.currency_code;
+      delete retryData.supplier_id;
       try {
         await apiFetch(API + '/api/projects/' + currentProject.id + '/bom/' + itemId, {
           method: 'PUT', credentials: 'include',

--- a/web/parts/edit.html
+++ b/web/parts/edit.html
@@ -173,7 +173,8 @@ description: Edit a part in the catalog
     if (e.key === 'Enter') { e.preventDefault(); document.getElementById('part-add-tag-btn').click(); }
   });
 
-  // --- Suppliers (issue #149: + country picker) ---
+  // --- Suppliers (issue #149: + country picker;
+  //                supplier-pricing-feature: + price + currency) ---
   // Curated short-list of common supplier countries. "" maps to NULL
   // server-side (legacy / unknown). Order matches the most common
   // hobbyist suppliers we link to.
@@ -197,19 +198,52 @@ description: Edit a part in the catalog
     ).join('');
   }
 
+  // Same shortlist as the BOM editor (web/assets/js/project-editor.js).
+  // Keep these two in sync — the supplier-pricing feature reads from
+  // here and writes BOM-row labels that the project editor mirrors.
+  const SUPPLIER_CURRENCIES = [
+    { code: '',    label: '— (no price)' },
+    { code: 'GBP', label: 'GBP £' },
+    { code: 'USD', label: 'USD $' },
+    { code: 'EUR', label: 'EUR €' },
+    { code: 'JPY', label: 'JPY ¥' },
+    { code: 'AUD', label: 'AUD A$' },
+    { code: 'CAD', label: 'CAD C$' },
+  ];
+  function currencyOptionsHtml(selected) {
+    const sel = (selected || '').toUpperCase();
+    return SUPPLIER_CURRENCIES.map(c =>
+      `<option value="${esc(c.code)}"${c.code === sel ? ' selected' : ''}>${esc(c.label)}</option>`
+    ).join('');
+  }
+
   const suppliersList = document.getElementById('suppliers-list');
   function renderSuppliers(suppliers) {
     suppliersList.innerHTML = '';
-    (suppliers || []).forEach(s => addSupplierRow(s.name || '', s.url || '', s.country_code || ''));
+    (suppliers || []).forEach(s => addSupplierRow(
+      s.name || '',
+      s.url || '',
+      s.country_code || '',
+      s.unit_cost,
+      s.currency_code || ''
+    ));
   }
-  function addSupplierRow(name, url, countryCode) {
+  function addSupplierRow(name, url, countryCode, unitCost, currencyCode) {
     const row = document.createElement('div');
-    row.className = 'row g-2 mb-2 supplier-row';
+    row.className = 'supplier-row mb-3 p-2 border rounded';
+    const priceVal = (unitCost == null || unitCost === '') ? '' : Number(unitCost);
     row.innerHTML = `
-      <div class="col-md-3"><input type="text" class="form-control form-control-sm supplier-name" placeholder="Supplier name" value="${esc(name)}"></div>
-      <div class="col-md-6"><input type="url" class="form-control form-control-sm supplier-url" placeholder="https://..." value="${esc(url)}"></div>
-      <div class="col-md-2"><select class="form-select form-select-sm supplier-country" aria-label="Supplier country">${countryOptionsHtml(countryCode)}</select></div>
-      <div class="col-md-1 d-flex align-items-center"><button class="btn btn-sm text-danger supplier-remove" type="button" aria-label="Remove"><i class="fas fa-times"></i></button></div>
+      <div class="row g-2 mb-1 align-items-center">
+        <div class="col-md-3"><input type="text" class="form-control form-control-sm supplier-name" placeholder="Supplier name" value="${esc(name)}"></div>
+        <div class="col-md-6"><input type="url" class="form-control form-control-sm supplier-url" placeholder="https://..." value="${esc(url)}"></div>
+        <div class="col-md-2"><select class="form-select form-select-sm supplier-country" aria-label="Supplier country">${countryOptionsHtml(countryCode)}</select></div>
+        <div class="col-md-1 d-flex align-items-center justify-content-end"><button class="btn btn-sm text-danger supplier-remove" type="button" aria-label="Remove"><i class="fas fa-times"></i></button></div>
+      </div>
+      <div class="row g-2 align-items-center">
+        <div class="col-md-3"><input type="number" min="0" step="0.01" class="form-control form-control-sm supplier-cost" placeholder="Unit cost" value="${esc(priceVal === '' ? '' : priceVal)}" aria-label="Unit cost"></div>
+        <div class="col-md-2"><select class="form-select form-select-sm supplier-currency" aria-label="Currency">${currencyOptionsHtml(currencyCode)}</select></div>
+        <div class="col-md-7"><small class="text-muted">Used by any project that links its BOM row to this supplier — editing here auto-updates those rows.</small></div>
+      </div>
     `;
     row.querySelector('.supplier-remove').addEventListener('click', () => row.remove());
     suppliersList.appendChild(row);
@@ -217,6 +251,15 @@ description: Edit a part in the catalog
   function getSuppliers() {
     return Array.from(suppliersList.querySelectorAll('.supplier-row')).map(r => {
       const code = r.querySelector('.supplier-country').value.trim().toUpperCase();
+      const currency = r.querySelector('.supplier-currency').value.trim().toUpperCase();
+      const costRaw = r.querySelector('.supplier-cost').value.trim();
+      // Pydantic ge=0 — anything <0 is rejected server-side, so we
+      // clamp here for a friendlier UX. Empty string -> NULL.
+      let cost = null;
+      if (costRaw !== '') {
+        const parsed = parseFloat(costRaw);
+        if (!Number.isNaN(parsed) && parsed >= 0) cost = parsed;
+      }
       return {
         name: r.querySelector('.supplier-name').value.trim(),
         url: r.querySelector('.supplier-url').value.trim(),
@@ -224,10 +267,12 @@ description: Edit a part in the catalog
         // accepts two uppercase letters, so we omit the key entirely
         // for the "Other / unknown" option.
         country_code: code || null,
+        unit_cost: cost,
+        currency_code: currency || null,
       };
     }).filter(s => s.name || s.url);
   }
-  document.getElementById('add-supplier-btn').addEventListener('click', () => addSupplierRow('', '', ''));
+  document.getElementById('add-supplier-btn').addEventListener('click', () => addSupplierRow('', '', '', null, ''));
 
   // --- Category dropdown + family autocomplete (issue #135) ---
   async function loadCategories() {

--- a/web/parts/view.html
+++ b/web/parts/view.html
@@ -259,6 +259,21 @@ description: View a part in the catalog
     return `<span class="badge bg-light text-dark ms-2" title="Supplier country: ${esc(up)}">${flag} ${esc(up)}</span>`;
   }
 
+  // Supplier-pricing feature: render a small "GBP 12.50"-style pill
+  // next to the supplier link when a price is set. Suppressed entirely
+  // when unit_cost is null so suppliers without recorded prices look
+  // unchanged.
+  function supplierPriceBadge(supplier) {
+    if (!supplier || supplier.unit_cost == null) return '';
+    const amount = Number(supplier.unit_cost).toFixed(2);
+    const code = (supplier.currency_code || '').trim().toUpperCase();
+    const label = code ? `${code} ${amount}` : amount;
+    const title = code
+      ? `Supplier price: ${code} ${amount}`
+      : `Supplier price: ${amount} (currency not set)`;
+    return `<span class="badge bg-success-subtle text-success ms-2" title="${esc(title)}"><i class="fas fa-tag me-1"></i>${esc(label)}</span>`;
+  }
+
   function fmtTime(dateStr) {
     if (!dateStr) return 'unknown';
     try { return new Date(dateStr).toLocaleDateString(); } catch (_) { return 'unknown'; }
@@ -327,6 +342,7 @@ description: View a part in the catalog
         <li class="list-group-item d-flex justify-content-between align-items-center">
           <div>
             <a href="${esc(s.url)}" target="_blank" rel="noopener">${esc(s.name || s.url)} <i class="fas fa-external-link-alt fa-xs text-muted"></i></a>
+            ${supplierPriceBadge(s)}
             ${supplierBrokenPill(s)}
             ${countryFlagBadge(s.country_code)}
             ${supplierStatusBadge(s.last_status)}

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -887,11 +887,22 @@ description: View project details
     let total = 0;
     // Tally currency codes so we can label the (un-converted) total with
     // the dominant one (issue #149) — or omit the symbol entirely if rows
-    // span more than one currency.
+    // span more than one currency. Supplier-pricing feature: the
+    // *effective* code (which is the supplier's currency when the row
+    // is linked to a priced supplier) drives both the per-row display
+    // and the dominant-currency tally.
     const currencyCounts = {};
     tbody.innerHTML = items.map((i, idx) => {
-      total += i.quantity * (i.unit_cost || 0);
-      const code = (i.currency_code || '').trim().toUpperCase();
+      // Use the resolved fields the server pre-computed. Old payloads
+      // (before the supplier-pricing feature shipped) don't carry
+      // effective_*; fall back to the row's own values so this page
+      // stays back-compat with stale CDN-cached responses.
+      const cost = (i.effective_unit_cost != null)
+        ? i.effective_unit_cost
+        : i.unit_cost;
+      const ccyEffective = i.effective_currency_code || i.currency_code || null;
+      total += i.quantity * (cost || 0);
+      const code = (ccyEffective || '').trim().toUpperCase();
       if (code) currencyCounts[code] = (currencyCounts[code] || 0) + 1;
       // If a part_id + slug came back with the BOM row, link the part name to
       // its parts-catalog page. Backwards compatible: rows without part_slug
@@ -903,17 +914,22 @@ description: View project details
       // Show bare native price up-front so the page renders without
       // waiting for the FX endpoint. The async enrichment below
       // replaces this cell with a converted suffix when applicable.
-      const ccy = i.currency_code || null;
-      const priceHtml = i.unit_cost == null
+      const priceHtml = cost == null
         ? '-'
         : (window.CurrencyConvert
-            ? CurrencyConvert.formatPrice(i.unit_cost, ccy || 'GBP')
-            : ('£' + Number(i.unit_cost).toFixed(2)));
+            ? CurrencyConvert.formatPrice(cost, ccyEffective || 'GBP')
+            : ('£' + Number(cost).toFixed(2)));
+      // Supplier-pricing feature: tiny link icon flags rows whose
+      // price came from the part's supplier rather than the row's own
+      // value. Helps viewers reason about why a price changed.
+      const supplierIndicator = i.price_source === 'supplier'
+        ? ' <i title="From supplier" class="fas fa-link text-muted small"></i>'
+        : '';
       return `<tr>
         <td>${nameCell}</td>
         <td>${i.quantity}</td>
         <td>${esc(i.unit)}</td>
-        <td data-bom-price="${idx}">${priceHtml}</td>
+        <td data-bom-price="${idx}" data-bom-ccy="${esc(ccyEffective || '')}" data-bom-cost="${cost == null ? '' : esc(cost)}">${priceHtml}${supplierIndicator}</td>
         <td>${supplierUrl ? `<a href="${esc(supplierUrl)}" target="_blank">Link <i class="fas fa-external-link-alt fa-xs"></i></a>` : '-'}</td>
       </tr>`;
     }).join('');
@@ -938,15 +954,26 @@ description: View project details
     // with a formatted "native (≈ converted)" string. Graceful
     // degradation: any failure (cold cache, no preference, missing
     // currency_code) leaves the bare native price in place.
+    // Supplier-pricing feature: read the effective_* values rather
+    // than the row's own — so a row that pulls its price from a
+    // supplier converts that supplier's price (which is the one the
+    // user actually sees in the table).
     if (window.CurrencyConvert) {
       items.forEach(async (i, idx) => {
-        if (i.unit_cost == null) return;
-        const ccy = i.currency_code;
+        const cost = (i.effective_unit_cost != null)
+          ? i.effective_unit_cost
+          : i.unit_cost;
+        if (cost == null) return;
+        const ccy = i.effective_currency_code || i.currency_code;
         if (!ccy) return;
         const cell = tbody.querySelector(`[data-bom-price="${idx}"]`);
         if (!cell) return;
+        // Preserve the trailing supplier-link icon if present.
+        const indicator = i.price_source === 'supplier'
+          ? ' <i title="From supplier" class="fas fa-link text-muted small"></i>'
+          : '';
         try {
-          cell.innerHTML = await CurrencyConvert.renderPrice(i.unit_cost, ccy);
+          cell.innerHTML = (await CurrencyConvert.renderPrice(cost, ccy)) + indicator;
         } catch (_) { /* keep the native fallback */ }
       });
     }


### PR DESCRIPTION
## Summary
Implements #167. Part prices live on the supplier; BOM rows linked to a supplier resolve price + currency at read time, so a single supplier-price edit propagates to every project that links it.

### Backend
- **`PartSupplier.unit_cost`** (Float, nullable) + **`PartSupplier.currency_code`** (CHAR(3), nullable). Helper `add_supplier_pricing_if_missing`.
- **`ProjectBOMItem.supplier_id`** (FK -> `part_suppliers.id`, `ON DELETE SET NULL`, indexed). Helper `add_bom_supplier_id_if_missing` (two-step pattern: column first, conditional FK).
- **`BOMItemResponse`** gains `supplier_id`, `effective_unit_cost`, `effective_currency_code`, `price_source` (`"supplier" | "row"`).
- **Supplier diff/signature** extended to compare price + currency so changes register as revisions; `_suppliers_to_json` snapshots both fields into `PartRevision.suppliers_json`.
- **N+1 avoided**: BOM list batches supplier lookups via one `WHERE id IN (:ids)` SELECT.

### Frontend
- `web/parts/edit.html`: per-supplier `unit_cost` + currency inputs.
- `web/parts/view.html`: supplier price pill (e.g. `Pimoroni · GBP 12.50 · 🇬🇧 GB`).
- `web/assets/js/project-editor.js`: BOM row supplier `<select>` (replaces free-form URL when row is linked to a part); manual price inputs lock when supplier chosen; `partSuppliersCache` avoids refetching per row.
- `web/projects/view.html`: renders `effective_unit_cost`/`effective_currency_code` + `fa-link` icon when `price_source === "supplier"`.

### Behaviour
- Stale `supplier_id` (supplier deleted, FK SET NULL): silently falls back to row values; `price_source = "row"`. Covered by `test_resolver_handles_truly_stale_supplier_id`.
- Auth + 14-day account-age gate on supplier edits (existing pattern).
- Backward compat: rows without `supplier_id` keep their manual price exactly as today.

### Tests
19 new in `test_supplier_pricing.py`. Full suite **321 passing**.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)