### PR TITLE
feat(terms): projects-hub T&Cs acceptance gate (#168)

### DIFF
--- a/stacks/projects-api/projects_api/auth.py
+++ b/stacks/projects-api/projects_api/auth.py
@@ -143,6 +143,102 @@ async def get_optional_user(
         return None
 
 
+async def _check_terms_accepted(session: AsyncSession, user: str) -> None:
+    """Raise 403 ``terms_not_accepted`` if ``user`` hasn't accepted the
+    current T&Cs version.
+
+    Lazily creates a ``users`` row with ``is_disabled=False`` and
+    ``terms_accepted_at=None`` when none exists yet, so the subsequent
+    ``POST /api/users/me/accept-terms`` call can update it in place.
+
+    Shared by :func:`require_terms_accepted` and
+    :func:`require_terms_accepted_aged` so the gate behaviour is identical
+    regardless of which auth dependency the route uses.
+    """
+    # Local import to avoid the models -> db -> auth -> models cycle.
+    from .models import User
+
+    settings = get_settings()
+    current_version = settings.current_terms_version
+
+    row = await session.scalar(select(User).where(User.username == user))
+    if row is None:
+        # Lazily create the row so accept-terms can update it later.
+        row = User(username=user, is_disabled=False)
+        session.add(row)
+        try:
+            await session.commit()
+        except Exception:  # noqa: BLE001 — racing duplicate insert is fine
+            await session.rollback()
+            row = await session.scalar(
+                select(User).where(User.username == user)
+            )
+
+    accepted = (
+        row is not None
+        and row.terms_accepted_at is not None
+        and row.terms_accepted_version == current_version
+    )
+    if not accepted:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "detail": "terms_not_accepted",
+                "current_version": current_version,
+            },
+        )
+
+
+async def require_terms_accepted(
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> str:
+    """FastAPI dependency: 403 when the user hasn't accepted the current T&Cs.
+
+    The shape of the 403 body is a stable contract the frontend depends on
+    to detect "this is a terms-acceptance problem, not a generic auth
+    error"::
+
+        {"detail": "terms_not_accepted", "current_version": "1.0"}
+
+    A user is considered "accepted" when their ``users`` row has a non-null
+    ``terms_accepted_at`` AND ``terms_accepted_version`` exactly matches
+    ``settings.current_terms_version``. Older versions are treated as not
+    accepted so a version bump forces everyone to re-agree.
+
+    Edge case: if the ``users`` row doesn't exist yet (first write from a
+    brand-new account), we auto-create it with ``is_disabled=False`` and
+    ``terms_accepted_at=None`` and THEN raise the 403. This keeps the row
+    available for the subsequent ``POST /api/users/me/accept-terms`` call.
+    """
+    await _check_terms_accepted(session, user)
+    return user
+
+
+async def require_terms_accepted_aged(
+    access_token: Optional[str] = Cookie(default=None),
+    authorization: Optional[str] = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> str:
+    """Combined dependency: 14-day account-age gate + T&Cs acceptance gate.
+
+    Used by parts-catalog mutation endpoints (POST/PUT/restore) and the
+    parts-moderation merge endpoints — they already required
+    :func:`get_current_user_aged`, this wrapper layers the terms-acceptance
+    check on top so both gates fire in the right order (auth -> disabled
+    -> age -> terms). The 403 ``terms_not_accepted`` payload shape matches
+    :func:`require_terms_accepted` so the frontend's gate-handling path
+    works regardless of which dependency raised it.
+    """
+    username = await get_current_user_aged(
+        access_token=access_token,
+        authorization=authorization,
+        session=session,
+    )
+    await _check_terms_accepted(session, username)
+    return username
+
+
 def require_admin(user: str = Depends(get_current_user)) -> str:
     """FastAPI dependency: 401 if not logged in, 403 if not in the admin list.
 

--- a/stacks/projects-api/projects_api/config.py
+++ b/stacks/projects-api/projects_api/config.py
@@ -73,6 +73,13 @@ class Settings(BaseSettings):
     max_image_size: int = 10 * 1024 * 1024  # 10MB
     max_project_storage: int = 50 * 1024 * 1024  # 50MB total per project
 
+    # T&Cs acceptance gate (terms-gate). Bumping this value forces every
+    # already-accepted user to re-accept on their next upload attempt; the
+    # frontend reads ``current_terms_version`` from ``/api/auth/me`` and
+    # compares it with the user's stored ``terms_accepted_version``. Keep
+    # the format short (e.g. "1.0", "1.1") — the column is ``String(20)``.
+    current_terms_version: str = "1.0"
+
     # IP hashing for download dedup — never expose raw IPs in API responses.
     # In production, set this via env (e.g. IP_HASH_SALT=...) to a long random
     # value so hashes are not predictable. Default is a per-process random

--- a/stacks/projects-api/projects_api/db.py
+++ b/stacks/projects-api/projects_api/db.py
@@ -353,6 +353,53 @@ async def add_user_disabled_columns_if_missing() -> None:
             ))
 
 
+async def add_user_terms_acceptance_if_missing() -> None:
+    """Additive migration for the T&Cs acceptance gate (terms-gate).
+
+    Adds ``terms_accepted_at`` (TIMESTAMP NULL) and
+    ``terms_accepted_version`` (VARCHAR(20) NULL) to the existing
+    ``users`` table when they do not already exist. On fresh deploys
+    ``create_all`` builds the columns from the ORM definition, so this
+    helper is a no-op there. Postgres-only; SQLite tests rely on
+    ``create_all`` against a fresh in-memory DB.
+
+    Safe to run on every startup — runs an idempotent
+    ``information_schema`` probe before each ALTER.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.begin() as conn:
+        table_check = await conn.execute(text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = 'users'"
+        ))
+        if table_check.first() is None:
+            # Brand-new deployment — create_all on the same startup pass
+            # will build the table with every column already present.
+            return
+
+        existing = await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'users'"
+        ))
+        cols = {row[0] for row in existing.fetchall()}
+
+        if "terms_accepted_at" not in cols:
+            logger.warning("Adding users.terms_accepted_at column (terms-gate)")
+            await conn.execute(text(
+                'ALTER TABLE "users" ADD COLUMN "terms_accepted_at" TIMESTAMP'
+            ))
+        if "terms_accepted_version" not in cols:
+            logger.warning(
+                "Adding users.terms_accepted_version column (terms-gate)"
+            )
+            await conn.execute(text(
+                'ALTER TABLE "users" ADD COLUMN "terms_accepted_version" '
+                'VARCHAR(20)'
+            ))
+
+
 async def add_supplier_health_columns_if_missing() -> None:
     """Additive migration for issue #122 Phase 2 (supplier link health).
 

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -26,6 +26,7 @@ from .db import (
     add_user_currency_preference_if_missing,
     add_user_disabled_columns_if_missing,
     add_user_profile_columns_if_missing,
+    add_user_terms_acceptance_if_missing,
     create_all,
     get_sessionmaker,
     repair_stale_fks,
@@ -83,6 +84,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await add_user_currency_preference_if_missing()
     # Issue #136: ensure users.is_disabled / disabled_reason columns exist.
     await add_user_disabled_columns_if_missing()
+    # T&Cs acceptance gate (terms-gate): ensure terms_accepted_at +
+    # terms_accepted_version columns exist on legacy Postgres deployments.
+    await add_user_terms_acceptance_if_missing()
     # Issue #152: add projects.slug + (author_username, slug) unique
     # constraint + backfill legacy rows. Must run after create_all (which
     # builds the table on fresh deploys) and before any router handles a

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -751,6 +751,15 @@ class User(Base):
     )
     disabled_reason: Mapped[Optional[str]] = mapped_column(Text)
     disabled_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    # T&Cs acceptance gate for the Projects Hub (issue: terms-gate).
+    # ``terms_accepted_at`` is the UTC timestamp at which the user clicked
+    # "I agree" in the modal; ``terms_accepted_version`` records WHICH
+    # version of the T&Cs they signed off on. Both nullable for back-compat
+    # with users who pre-date the gate — the runtime check treats null as
+    # "needs to accept". When ``settings.current_terms_version`` is bumped
+    # the user gets re-prompted to accept the new version.
+    terms_accepted_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    terms_accepted_version: Mapped[Optional[str]] = mapped_column(String(20))
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )

--- a/stacks/projects-api/projects_api/routers/auth.py
+++ b/stacks/projects-api/projects_api/routers/auth.py
@@ -18,9 +18,13 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import extract_token, fetch_chatter_me, get_current_user
 from ..config import get_settings
+from ..db import get_session
+from ..models import User
 
 router = APIRouter(tags=["auth"])
 
@@ -59,12 +63,17 @@ async def auth_me(
     response: Response,
     username: str = Depends(get_current_user),
     token: Optional[str] = Depends(extract_token),
+    session: AsyncSession = Depends(get_session),
 ) -> dict[str, Any]:
     """Return the authenticated user's profile.
 
     Raises 401 (via :func:`get_current_user`) if no valid session token
     is present. On success, enriches the local view (username,
     is_admin) with Chatter's ``/api/me`` payload when available.
+
+    Also exposes the T&Cs acceptance state (terms-gate) so the frontend
+    can decide upfront whether to block uploads — no need to wait for a
+    write to 403 with ``terms_not_accepted`` first.
     """
     response.headers["Cache-Control"] = "no-store"
 
@@ -96,6 +105,17 @@ async def auth_me(
     if not isinstance(avatar_url, str):
         avatar_url = None
 
+    # T&Cs acceptance — read the local users row (lazy; null when missing).
+    terms_accepted_at: Optional[str] = None
+    terms_accepted_version: Optional[str] = None
+    user_row = await session.scalar(select(User).where(User.username == username))
+    if user_row is not None:
+        if user_row.terms_accepted_at is not None:
+            terms_accepted_at = user_row.terms_accepted_at.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+        terms_accepted_version = user_row.terms_accepted_version
+
     return {
         "id": user_id,
         "username": username,
@@ -103,4 +123,7 @@ async def auth_me(
         "is_admin": is_admin,
         "created_at": created_at,
         "avatar_url": avatar_url,
+        "terms_accepted_at": terms_accepted_at,
+        "terms_accepted_version": terms_accepted_version,
+        "current_terms_version": settings.current_terms_version,
     }

--- a/stacks/projects-api/projects_api/routers/bom.py
+++ b/stacks/projects-api/projects_api/routers/bom.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..db import get_session
 from ..models import Part, PartSupplier, Project, ProjectBOMItem
 from ..schemas import BOMItemCreate, BOMItemResponse
@@ -135,7 +135,7 @@ async def list_bom(
 async def add_bom_item(
     project_id: int,
     body: BOMItemCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> BOMItemResponse:
     await _check_owner(session, project_id, user)
@@ -165,7 +165,7 @@ async def update_bom_item(
     project_id: int,
     item_id: int,
     body: BOMItemCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> BOMItemResponse:
     await _check_owner(session, project_id, user)
@@ -198,7 +198,7 @@ async def update_bom_item(
 async def delete_bom_item(
     project_id: int,
     item_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     await _check_owner(session, project_id, user)

--- a/stacks/projects-api/projects_api/routers/feedback.py
+++ b/stacks/projects-api/projects_api/routers/feedback.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import UploadFile
 from starlette.formparsers import MultiPartException
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..db import get_session
 from ..models import Feedback
 from ..schemas import FeedbackCreate, FeedbackCreateResponse
@@ -62,7 +62,7 @@ def _coerce_optional_str(value: object) -> Optional[str]:
 )
 async def create_feedback(
     request: Request,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> FeedbackCreateResponse:
     """Create a new feedback row.

--- a/stacks/projects-api/projects_api/routers/files.py
+++ b/stacks/projects-api/projects_api/routers/files.py
@@ -12,7 +12,7 @@ from fastapi.responses import Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user, get_optional_user
+from ..auth import get_current_user, get_optional_user, require_terms_accepted
 from ..config import get_settings
 from ..db import get_session
 from ..models import Download, Project, ProjectFile
@@ -138,7 +138,7 @@ async def list_files(
 async def upload_file(
     project_id: int,
     file: UploadFile,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> FileResponse:
     project = await session.get(Project, project_id)
@@ -223,7 +223,7 @@ async def download_file(
 async def delete_file_endpoint(
     project_id: int,
     file_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     project = await session.get(Project, project_id)

--- a/stacks/projects-api/projects_api/routers/images.py
+++ b/stacks/projects-api/projects_api/routers/images.py
@@ -7,7 +7,7 @@ from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..config import get_settings
 from ..db import get_session
 from ..models import Project, ProjectImage
@@ -42,7 +42,7 @@ async def list_images(
 async def upload_image(
     project_id: int,
     file: UploadFile,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> ImageResponse:
     project = await session.get(Project, project_id)
@@ -101,7 +101,7 @@ async def update_image(
     project_id: int,
     image_id: int,
     body: dict,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> ImageResponse:
     project = await session.get(Project, project_id)
@@ -125,7 +125,7 @@ async def update_image(
 async def delete_image(
     project_id: int,
     image_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     project = await session.get(Project, project_id)

--- a/stacks/projects-api/projects_api/routers/journal.py
+++ b/stacks/projects-api/projects_api/routers/journal.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..db import get_session
 from ..models import Project, ProjectJournalEntry
 from ..schemas import JournalEntryCreate, JournalEntryResponse
@@ -35,7 +35,7 @@ async def list_entries(
 async def add_entry(
     project_id: int,
     body: JournalEntryCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> JournalEntryResponse:
     project = await session.get(Project, project_id)
@@ -55,7 +55,7 @@ async def update_entry(
     project_id: int,
     entry_id: int,
     body: JournalEntryCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> JournalEntryResponse:
     project = await session.get(Project, project_id)
@@ -78,7 +78,7 @@ async def update_entry(
 async def delete_entry(
     project_id: int,
     entry_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     project = await session.get(Project, project_id)

--- a/stacks/projects-api/projects_api/routers/links.py
+++ b/stacks/projects-api/projects_api/routers/links.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..db import get_session
 from ..models import Project, ProjectLink
 from ..schemas import LinkCreate, LinkResponse
@@ -31,7 +31,7 @@ async def list_links(
 async def add_link(
     project_id: int,
     body: LinkCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> LinkResponse:
     project = await session.get(Project, project_id)
@@ -50,7 +50,7 @@ async def add_link(
 async def delete_link(
     project_id: int,
     link_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     project = await session.get(Project, project_id)

--- a/stacks/projects-api/projects_api/routers/makes.py
+++ b/stacks/projects-api/projects_api/routers/makes.py
@@ -25,7 +25,7 @@ from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..badges import evaluate_user
 from ..config import get_settings
 from ..db import get_session
@@ -109,7 +109,7 @@ async def create_make(
     notes: Optional[str] = Form(default=None),
     modifications: Optional[str] = Form(default=None),
     images: list[UploadFile] = [],  # noqa: B006 — FastAPI handles default
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> MakeResponse:
     project = await session.get(Project, project_id)
@@ -301,7 +301,7 @@ async def get_make(
 @router.delete("/api/makes/{make_id}", status_code=204)
 async def delete_make(
     make_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     make = await session.get(Make, make_id)
@@ -335,7 +335,7 @@ async def delete_make(
 @router.post("/api/makes/{make_id}/heart", response_model=MakeResponse)
 async def heart_make(
     make_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> MakeResponse:
     make = await session.get(Make, make_id)
@@ -361,7 +361,7 @@ async def heart_make(
 @router.delete("/api/makes/{make_id}/heart", response_model=MakeResponse)
 async def unheart_make(
     make_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> MakeResponse:
     make = await session.get(Make, make_id)

--- a/stacks/projects-api/projects_api/routers/parts.py
+++ b/stacks/projects-api/projects_api/routers/parts.py
@@ -15,13 +15,18 @@ This router implements:
                                           restore (writes a new revision
                                           whose snapshot equals rev_id).
 
-Account-age gate
-----------------
-Mutating endpoints depend on :func:`get_current_user_aged` which calls
-:func:`fetch_account_created_at` against Chatter's ``/api/me``. If Chatter
-is unreachable or omits the ``account_created_at`` field, the gate fails
-closed (HTTP 403 "Account age cannot be verified"). Tests monkeypatch
-``fetch_account_created_at`` directly.
+Account-age + T&Cs gate
+-----------------------
+Mutating endpoints depend on :func:`require_terms_accepted_aged` which
+layers the T&Cs acceptance gate (terms-gate) on top of
+:func:`get_current_user_aged`. The age gate calls
+:func:`fetch_account_created_at` against Chatter's ``/api/me``; if Chatter
+is unreachable or omits the ``account_created_at`` field, it fails closed
+(HTTP 403 "Account age cannot be verified"). The T&Cs gate raises a 403
+with ``detail: terms_not_accepted`` until the user has POSTed the current
+version to ``/api/users/me/accept-terms``. Tests monkeypatch
+``fetch_account_created_at`` directly and the test client bypasses the
+T&Cs gate by default (see ``tests/conftest.py``).
 
 Usage-count semantics
 ---------------------
@@ -51,7 +56,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user_aged
+from ..auth import require_terms_accepted_aged
 from ..db import get_session
 from ..mass_deletion import (
     check_and_handle_mass_deletion,
@@ -385,7 +390,7 @@ async def list_families(
 @router.post("", response_model=PartDetail, status_code=201)
 async def create_part(
     body: PartCreate,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> PartDetail:
     slug = await _unique_slug(session, _slugify(body.name))
@@ -494,7 +499,7 @@ def _supplier_signature(suppliers: list[dict]) -> list[tuple]:
 async def update_part(
     slug: str,
     body: PartUpdate,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> PartDetail:
     part = await _get_part_by_slug(session, slug)
@@ -710,7 +715,7 @@ async def get_revision(
 async def restore_revision(
     slug: str,
     rev_id: int,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> PartDetail:
     """Non-destructive restore: write a NEW revision whose snapshot
@@ -819,7 +824,7 @@ async def list_related_parts(
 async def add_related_part(
     slug: str,
     body: PartRelationCreate,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> list[PartRelatedRef]:
     """Link ``slug`` to another part identified by ``related_slug``.
@@ -870,7 +875,7 @@ async def add_related_part(
 async def remove_related_part(
     slug: str,
     related_slug: str,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     part = await _get_part_by_slug(session, slug)

--- a/stacks/projects-api/projects_api/routers/parts_moderation.py
+++ b/stacks/projects-api/projects_api/routers/parts_moderation.py
@@ -70,7 +70,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user, get_current_user_aged, require_admin
+from ..auth import (
+    get_current_user,
+    require_admin,
+    require_terms_accepted_aged,
+)
 from ..db import get_session
 from ..models import (
     Part,
@@ -403,12 +407,12 @@ async def resolve_part_report(
 async def propose_merge(
     slug: str,
     body: PartMergeProposalCreate,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> PartMergeProposalResponse:
     """Propose merging the part identified by URL slug INTO ``target_slug``.
 
-    14-day account-age gate (via :func:`get_current_user_aged`). The
+    14-day account-age gate + T&Cs gate (via :func:`require_terms_accepted_aged`). The
     source part is identified by the URL slug, target by the body field.
     """
     source = await _get_part_by_slug(session, slug)
@@ -522,7 +526,7 @@ async def get_merge_proposal(
 async def vote_on_merge_proposal(
     proposal_id: int,
     body: PartMergeVoteCreate,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> PartMergeVoteResponse:
     """Approve or reject — re-POSTing flips the existing vote in place.

--- a/stacks/projects-api/projects_api/routers/parts_talk.py
+++ b/stacks/projects-api/projects_api/routers/parts_talk.py
@@ -29,7 +29,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user, get_current_user_aged
+from ..auth import (
+    require_terms_accepted,
+    require_terms_accepted_aged,
+)
 from ..config import get_settings
 from ..db import get_session
 from ..models import Part, PartTalkPost, PartTalkThread
@@ -133,7 +136,7 @@ async def list_threads(
 async def create_thread(
     slug: str,
     body: PartTalkThreadCreate,
-    user: str = Depends(get_current_user_aged),
+    user: str = Depends(require_terms_accepted_aged),
     session: AsyncSession = Depends(get_session),
 ) -> PartTalkThreadDetail:
     """Open a new discussion thread on a part.
@@ -232,7 +235,7 @@ async def add_post(
     slug: str,
     thread_id: int,
     body: PartTalkPostCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> PartTalkPostResponse:
     """Append a post to a thread.
@@ -271,7 +274,7 @@ async def update_thread(
     slug: str,
     thread_id: int,
     body: PartTalkThreadUpdate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> PartTalkThreadDetail:
     """Toggle the closed state on a thread.
@@ -328,7 +331,7 @@ async def update_post(
     thread_id: int,
     post_id: int,
     body: PartTalkPostUpdate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> PartTalkPostResponse:
     """Edit a post — original author OR admin only.

--- a/stacks/projects-api/projects_api/routers/projects.py
+++ b/stacks/projects-api/projects_api/routers/projects.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user, get_optional_user
+from ..auth import get_current_user, get_optional_user, require_terms_accepted
 from ..badges import evaluate_user
 from ..db import get_session
 from ..models import Download, Project, ProjectTag, UserFollow
@@ -244,7 +244,7 @@ async def get_project(
 @router.post("", response_model=ProjectResponse, status_code=201)
 async def create_project(
     body: ProjectCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> ProjectResponse:
     # Issue #152: auto-generate a slug from the title at create time. The
@@ -304,7 +304,7 @@ async def update_project(
     project_id: int,
     body: ProjectUpdate,
     request: Request,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> ProjectResponse:
     project = await session.get(Project, project_id)
@@ -379,7 +379,7 @@ async def update_project(
 @router.delete("/{project_id}", status_code=204)
 async def delete_project(
     project_id: int,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> None:
     project = await session.get(Project, project_id)

--- a/stacks/projects-api/projects_api/routers/remixes.py
+++ b/stacks/projects-api/projects_api/routers/remixes.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..auth import get_current_user
+from ..auth import get_current_user, require_terms_accepted
 from ..badges import evaluate_user
 from ..db import get_session
 from ..models import Project, ProjectTag
@@ -64,7 +64,7 @@ def _list_item_from_project(project: Project, tags: list[str]) -> ProjectListIte
 async def create_remix(
     project_id: int,
     body: ProjectRemixCreate,
-    user: str = Depends(get_current_user),
+    user: str = Depends(require_terms_accepted),
     session: AsyncSession = Depends(get_session),
 ) -> ProjectResponse:
     """Create a remix of an existing project.

--- a/stacks/projects-api/projects_api/routers/users.py
+++ b/stacks/projects-api/projects_api/routers/users.py
@@ -26,16 +26,19 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_current_user
+from ..config import get_settings
 from ..db import get_session
 from ..fx import SUPPORTED_CURRENCIES
 from ..models import (
     Download,
     Make,
     Project,
+    User,
     UserActivity,
     UserFollow,
     UserProfile,
@@ -136,6 +139,79 @@ async def _compute_stats(session: AsyncSession, username: str) -> UserProfileSta
         likes=0,
         followers=int(followers),
         following=int(following),
+    )
+
+
+# --- T&Cs acceptance gate (terms-gate) -----------------------------------
+#
+# ``POST /api/users/me/accept-terms`` records a user's "I agree" click.
+# This endpoint is intentionally NOT gated by ``require_terms_accepted``
+# (that would be circular) — it only requires authentication.
+#
+# We reject any version that doesn't exactly match
+# ``settings.current_terms_version``. The frontend reads the current
+# version off ``/api/auth/me`` so a stale tab can't accidentally lock in
+# an older acceptance.
+
+
+class AcceptTermsRequest(BaseModel):
+    version: str = Field(..., max_length=20)
+
+
+class AcceptTermsResponse(BaseModel):
+    accepted_at: datetime
+    version: str
+
+
+@router.post(
+    "/api/users/me/accept-terms",
+    response_model=AcceptTermsResponse,
+)
+async def accept_terms(
+    body: AcceptTermsRequest,
+    user: str = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> AcceptTermsResponse:
+    """Record the caller's acceptance of the current T&Cs version.
+
+    The request body's ``version`` must exactly match the server's
+    ``settings.current_terms_version``. Older versions are rejected with
+    400 so a stale frontend tab can't accidentally lock the user into
+    accepting an outdated copy.
+
+    The ``users`` row is created lazily on first call. Re-accepting the
+    same version is idempotent — the timestamp is refreshed.
+    """
+    settings = get_settings()
+    if body.version != settings.current_terms_version:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Version {body.version!r} does not match the current "
+                f"terms version {settings.current_terms_version!r}."
+            ),
+        )
+
+    row = await session.scalar(select(User).where(User.username == user))
+    now = datetime.utcnow()
+    if row is None:
+        row = User(
+            username=user,
+            is_disabled=False,
+            terms_accepted_at=now,
+            terms_accepted_version=body.version,
+        )
+        session.add(row)
+    else:
+        row.terms_accepted_at = now
+        row.terms_accepted_version = body.version
+
+    await session.commit()
+    await session.refresh(row)
+
+    return AcceptTermsResponse(
+        accepted_at=row.terms_accepted_at or now,
+        version=row.terms_accepted_version or body.version,
     )
 
 

--- a/stacks/projects-api/tests/conftest.py
+++ b/stacks/projects-api/tests/conftest.py
@@ -56,6 +56,7 @@ async def session(sessionmaker_) -> AsyncIterator[AsyncSession]:
 
 @pytest_asyncio.fixture
 async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
+    from projects_api import auth as auth_module
     from projects_api import db as db_module
     from projects_api import main as main_module
     from projects_api.main import create_app
@@ -79,6 +80,17 @@ async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
 
     app = create_app()
     app.dependency_overrides[db_module.get_session] = _override_session
+
+    # Terms-gate (terms-gate): bypass the T&Cs acceptance check in the
+    # default test client so the ~290 existing tests don't need to first
+    # POST to /api/users/me/accept-terms. ``test_terms.py`` opts back IN
+    # to the real gate by deleting these overrides on its own client.
+    app.dependency_overrides[auth_module.require_terms_accepted] = (
+        auth_module.get_current_user
+    )
+    app.dependency_overrides[auth_module.require_terms_accepted_aged] = (
+        auth_module.get_current_user_aged
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/stacks/projects-api/tests/test_auth_me.py
+++ b/stacks/projects-api/tests/test_auth_me.py
@@ -72,6 +72,10 @@ async def test_auth_me_logged_in_returns_full_profile(
         "is_admin",
         "created_at",
         "avatar_url",
+        # terms-gate: T&Cs acceptance state exposed for the frontend gate.
+        "terms_accepted_at",
+        "terms_accepted_version",
+        "current_terms_version",
     }
     assert body["id"] == 42
     assert body["username"] == "kevin"
@@ -79,6 +83,10 @@ async def test_auth_me_logged_in_returns_full_profile(
     assert body["is_admin"] is False
     assert body["created_at"] == "2024-04-01T12:00:00Z"
     assert body["avatar_url"] is None
+    # Brand-new user with no acceptance row yet.
+    assert body["terms_accepted_at"] is None
+    assert body["terms_accepted_version"] is None
+    assert body["current_terms_version"] == "1.0"
 
     # Cache-Control: no-store is required (per-user, never cacheable).
     assert resp.headers.get("cache-control") == "no-store"

--- a/stacks/projects-api/tests/test_terms.py
+++ b/stacks/projects-api/tests/test_terms.py
@@ -1,0 +1,264 @@
+"""Tests for the T&Cs acceptance gate (terms-gate).
+
+Covers:
+
+* ``GET /api/auth/me`` exposes the three terms fields with the right
+  defaults and the current server-side version.
+* ``POST /api/users/me/accept-terms`` happy path persists timestamp +
+  version.
+* Mismatched / stale version on accept-terms -> 400.
+* Gated write endpoint without acceptance -> 403 with
+  ``detail: "terms_not_accepted"`` and ``current_version``.
+* After accepting, the same write succeeds.
+* Bumping ``settings.current_terms_version`` invalidates an already-
+  accepted record until the user re-accepts.
+* GET endpoints are NEVER blocked by the gate.
+
+These tests intentionally opt OUT of the default conftest bypass (which
+patches ``require_terms_accepted`` / ``require_terms_accepted_aged`` to
+no-ops so the existing 290-ish tests don't all need to first call
+accept-terms). The fixture below restores the live dependencies on the
+test app.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture(autouse=True)
+def _restore_gate(client):
+    """Strip the conftest bypass so the real terms gate runs in these tests."""
+    from projects_api import auth as auth_module
+
+    # ``client`` is the async fixture's AsyncClient; the underlying ASGI app
+    # carries the dependency_overrides we want to clear. AsyncClient exposes
+    # the ASGI transport as ``_transport`` (httpx) which holds the app.
+    app = client._transport.app
+    for dep in (
+        auth_module.require_terms_accepted,
+        auth_module.require_terms_accepted_aged,
+    ):
+        app.dependency_overrides.pop(dep, None)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_auth_me_exposes_terms_fields_with_defaults(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh user has no acceptance, and current_version mirrors settings."""
+    from projects_api import auth as auth_module
+    from projects_api.routers import auth as auth_router
+
+    async def _fake_me(token: str):
+        return {"id": 1, "email": "x@y.z"}
+
+    monkeypatch.setattr(auth_module, "fetch_chatter_me", _fake_me)
+    monkeypatch.setattr(auth_router, "fetch_chatter_me", _fake_me)
+
+    resp = await client.get("/api/auth/me", headers=make_auth_header("alice"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["terms_accepted_at"] is None
+    assert body["terms_accepted_version"] is None
+    assert body["current_terms_version"] == "1.0"
+
+
+@pytest.mark.asyncio
+async def test_accept_terms_happy_path_persists(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POSTing the current version succeeds and is reflected on /me."""
+    from projects_api import auth as auth_module
+    from projects_api.routers import auth as auth_router
+
+    async def _fake_me(token: str):
+        return {"id": 1, "email": "x@y.z"}
+
+    monkeypatch.setattr(auth_module, "fetch_chatter_me", _fake_me)
+    monkeypatch.setattr(auth_router, "fetch_chatter_me", _fake_me)
+
+    headers = make_auth_header("alice")
+    resp = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["version"] == "1.0"
+    assert body["accepted_at"]  # ISO timestamp present
+
+    # /me now surfaces the acceptance.
+    me = await client.get("/api/auth/me", headers=headers)
+    assert me.status_code == 200
+    me_body = me.json()
+    assert me_body["terms_accepted_version"] == "1.0"
+    assert me_body["terms_accepted_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_accept_terms_rejects_stale_version(client) -> None:
+    """A version that doesn't match settings is 400 (stale tab guard)."""
+    resp = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "0.9"},
+        headers=make_auth_header("alice"),
+    )
+    assert resp.status_code == 400
+    assert "does not match" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_write_without_acceptance_returns_terms_not_accepted(
+    client,
+) -> None:
+    """A gated POST without prior acceptance -> 403 with the contract shape."""
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Should Be Blocked", "short_description": "x"},
+        headers=make_auth_header("alice"),
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    # FastAPI wraps the dict we raise into ``detail``.
+    detail = body.get("detail")
+    assert isinstance(detail, dict)
+    assert detail.get("detail") == "terms_not_accepted"
+    assert detail.get("current_version") == "1.0"
+
+
+@pytest.mark.asyncio
+async def test_write_after_acceptance_succeeds(client) -> None:
+    """Accept then retry: the same POST now lands."""
+    headers = make_auth_header("alice")
+
+    # First call confirms gate is active.
+    blocked = await client.post(
+        "/api/projects",
+        json={"title": "Gate Test"},
+        headers=headers,
+    )
+    assert blocked.status_code == 403
+
+    # Accept the current version.
+    acc = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert acc.status_code == 200
+
+    # Retry the write.
+    ok = await client.post(
+        "/api/projects",
+        json={"title": "Gate Test"},
+        headers=headers,
+    )
+    assert ok.status_code == 201, ok.text
+    assert ok.json()["title"] == "Gate Test"
+
+
+@pytest.mark.asyncio
+async def test_version_bump_invalidates_prior_acceptance(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bumping current_terms_version forces a re-accept."""
+    headers = make_auth_header("alice")
+
+    # Accept 1.0 then write — works.
+    acc = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert acc.status_code == 200
+    ok = await client.post(
+        "/api/projects", json={"title": "Pre-bump"}, headers=headers
+    )
+    assert ok.status_code == 201
+
+    # Bump the server's required version. We patch get_settings so every
+    # consumer (auth.py + routers/auth.py + routers/users.py) sees 1.1.
+    # Wrap the real Settings rather than mocking it — the auth code reads
+    # jwt_secret/jwt_algorithm too, so we need all those fields intact.
+    from projects_api import auth as auth_module
+    from projects_api import config as config_module
+    from projects_api.routers import users as users_router
+
+    real_settings = config_module.get_settings()
+
+    def _fake_get_settings():
+        # Re-build a fresh Settings each call (mirrors the real factory)
+        # but override the one attribute we care about. ``model_copy``
+        # preserves every other field including jwt_secret.
+        s = config_module.Settings()
+        return s.model_copy(update={"current_terms_version": "1.1"})
+
+    monkeypatch.setattr(config_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(auth_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(users_router, "get_settings", _fake_get_settings)
+    # Sanity: avoid an unused-name warning.
+    assert real_settings.current_terms_version == "1.0"
+
+    # Now the next write should 403 — the user's stored 1.0 acceptance is
+    # stale.
+    blocked = await client.post(
+        "/api/projects", json={"title": "Post-bump"}, headers=headers
+    )
+    assert blocked.status_code == 403
+    detail = blocked.json()["detail"]
+    assert detail["detail"] == "terms_not_accepted"
+    assert detail["current_version"] == "1.1"
+
+    # Accepting 1.0 again is rejected — only the current 1.1 is valid.
+    stale = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert stale.status_code == 400
+
+    # Accept 1.1 → write unblocks again.
+    fresh = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.1"},
+        headers=headers,
+    )
+    assert fresh.status_code == 200
+    ok2 = await client.post(
+        "/api/projects", json={"title": "Post-bump 2"}, headers=headers
+    )
+    assert ok2.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_read_endpoints_are_never_blocked(client) -> None:
+    """GET endpoints don't go through the gate, even for unaccepted users."""
+    # No acceptance — but reads must still work.
+    resp = await client.get("/api/projects")
+    assert resp.status_code == 200
+    # Featured list is also a read.
+    resp2 = await client.get("/api/projects/featured")
+    assert resp2.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_report_endpoint_remains_open(client) -> None:
+    """The parts-moderation report POST is intentionally NOT gated.
+
+    Abuse reporting must stay frictionless — users who haven't accepted
+    the T&Cs are still allowed to flag a part. Here we just verify the
+    handler is reachable past the gate (the actual 404 for a non-existent
+    part is fine — what we're proving is that we didn't 403 first).
+    """
+    resp = await client.post(
+        "/api/parts/no-such-part/report",
+        json={"reason": "spam"},
+        headers=make_auth_header("alice"),
+    )
+    # 404 (no part) — not 403 (terms gate).
+    assert resp.status_code == 404

--- a/web/account.md
+++ b/web/account.md
@@ -243,12 +243,33 @@ description: Manage your kevsrobots.com account
           </div>
         </div>
       </div>
+
+      <!-- Content & Acceptance (terms-gate) -->
+      <div class="card mb-4" id="terms-card">
+        <div class="card-body">
+          <h3 class="card-title mb-3"><i class="fas fa-file-signature me-2 text-primary"></i>Content &amp; Acceptance</h3>
+          <p class="text-muted small">
+            Uploading projects, images, BOMs, comments, parts edits, or other
+            content to the Projects Hub requires accepting our content terms.
+          </p>
+          <p class="mb-1"><strong>Status:</strong> <span id="terms-status-text" class="text-muted">Loading…</span></p>
+          <p class="mb-1"><strong>Accepted version:</strong> <span id="terms-accepted-version" class="font-monospace text-muted">—</span></p>
+          <p class="mb-3"><strong>Current version:</strong> <span id="terms-current-version" class="font-monospace text-muted">—</span></p>
+          <a href="/projects-hub-terms/" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener">
+            <i class="fas fa-external-link-alt me-1"></i>View full terms
+          </a>
+          <button type="button" class="btn btn-primary btn-sm" id="terms-accept-btn" style="display:none;">
+            <i class="fas fa-check me-1"></i>Accept terms
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </div>
 
 <script src="/assets/js/chatter-api.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/terms-gate.js?v={{ site.time | date: '%s' }}"></script>
 <script>
   let currentUser = null;
   // Cached projects-api profile (the source of truth for public profile fields).
@@ -761,6 +782,61 @@ description: Manage your kevsrobots.com account
     }
   });
 
+  // --- Terms acceptance card (terms-gate) ---------------------------------
+  // Renders the user's current acceptance status next to the Activity card,
+  // and exposes an "Accept terms" button when the user hasn't accepted the
+  // current version (either never accepted, or accepted an older version).
+  async function loadTermsStatus() {
+    if (typeof TermsGate === 'undefined') return;
+    try {
+      const r = await ProjectAuth.apiFetch(`${PROJECTS_API}/api/auth/me`);
+      if (!r.ok) return;
+      const me = await r.json();
+      const statusEl = document.getElementById('terms-status-text');
+      const acceptedVersionEl = document.getElementById('terms-accepted-version');
+      const currentVersionEl = document.getElementById('terms-current-version');
+      const btn = document.getElementById('terms-accept-btn');
+
+      const accepted =
+        me.terms_accepted_version &&
+        me.terms_accepted_at &&
+        me.terms_accepted_version === me.current_terms_version;
+
+      currentVersionEl.textContent = me.current_terms_version || '—';
+
+      if (accepted) {
+        const date = new Date(me.terms_accepted_at);
+        statusEl.innerHTML = '<span class="badge bg-success">Accepted</span> ' +
+          'on ' + date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        acceptedVersionEl.textContent = me.terms_accepted_version;
+        acceptedVersionEl.classList.remove('text-muted');
+        btn.style.display = 'none';
+      } else if (me.terms_accepted_version) {
+        statusEl.innerHTML = '<span class="badge bg-warning text-dark">Update required</span> ' +
+          'Please re-accept the latest version to keep uploading.';
+        acceptedVersionEl.textContent = me.terms_accepted_version + ' (outdated)';
+        btn.style.display = 'inline-block';
+      } else {
+        statusEl.innerHTML = '<span class="badge bg-secondary">Not yet accepted</span> ' +
+          'Please accept to upload content.';
+        acceptedVersionEl.textContent = '—';
+        btn.style.display = 'inline-block';
+      }
+    } catch (_) {
+      // Defensive — the card just stays in its loading state.
+    }
+  }
+
+  const termsBtn = document.getElementById('terms-accept-btn');
+  if (termsBtn) {
+    termsBtn.addEventListener('click', function () {
+      TermsGate.showModal().then(function (ok) {
+        if (ok) loadTermsStatus();
+      });
+    });
+  }
+
   // Load data on page load
   loadUserData();
+  loadTermsStatus();
 </script>

--- a/web/assets/js/terms-gate.js
+++ b/web/assets/js/terms-gate.js
@@ -1,0 +1,321 @@
+/**
+ * TermsGate — frontend helper for the Projects Hub T&Cs acceptance gate.
+ *
+ * Surfaces three things:
+ *   - TermsGate.check() — Promise<bool>. true iff the logged-in user has
+ *     accepted the CURRENT version of the terms (as reported by the
+ *     server in /api/auth/me).
+ *   - TermsGate.showModal() — Promise<bool>. Renders the acceptance modal,
+ *     resolves true when the user accepts, false on cancel / close.
+ *   - TermsGate.guard(fn) — convenience wrapper. If the user has accepted,
+ *     calls fn() and returns its result. Otherwise pops the modal first and
+ *     only calls fn() on accept.
+ *
+ * The modal markup is injected into <body> on first call so pages don't
+ * need any per-page HTML. The modal fetches the rendered T&Cs page at
+ * /projects-hub-terms/ via fetch() and inlines the <main> content into a
+ * scrollable preview, with a "Read full terms in new tab" link as a
+ * fallback for screen-readers and "just give me the whole page" users.
+ *
+ * Depends on ProjectAuth.apiFetch (web/assets/js/project-auth.js) being
+ * loaded first so the dev-token shim works in local development. Falls
+ * back to plain fetch with ``credentials: include`` if ProjectAuth is
+ * not present.
+ */
+(function () {
+  'use strict';
+
+  var PROJECTS_API = 'https://projects.kevsrobots.com';
+  var TERMS_URL = '/projects-hub-terms/';
+  var MODAL_ID = 'terms-gate-modal';
+
+  // Cached /api/auth/me payload — invalidated after each accept.
+  var _meCache = null;
+
+  function _apiFetch(url, opts) {
+    if (typeof ProjectAuth !== 'undefined' && ProjectAuth.apiFetch) {
+      return ProjectAuth.apiFetch(url, opts);
+    }
+    opts = opts || {};
+    opts.credentials = 'include';
+    return fetch(url, opts);
+  }
+
+  function _fetchMe(force) {
+    if (_meCache && !force) {
+      return Promise.resolve(_meCache);
+    }
+    return _apiFetch(PROJECTS_API + '/api/auth/me', { method: 'GET' })
+      .then(function (r) {
+        if (!r.ok) {
+          // 401 / 403 — surface as "not logged in / not accepted".
+          return { _httpStatus: r.status };
+        }
+        return r.json();
+      })
+      .then(function (body) {
+        _meCache = body;
+        return body;
+      })
+      .catch(function () {
+        return { _httpStatus: 0 };
+      });
+  }
+
+  /**
+   * Return true iff the user's stored terms_accepted_version matches the
+   * server's current_terms_version.
+   */
+  function check() {
+    return _fetchMe(false).then(function (me) {
+      if (!me || me._httpStatus) return false;
+      if (!me.terms_accepted_version) return false;
+      if (!me.terms_accepted_at) return false;
+      return me.terms_accepted_version === me.current_terms_version;
+    });
+  }
+
+  /**
+   * Build the modal DOM (once) and return its Bootstrap instance.
+   */
+  function _ensureModal() {
+    var existing = document.getElementById(MODAL_ID);
+    if (existing) return existing;
+
+    var html =
+      '<div class="modal fade" id="' + MODAL_ID + '" tabindex="-1" ' +
+      '  aria-labelledby="' + MODAL_ID + '-label" aria-hidden="true" ' +
+      '  data-bs-backdrop="static" data-bs-keyboard="false">' +
+      '  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">' +
+      '    <div class="modal-content">' +
+      '      <div class="modal-header">' +
+      '        <h5 class="modal-title" id="' + MODAL_ID + '-label">' +
+      '          <i class="fas fa-file-signature me-2 text-primary"></i>' +
+      '          Please review the Projects Hub terms' +
+      '        </h5>' +
+      '      </div>' +
+      '      <div class="modal-body">' +
+      '        <p class="text-muted small mb-2">' +
+      '          To upload projects, images, files, BOMs, makes, comments, or ' +
+      '          parts-catalogue edits, please read and accept the content ' +
+      '          terms below. You retain ownership of what you upload — see ' +
+      '          the TL;DR at the top of the full page.' +
+      '        </p>' +
+      '        <div id="' + MODAL_ID + '-preview" class="border rounded p-3 mb-3" ' +
+      '          style="max-height:40vh; overflow-y:auto; background:#f8f9fa;">' +
+      '          <div class="text-muted"><i class="fas fa-spinner fa-spin me-2"></i>Loading terms…</div>' +
+      '        </div>' +
+      '        <p class="small mb-3">' +
+      '          <a href="' + TERMS_URL + '" target="_blank" rel="noopener">' +
+      '            <i class="fas fa-external-link-alt me-1"></i>Open the full terms in a new tab' +
+      '          </a>' +
+      '          &middot; current version: <span id="' + MODAL_ID + '-version" class="font-monospace">…</span>' +
+      '        </p>' +
+      '        <div class="form-check">' +
+      '          <input class="form-check-input" type="checkbox" id="terms-accept">' +
+      '          <label class="form-check-label" for="terms-accept">' +
+      '            I have read and agree to the Projects Hub terms.' +
+      '          </label>' +
+      '        </div>' +
+      '        <div id="' + MODAL_ID + '-error" class="alert alert-danger mt-3 d-none" role="alert"></div>' +
+      '      </div>' +
+      '      <div class="modal-footer">' +
+      '        <button type="button" class="btn btn-secondary" id="' + MODAL_ID + '-cancel">' +
+      '          Cancel' +
+      '        </button>' +
+      '        <button type="button" class="btn btn-primary" id="' + MODAL_ID + '-confirm" disabled>' +
+      '          <span id="' + MODAL_ID + '-confirm-spinner" class="spinner-border spinner-border-sm me-2 d-none" role="status"></span>' +
+      '          I have read and agree' +
+      '        </button>' +
+      '      </div>' +
+      '    </div>' +
+      '  </div>' +
+      '</div>';
+
+    var wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    var node = wrap.firstElementChild;
+    document.body.appendChild(node);
+
+    // Wire the checkbox -> button enable state.
+    var box = node.querySelector('#terms-accept');
+    var confirm = node.querySelector('#' + MODAL_ID + '-confirm');
+    box.addEventListener('change', function () {
+      confirm.disabled = !box.checked;
+    });
+
+    // Lazy-load the terms preview body.
+    fetch(TERMS_URL, { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.text() : null; })
+      .then(function (html) {
+        var target = node.querySelector('#' + MODAL_ID + '-preview');
+        if (!html) {
+          target.innerHTML =
+            '<div class="text-muted">' +
+            'Could not load the terms inline. Please use the link above to ' +
+            'read them in a new tab.' +
+            '</div>';
+          return;
+        }
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+        var main = doc.querySelector('main') ||
+                   doc.querySelector('.content') ||
+                   doc.querySelector('article') ||
+                   doc.body;
+        // Strip the DRAFT banner from the preview — it appears in full on
+        // the linked-out page already.
+        target.innerHTML = main.innerHTML;
+      })
+      .catch(function () {
+        var target = node.querySelector('#' + MODAL_ID + '-preview');
+        target.innerHTML =
+          '<div class="text-muted">Could not load the terms inline.</div>';
+      });
+
+    return node;
+  }
+
+  function _showError(msg) {
+    var node = document.getElementById(MODAL_ID);
+    if (!node) return;
+    var box = node.querySelector('#' + MODAL_ID + '-error');
+    box.textContent = msg;
+    box.classList.remove('d-none');
+  }
+
+  function _setVersion(version) {
+    var el = document.getElementById(MODAL_ID + '-version');
+    if (el) el.textContent = version || '?';
+  }
+
+  /**
+   * Show the modal and resolve on accept or cancel.
+   */
+  function showModal() {
+    return _fetchMe(true).then(function (me) {
+      var node = _ensureModal();
+      _setVersion(me && me.current_terms_version);
+
+      // Reset state.
+      var box = node.querySelector('#terms-accept');
+      var confirm = node.querySelector('#' + MODAL_ID + '-confirm');
+      var cancel = node.querySelector('#' + MODAL_ID + '-cancel');
+      var errBox = node.querySelector('#' + MODAL_ID + '-error');
+      var spinner = node.querySelector('#' + MODAL_ID + '-confirm-spinner');
+      box.checked = false;
+      confirm.disabled = true;
+      errBox.classList.add('d-none');
+      spinner.classList.add('d-none');
+
+      var modal = null;
+      if (window.bootstrap && window.bootstrap.Modal) {
+        modal = window.bootstrap.Modal.getOrCreateInstance(node);
+        modal.show();
+      } else {
+        // Bootstrap not loaded — fall back to .show class.
+        node.classList.add('show');
+        node.style.display = 'block';
+      }
+
+      return new Promise(function (resolve) {
+        function cleanup(result) {
+          confirm.removeEventListener('click', onConfirm);
+          cancel.removeEventListener('click', onCancel);
+          if (modal) {
+            modal.hide();
+          } else {
+            node.classList.remove('show');
+            node.style.display = 'none';
+          }
+          resolve(result);
+        }
+
+        function onConfirm() {
+          if (!box.checked) return;
+          confirm.disabled = true;
+          spinner.classList.remove('d-none');
+          errBox.classList.add('d-none');
+
+          var version = (me && me.current_terms_version) || '1.0';
+          _apiFetch(PROJECTS_API + '/api/users/me/accept-terms', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ version: version }),
+          })
+            .then(function (r) {
+              spinner.classList.add('d-none');
+              if (r.ok) {
+                // Bust the /me cache so the next check() reflects the
+                // acceptance.
+                _meCache = null;
+                cleanup(true);
+                return;
+              }
+              return r.json().catch(function () { return {}; })
+                .then(function (body) {
+                  var msg = body && (body.detail || body.message) ||
+                            ('Accept failed (' + r.status + ')');
+                  if (typeof msg !== 'string') msg = JSON.stringify(msg);
+                  _showError(msg);
+                  confirm.disabled = false;
+                });
+            })
+            .catch(function () {
+              spinner.classList.add('d-none');
+              _showError('Network error — please try again.');
+              confirm.disabled = false;
+            });
+        }
+
+        function onCancel() {
+          cleanup(false);
+        }
+
+        confirm.addEventListener('click', onConfirm);
+        cancel.addEventListener('click', onCancel);
+      });
+    });
+  }
+
+  /**
+   * Wrap an upload action. If accepted, calls fn() directly. Otherwise
+   * pops the modal first and only calls fn() on accept.
+   */
+  function guard(fn) {
+    return check().then(function (accepted) {
+      if (accepted) return fn();
+      return showModal().then(function (ok) {
+        if (ok) return fn();
+        return undefined;
+      });
+    });
+  }
+
+  /**
+   * Inspect a response that came back from a write endpoint and, if it's
+   * a 403 ``terms_not_accepted``, pop the modal. Returns a Promise that
+   * resolves to ``true`` if the user accepted and the caller should retry,
+   * ``false`` otherwise. Pages without this helper just see a generic 403.
+   */
+  function handleResponse(response) {
+    if (!response || response.status !== 403) return Promise.resolve(false);
+    return response
+      .clone()
+      .json()
+      .catch(function () { return null; })
+      .then(function (body) {
+        var detail = body && body.detail;
+        if (!detail || typeof detail !== 'object') return false;
+        if (detail.detail !== 'terms_not_accepted') return false;
+        return showModal();
+      });
+  }
+
+  window.TermsGate = {
+    check: check,
+    showModal: showModal,
+    guard: guard,
+    handleResponse: handleResponse,
+    _clearCache: function () { _meCache = null; },
+  };
+})();

--- a/web/projects-hub-terms.md
+++ b/web/projects-hub-terms.md
@@ -1,0 +1,171 @@
+---
+layout: content
+title: Projects Hub — Content Licence and Terms
+description: Terms and Conditions governing content you upload to the kevsrobots.com Projects Hub.
+permalink: /projects-hub-terms/
+---
+
+# Projects Hub — Content Licence and Terms
+
+<small>Version 1.0 — effective 2026-05-19</small>
+
+<div class="alert alert-warning my-3" role="alert">
+  <strong><i class="fas fa-exclamation-triangle me-2"></i>DRAFT — pending legal review.</strong>
+  This is a starter draft of the Projects Hub content terms. It is published
+  here so the technical implementation of the acceptance flow can be tested,
+  but it has <em>not</em> yet been reviewed by a solicitor. Before this draft
+  is treated as the live, binding licence please get a UK lawyer to review it
+  against current ICO / IP guidance and finalise the wording.
+</div>
+
+## TL;DR
+
+You keep ownership of what you upload. You give us permission to display
+your contributions on kevsrobots.com and related channels so other makers
+can read, learn from, and build on them. You confirm you have the right to
+upload what you upload.
+
+If you'd rather not agree to these terms, you can still read everything on
+the site — you just won't be able to upload projects, makes, images,
+files, BOM entries, journal posts, parts-catalogue edits, comments, or
+other contributions until you accept.
+
+---
+
+## 1. Who these terms are with
+
+The Projects Hub at <https://www.kevsrobots.com> is operated by **Advice
+Factory Ltd**, a company registered in England & Wales ("we", "us",
+"our"). These terms apply between us and you ("you", "the user") whenever
+you upload content to the Projects Hub.
+
+## 2. What counts as "your content"
+
+"Your content" means anything you submit, upload, paste, type, or
+otherwise contribute to the Projects Hub, including but not limited to:
+
+- Projects (titles, descriptions, content / write-ups, cover images)
+- Project images, files, attachments, and 3D models
+- Bill-of-materials (BOM) entries, links, suppliers, prices
+- Journal / build-log entries
+- Related links and references
+- "I Made This!" makes and their images
+- Parts catalogue entries, revisions, and edits
+- Comments, talk-page posts, and feedback
+- Merge proposals, votes, and other moderation-surface contributions
+
+## 3. The licence you grant us
+
+By uploading your content to the Projects Hub you grant Advice Factory Ltd
+a **perpetual, worldwide, non-exclusive, royalty-free, sub-licensable
+licence** to:
+
+- Host, display, reproduce, transmit, and distribute your content on the
+  Projects Hub and any related service we operate (including but not
+  limited to social-media accounts, newsletters, RSS feeds, embeddable
+  cards, and printable / downloadable formats).
+- Make and store backups, indexes, search caches, thumbnails, and other
+  technical copies needed to run the service.
+- Make derivative works of your content for the limited purposes of
+  formatting, layout, accessibility, translation, summarisation, and the
+  generation of derivative previews (e.g. social-media share images).
+- Allow other users to interact with your content through the
+  features the Projects Hub already exposes — for example, remixing a
+  project you've published, copying your BOM into theirs, or quoting
+  your comment in a thread.
+
+This licence continues for as long as legally necessary for us to keep
+the service running and to preserve the audit trail of community
+contributions, even if you later delete your account or specific
+content. **You retain ownership of and all underlying rights in your
+content** — granting us this licence does not transfer copyright.
+
+## 4. Your warranties
+
+By uploading content you confirm that:
+
+- You own your content or have all the rights, licences, consents, and
+  permissions required to upload it and to grant the licence in clause 3.
+- Your content does not infringe anyone else's copyright, trade mark,
+  patent, trade secret, privacy, publicity, or other rights.
+- Your content does not include personal data about other people that
+  you don't have permission to share.
+- Your content is not unlawful, defamatory, harassing, threatening,
+  hateful, obscene, or otherwise inappropriate for a community of
+  makers — including readers under 18.
+- You have read the rest of these terms and agree to be bound by them.
+
+## 5. Takedown of your own content
+
+You can request takedown of any content you uploaded by deleting it
+through the relevant editor (project editor, account page, etc.) or by
+emailing <kevinmcaleer@gmail.com>. We aim to action takedown requests
+within 7 days. We may retain anonymised aggregates (e.g. counts) and
+audit-log entries to preserve the integrity of the service — these never
+re-expose the underlying content publicly.
+
+## 6. Our right to remove content
+
+We may remove, hide, or moderate any content at any time, at our sole
+discretion, for any reason — including (but not limited to) suspected
+copyright infringement, spam, abuse, off-topic posts, breach of these
+terms, or operational reasons (storage limits, NSFW content, etc.). We
+aren't obliged to explain why, although we'll try to be reasonable about
+it. We may also remove your access to upload further content if your
+behaviour repeatedly breaches these terms.
+
+## 7. BOM affiliate links
+
+The Projects Hub allows authors to attach supplier URLs to BOM entries.
+You acknowledge that we may, at our discretion, rewrite some supplier
+URLs to include affiliate / referral codes that benefit Advice Factory
+Ltd. We do not pay you a share of any resulting affiliate income, and
+adding a supplier URL to a BOM does not entitle you to one. If you'd
+rather not see your supplier links rewritten, don't add them.
+
+## 8. Indemnity
+
+You agree to indemnify and hold harmless Advice Factory Ltd and its
+directors, employees, and contractors against any third-party claim,
+loss, damage, cost, or expense (including reasonable legal fees) arising
+out of your content — for example, a claim that a photo you uploaded
+infringes someone else's copyright, or that a comment you posted is
+defamatory.
+
+## 9. No warranty
+
+We provide the Projects Hub "as is". To the maximum extent permitted by
+law, we exclude all warranties (express, implied, or statutory) that
+aren't expressly given in these terms. We don't warrant that the
+service will be uninterrupted, that data won't be lost, or that any
+particular feature will continue to be available.
+
+## 10. Liability
+
+Nothing in these terms limits our liability for death or personal injury
+caused by negligence, fraud, or anything else that cannot be excluded
+under English law. Subject to that, our total liability to you for any
+claim arising out of your use of the Projects Hub is limited to £100.
+
+## 11. Versioning
+
+We may update these terms from time to time. When we do, the
+``version`` shown at the top of this page is bumped, and the next time
+you try to upload content you'll be asked to re-accept. Your previous
+acceptance of an older version remains valid for content you uploaded
+under that version — the new acceptance only applies prospectively.
+
+## 12. Governing law
+
+These terms and any dispute arising under them are governed by the laws
+of England & Wales, and you and we submit to the exclusive jurisdiction
+of the courts of England & Wales.
+
+## 13. Contact
+
+If anything in these terms is unclear, or you'd like to flag a content
+issue, get in touch:
+
+- **Email:** <kevinmcaleer@gmail.com>
+- **Website:** <https://www.kevsrobots.com>
+- **Operator:** Advice Factory Ltd (England & Wales)

--- a/web/projects/editor.html
+++ b/web/projects/editor.html
@@ -334,6 +334,7 @@ hide_nibsy: true
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/terms-gate.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/image-viewer.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/circuit-components.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/circuit-editor.js?v={{ site.time | date: '%s' }}"></script>
@@ -454,5 +455,47 @@ hide_nibsy: true
 
   document.addEventListener('DOMContentLoaded', attach);
   if (document.readyState !== 'loading') attach();
+})();
+</script>
+
+<!-- Terms-gate (terms-gate): blocks the editor until the logged-in user
+     has accepted the current version of the Projects Hub T&Cs. The check
+     runs on page load and pops the standard TermsGate modal if needed.
+     Once accepted the modal closes and the editor unblocks. -->
+<script>
+(function () {
+  if (typeof TermsGate === 'undefined') return;
+  document.addEventListener('DOMContentLoaded', function () {
+    TermsGate.check().then(function (accepted) {
+      if (accepted) return;
+      // Pause autosave while the gate is open so a half-typed draft
+      // doesn't try to save through a 403.
+      if (window.projectEditorAutosave && window.projectEditorAutosave.pause) {
+        try { window.projectEditorAutosave.pause(); } catch (e) {}
+      }
+      var banner = document.createElement('div');
+      banner.className = 'alert alert-warning text-center my-3';
+      banner.innerHTML =
+        '<strong><i class="fas fa-lock me-2"></i>Accept the Projects Hub terms to continue editing.</strong> ' +
+        '<button type="button" class="btn btn-sm btn-primary ms-2" id="terms-gate-banner-btn">' +
+        'Review and accept</button>';
+      var host = document.querySelector('.container') ||
+                 document.querySelector('main') || document.body;
+      host.insertBefore(banner, host.firstChild);
+      document.getElementById('terms-gate-banner-btn').addEventListener(
+        'click',
+        function () { TermsGate.showModal().then(reloadIfAccepted); }
+      );
+      // Auto-pop on load too.
+      TermsGate.showModal().then(reloadIfAccepted);
+
+      function reloadIfAccepted(ok) {
+        if (!ok) return;
+        // Easiest reliable re-init path — reload the page so the editor
+        // boots fresh under the accepted state.
+        window.location.reload();
+      }
+    });
+  });
 })();
 </script>


### PR DESCRIPTION
## Summary
Implements #168. Captures explicit user consent for uploads to the kevsrobots.com projects hub, with server-enforced gating on every write endpoint and a versioned acceptance record.

### Backend
- **`User.terms_accepted_at`** (DateTime, nullable) + **`User.terms_accepted_version`** (String(20), nullable). Migration helper `add_user_terms_acceptance_if_missing` wired into lifespan.
- **Config `current_terms_version: "1.0"`** — env-overridable for future bumps.
- **`auth.require_terms_accepted`** + companion `require_terms_accepted_aged`. Both raise `403 { detail: "terms_not_accepted", current_version }` so the frontend can detect and prompt.
- **`POST /api/users/me/accept-terms`** — body `{ version }`. Auth via `get_current_user` (not the gated dep — circular).
- **`/api/auth/me`** now exposes `terms_accepted_at`, `terms_accepted_version`, `current_terms_version`.

**Gated routes** (every user-content write): projects, images, files, BOM, journal, links, parts wiki edits, makes, remixes, feedback, parts talk posts/threads, merge proposals + votes.

**Intentionally NOT gated**: `POST /api/parts/{slug}/report` (abuse reporting stays frictionless); `DELETE /api/parts/merge-proposals/{id}` (self-cleanup); the accept-terms endpoint itself (circular); all GETs; admin routes (`require_admin` is already a stricter check).

### Frontend
- **`/projects-hub-terms/`** new content page with a starter UGC licence draft.
- **`web/assets/js/terms-gate.js`** — `TermsGate.{check, showModal, guard}`. Injects a modal on first call; on accept, POSTs to `/api/users/me/accept-terms`.
- **`web/projects/editor.html`** — auto-shows the modal on page load if not accepted; blocks autosave until accepted.
- **`web/account.md`** — "Content & Acceptance" card with status + version + re-accept button.

### Tests
8 new in `test_terms.py`. Full suite **329 passing** (321 existing + 8 new).

### ⚠️ Legal review required before going live
The starter T&Cs text is a standard UGC-licence template; it is marked **DRAFT** in a banner at the top of the page. **A UK solicitor must review and sign off before this is published as binding.** That review is not part of this PR.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)