### PR TITLE
Projects hub polish: clickable tags, cleaner T&Cs modal, Staff Picks in sub-nav

### DIFF
--- a/web/_data/nav_projects.yml
+++ b/web/_data/nav_projects.yml
@@ -5,6 +5,9 @@
 - name: Search
   link: /projects/search
   icon: fas fa-magnifying-glass
+- name: Staff Picks
+  link: /projects/staff-picks/
+  icon: fas fa-star
 - name: My Projects
   link: /projects/my-projects
   icon: fas fa-user-gear

--- a/web/_layouts/content.html
+++ b/web/_layouts/content.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 
+<main>
 <div class="px-3 my-0 mx-3">
 {{content}}
 {% unless page.hide_likes_and_comments %}
@@ -10,3 +11,4 @@ This page is awesome? Show some love!
 {% endunless %}
 {% include thanks.html %}
 </div>
+</main>

--- a/web/assets/js/terms-gate.js
+++ b/web/assets/js/terms-gate.js
@@ -111,21 +111,21 @@
       '          </a>' +
       '          &middot; current version: <span id="' + MODAL_ID + '-version" class="font-monospace">…</span>' +
       '        </p>' +
-      '        <div class="form-check">' +
-      '          <input class="form-check-input" type="checkbox" id="terms-accept">' +
-      '          <label class="form-check-label" for="terms-accept">' +
-      '            I have read and agree to the Projects Hub terms.' +
-      '          </label>' +
-      '        </div>' +
       '        <div id="' + MODAL_ID + '-error" class="alert alert-danger mt-3 d-none" role="alert"></div>' +
       '      </div>' +
-      '      <div class="modal-footer">' +
+      '      <div class="modal-footer flex-wrap gap-2 align-items-center" style="background:#fff8e1; border-top:2px solid #ffc107;">' +
+      '        <div class="form-check me-auto fs-6 mb-0">' +
+      '          <input class="form-check-input" type="checkbox" id="terms-accept" style="width:1.25em; height:1.25em;">' +
+      '          <label class="form-check-label fw-semibold" for="terms-accept">' +
+      '            I have read and agree to the Projects Hub terms' +
+      '          </label>' +
+      '        </div>' +
       '        <button type="button" class="btn btn-secondary" id="' + MODAL_ID + '-cancel">' +
       '          Cancel' +
       '        </button>' +
       '        <button type="button" class="btn btn-primary" id="' + MODAL_ID + '-confirm" disabled>' +
       '          <span id="' + MODAL_ID + '-confirm-spinner" class="spinner-border spinner-border-sm me-2 d-none" role="status"></span>' +
-      '          I have read and agree' +
+      '          I agree' +
       '        </button>' +
       '      </div>' +
       '    </div>' +

--- a/web/projects/staff-picks/index.html
+++ b/web/projects/staff-picks/index.html
@@ -10,10 +10,6 @@ permalink: /projects/staff-picks/
 <link rel="stylesheet" href="/assets/css/featured-projects.css?v={{ site.time | date: '%s' }}">
 
 <div class="container py-4">
-  <div class="mb-3">
-    <a href="/projects/hub" class="text-decoration-none text-muted"><i class="fas fa-arrow-left"></i> Back to Projects</a>
-  </div>
-
   <h1><i class="fas fa-star text-warning me-3"></i> Staff Picks</h1>
   <p class="lead text-muted">
     Hand-picked collections of outstanding builds, curated by the kevsrobots team.

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -714,7 +714,11 @@ description: View project details
         const tRow = document.getElementById('view-tags-row');
         const tEl = document.getElementById('view-tags');
         if (tRow && tEl) {
-          tEl.innerHTML = project.tags.map(t => `<span class="badge bg-light text-primary">${esc(t)}</span>`).join('');
+          tEl.innerHTML = project.tags.map(t => {
+            const safe = esc(t);
+            const url = '/projects/search?tag=' + encodeURIComponent(String(t).toLowerCase());
+            return `<a href="${url}" class="badge bg-light text-primary text-decoration-none">${safe}</a>`;
+          }).join('');
           tRow.classList.remove('d-none');
           anyMeta = true;
         }


### PR DESCRIPTION
## Summary

- Project view page tags are now clickable links to `/projects/search?tag=<value>` (lowercased, URI-encoded), making it easy to find related builds.
- Terms & Conditions modal: the agreement checkbox moved into the modal footer with highlighted amber styling and is now adjacent to the "I agree" button, so users can't miss the gating step. Agree-button label shortened from "I have read and agree" to "I agree" since the full sentence sits next to the checkbox.
- `content.html` layout wraps its body in `<main>`, so the T&Cs modal's preview selector (`main` → `.content` → `article` → `body`) matches the layout's actual content and no longer inlines the site header/footer.
- Staff Picks promoted into the projects sub-nav (between Search and My Projects); redundant "Back to Projects" link removed from the staff-picks index now that the sub-nav handles navigation.

## Test plan

- [ ] On a project view page with tags, each tag renders as a link badge with no underline; clicking it lands on \`/projects/search\` with the tag filter applied.
- [ ] On any page that triggers the T&Cs gate, the modal preview shows only the terms content (no site chrome). The checkbox lives in the footer next to the buttons, and the "I agree" button is disabled until the box is ticked.
- [ ] Projects sub-nav shows Projects Hub → Search → Staff Picks → My Projects → Create New → Parts Catalog. The Staff Picks item is highlighted as active when on \`/projects/staff-picks/\`.
- [ ] The staff-picks index no longer shows the "← Back to Projects" link; the per-pick view page still shows its "All Staff Picks" breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)