### PR TITLE
feat(instructions): Phase 0 plumbing — DB schema, CRUD API, editor card

### DIFF
--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -48,6 +48,7 @@ from .routers import (
     fx,
     health,
     images,
+    instructions,
     journal,
     links,
     makes,
@@ -182,6 +183,9 @@ def create_app() -> FastAPI:
     # Issue #171: YouTube videos as a first-class table, embedded above
     # the description on the public view page.
     app.include_router(videos.router)
+    # Issue #178 Phase 0: build instructions (step-by-step outlines).
+    # Phase 1 will layer a Fabric.js canvas on top of these rows.
+    app.include_router(instructions.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
     # Issue #123: parts catalog moderation (reports + community merges).

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import JSON
 
 from .db import Base
@@ -198,6 +198,87 @@ class ProjectVideo(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), nullable=False
     )
+
+
+# --- Build instructions (issue #178) -------------------------------------
+#
+# Phase 0 ("plumbing") of the Instruction Builder epic. Each project has at
+# most ONE ``Instruction`` row — represented by the unique constraint on
+# ``project_id`` — which carries a title + description and owns an ordered
+# sequence of ``InstructionStep`` rows. The 1:1 invariant is enforced by the
+# router (POST is idempotent) and by the schema (unique FK); future phases
+# may relax this to N:1 by dropping the unique constraint.
+#
+# Step ordering: ``step_number`` is 1-based and stored verbatim. The router
+# normalises the sequence on reorder PUTs so callers can rely on
+# 1..len(steps) after a reorder, but DELETE intentionally leaves gaps —
+# renumbering survivors would invalidate any UI handles the frontend has
+# cached. Brand-new tables — ``create_all`` handles them, no ALTER helper.
+#
+# ``canvas_json`` is unused in Phase 0; Phase 1 will write Fabric.js scene
+# state into it. Nullable so text-only steps and canvas-backed steps can
+# coexist in the same instruction.
+
+
+class Instruction(Base):
+    __tablename__ = "instructions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    title: Mapped[Optional[str]] = mapped_column(String(200))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    steps = relationship(
+        "InstructionStep",
+        back_populates="instruction",
+        cascade="all, delete-orphan",
+        order_by="InstructionStep.step_number",
+    )
+
+
+class InstructionStep(Base):
+    __tablename__ = "instruction_steps"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    instruction_id: Mapped[int] = mapped_column(
+        ForeignKey("instructions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # 1-based step ordering. The DB does not enforce a gap-free sequence —
+    # the API normalises gaps on reorder PUTs, but DELETE leaves gaps so
+    # surviving steps keep their stable numbers / UI handles.
+    step_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    title: Mapped[Optional[str]] = mapped_column(String(200))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    # Phase 1 will write Fabric.js canvas scene JSON here. Nullable so
+    # Phase 0 text-only steps and Phase 1+ canvas steps coexist.
+    canvas_json: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    instruction = relationship("Instruction", back_populates="steps")
 
 
 class ProjectFile(Base):

--- a/stacks/projects-api/projects_api/routers/instructions.py
+++ b/stacks/projects-api/projects_api/routers/instructions.py
@@ -1,0 +1,347 @@
+"""Build-instructions endpoints (issue #178, Phase 0).
+
+Each project has at most ONE instruction set today — enforced by the
+unique constraint on ``instructions.project_id`` and the idempotent POST
+below. A future phase may relax this to multiple instructions per
+project (e.g. assembly vs. wiring) by removing the unique constraint;
+the URL scheme reserves only the singular ``/instruction`` path so the
+plural form is available for that expansion.
+
+URL surface (mirrors ``routers/videos.py`` for shape + ownership rules):
+
+* ``GET    /api/projects/{id}/instruction``           — public, 404 if absent.
+* ``POST   /api/projects/{id}/instruction``           — owner + T&Cs.
+  Idempotent: if a row already exists, returns it with 200 (NOT 201).
+* ``PUT    /api/projects/{id}/instruction``           — owner + T&Cs.
+* ``DELETE /api/projects/{id}/instruction``           — owner + T&Cs.
+* ``GET    /api/projects/{id}/instruction/steps``     — public.
+* ``POST   /api/projects/{id}/instruction/steps``     — owner + T&Cs.
+* ``PUT    /api/projects/{id}/instruction/steps/{id}`` — owner + T&Cs.
+* ``DELETE /api/projects/{id}/instruction/steps/{id}`` — owner + T&Cs.
+
+Reorder semantics: a step PUT carrying ``step_number`` triggers a
+single-transaction renumber so the resulting sequence is gap-free
+(1..len(steps)). A step DELETE intentionally leaves gaps; survivors
+keep their stable numbers so any UI handles the frontend has cached
+remain valid.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from ..auth import require_terms_accepted
+from ..db import get_session
+from ..models import Instruction, InstructionStep, Project
+from ..schemas import (
+    InstructionCreate,
+    InstructionResponse,
+    InstructionStepCreate,
+    InstructionStepResponse,
+    InstructionStepUpdate,
+    InstructionUpdate,
+)
+
+router = APIRouter(prefix="/api/projects/{project_id}/instruction", tags=["instructions"])
+
+
+async def _check_owner(session: AsyncSession, project_id: int, user: str) -> Project:
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+    if project.author_username != user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not the project owner")
+    return project
+
+
+async def _get_instruction(
+    session: AsyncSession, project_id: int
+) -> Instruction | None:
+    """Load the single instruction for a project (or None)."""
+    return (
+        await session.scalars(
+            select(Instruction)
+            .where(Instruction.project_id == project_id)
+            .options(selectinload(Instruction.steps))
+        )
+    ).first()
+
+
+async def _load_steps(
+    session: AsyncSession, instruction_id: int
+) -> list[InstructionStep]:
+    return list(
+        (
+            await session.scalars(
+                select(InstructionStep)
+                .where(InstructionStep.instruction_id == instruction_id)
+                .order_by(InstructionStep.step_number, InstructionStep.id)
+            )
+        ).all()
+    )
+
+
+def _instruction_to_response(instruction: Instruction) -> InstructionResponse:
+    """Build the response dict. ``selectinload`` populates ``steps`` already
+    in ``step_number`` order (per the relationship's ``order_by``)."""
+    return InstructionResponse(
+        id=instruction.id,
+        project_id=instruction.project_id,
+        title=instruction.title,
+        description=instruction.description,
+        created_at=instruction.created_at,
+        updated_at=instruction.updated_at,
+        steps=[
+            InstructionStepResponse.model_validate(s, from_attributes=True)
+            for s in instruction.steps
+        ],
+    )
+
+
+# --- Instruction (singular) ---------------------------------------------
+
+
+@router.get("", response_model=InstructionResponse)
+async def get_instruction(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> InstructionResponse:
+    """Public read — surfaces user-authored content like the other GETs."""
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No instructions for this project",
+        )
+    return _instruction_to_response(instruction)
+
+
+@router.post("", response_model=InstructionResponse)
+async def create_instruction(
+    project_id: int,
+    body: InstructionCreate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> InstructionResponse:
+    """Owner-only, idempotent.
+
+    If an instruction already exists for this project, the existing row
+    is returned with 200 (NOT 201) — the frontend "Add step" button POSTs
+    here without checking first, so we need to be safe under double-click
+    and stale-state races.
+    """
+    await _check_owner(session, project_id, user)
+    existing = await _get_instruction(session, project_id)
+    if existing is not None:
+        # Existing-row return is a 200 by virtue of the default status code
+        # on @router.post (FastAPI default is 201 only when the route's
+        # `status_code` argument is set; we leave it unset on purpose so
+        # the idempotent re-create lands as 200 OK).
+        return _instruction_to_response(existing)
+    instruction = Instruction(
+        project_id=project_id,
+        title=body.title,
+        description=body.description,
+    )
+    session.add(instruction)
+    await session.commit()
+    await session.refresh(instruction)
+    # Re-load with steps eager-loaded so the response shape is consistent.
+    fresh = await _get_instruction(session, project_id)
+    assert fresh is not None  # just inserted, so the row must exist
+    return _instruction_to_response(fresh)
+
+
+@router.put("", response_model=InstructionResponse)
+async def update_instruction(
+    project_id: int,
+    body: InstructionUpdate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> InstructionResponse:
+    """Partial update of title / description. Steps are untouched here —
+    callers manage them through the ``/steps`` sub-collection."""
+    await _check_owner(session, project_id, user)
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No instructions for this project",
+        )
+    payload = body.model_dump(exclude_unset=True)
+    for field, value in payload.items():
+        setattr(instruction, field, value)
+    await session.commit()
+    await session.refresh(instruction)
+    fresh = await _get_instruction(session, project_id)
+    assert fresh is not None
+    return _instruction_to_response(fresh)
+
+
+@router.delete("", status_code=204)
+async def delete_instruction(
+    project_id: int,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    await _check_owner(session, project_id, user)
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No instructions for this project",
+        )
+    # ``cascade="all, delete-orphan"`` on the relationship plus
+    # ``ondelete="CASCADE"`` on the FK takes care of steps.
+    await session.delete(instruction)
+    await session.commit()
+
+
+# --- Instruction steps (nested collection) ------------------------------
+
+
+@router.get("/steps", response_model=list[InstructionStepResponse])
+async def list_steps(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> list[InstructionStepResponse]:
+    """Public read. Steps come back in ``step_number`` ASC order; ties
+    (which shouldn't happen post-renumber but might during a transient
+    DB state) fall back to ``id`` ASC."""
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        # Empty list rather than 404 — the steps collection is
+        # conceptually empty when the parent instruction doesn't exist,
+        # and the frontend can call the parent GET if it needs to
+        # distinguish "no instruction" from "instruction with no steps".
+        return []
+    steps = await _load_steps(session, instruction.id)
+    return [InstructionStepResponse.model_validate(s, from_attributes=True) for s in steps]
+
+
+@router.post("/steps", response_model=InstructionStepResponse, status_code=201)
+async def add_step(
+    project_id: int,
+    body: InstructionStepCreate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> InstructionStepResponse:
+    """Owner-only. Server assigns ``step_number = max(existing) + 1``
+    (or 1 on the first step)."""
+    await _check_owner(session, project_id, user)
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No instructions for this project",
+        )
+    max_step = await session.scalar(
+        select(func.max(InstructionStep.step_number)).where(
+            InstructionStep.instruction_id == instruction.id
+        )
+    )
+    next_number = 1 if max_step is None else int(max_step) + 1
+    step = InstructionStep(
+        instruction_id=instruction.id,
+        step_number=next_number,
+        title=body.title,
+        description=body.description,
+        canvas_json=body.canvas_json,
+    )
+    session.add(step)
+    await session.commit()
+    await session.refresh(step)
+    return InstructionStepResponse.model_validate(step, from_attributes=True)
+
+
+@router.put("/steps/{step_id}", response_model=InstructionStepResponse)
+async def update_step(
+    project_id: int,
+    step_id: int,
+    body: InstructionStepUpdate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> InstructionStepResponse:
+    """Partial update.
+
+    If ``step_number`` is in the payload, the router renumbers the entire
+    sequence so the target lands at the requested 1-based position and
+    survivors fill 1..N gap-free. Otherwise it just applies the field
+    update without disturbing ordering. ``step_number=0`` is rejected
+    at the Pydantic layer (``ge=1``); values beyond ``len(steps)`` clamp
+    to "last position" rather than 422 — that keeps the frontend's
+    move-down button trivial.
+    """
+    await _check_owner(session, project_id, user)
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No instructions for this project",
+        )
+    step = await session.get(InstructionStep, step_id)
+    if step is None or step.instruction_id != instruction.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Step not found")
+
+    payload = body.model_dump(exclude_unset=True)
+    new_step_number = payload.pop("step_number", None)
+
+    for field, value in payload.items():
+        setattr(step, field, value)
+
+    if new_step_number is not None:
+        # Pydantic's ge=1 enforces this — defence-in-depth.
+        if new_step_number < 1:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="step_number must be >= 1",
+            )
+        # Load the current ordering. ``step`` is in this list with its
+        # pre-update step_number — we'll move it out, re-insert at the
+        # requested position, and renumber 1..N.
+        steps = await _load_steps(session, instruction.id)
+        # ``_load_steps`` returns a fresh ORM read; locate the target by
+        # id rather than identity (which won't match the freshly queried
+        # objects under all session configurations).
+        survivors = [s for s in steps if s.id != step.id]
+        target_index = min(new_step_number, len(survivors) + 1) - 1
+        target_index = max(target_index, 0)
+        survivors.insert(target_index, step)
+        # Renumber: only assign when the new position differs from the
+        # current value to keep the UPDATE noise down (and avoid spurious
+        # ``updated_at`` bumps on untouched rows).
+        for idx, s in enumerate(survivors, start=1):
+            if s.step_number != idx:
+                s.step_number = idx
+
+    await session.commit()
+    await session.refresh(step)
+    return InstructionStepResponse.model_validate(step, from_attributes=True)
+
+
+@router.delete("/steps/{step_id}", status_code=204)
+async def delete_step(
+    project_id: int,
+    step_id: int,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    """Delete. Survivors keep their existing ``step_number`` — gaps are
+    allowed so any UI handles the frontend has cached remain valid.
+    The frontend can re-PUT explicit step_numbers if it wants to close
+    the gap visually."""
+    await _check_owner(session, project_id, user)
+    instruction = await _get_instruction(session, project_id)
+    if instruction is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No instructions for this project",
+        )
+    step = await session.get(InstructionStep, step_id)
+    if step is None or step.instruction_id != instruction.id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Step not found")
+    await session.delete(step)
+    await session.commit()

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -290,6 +290,77 @@ class VideoResponse(BaseModel):
     created_at: datetime
 
 
+# --- Build instructions (issue #178) -------------------------------------
+#
+# Phase 0 ("plumbing"): an ``Instruction`` is the (currently 1:1) container
+# attached to a project, carrying a title + description and owning an
+# ordered sequence of ``InstructionStep`` rows. Fabric.js canvas state
+# rides on each step in ``canvas_json``; Phase 0 leaves it null but
+# clients may set it via the standard step PUT path.
+
+
+class InstructionStepCreate(BaseModel):
+    """Body for ``POST /api/projects/{id}/instruction/steps``.
+
+    No ``step_number`` is accepted — the server assigns ``max(existing) + 1``
+    (or 1 on the first step) so insertion order is the source of truth.
+    """
+
+    title: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+    canvas_json: Optional[str] = None
+
+
+class InstructionStepUpdate(BaseModel):
+    """Partial update — fields omitted are left untouched.
+
+    Including ``step_number`` triggers a reorder: the router moves the
+    target into the requested 1-based position and renumbers the survivors
+    so the resulting sequence is 1..N gap-free. ``step_number`` must be
+    >= 1; values larger than the current length clamp to "last".
+    """
+
+    title: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+    canvas_json: Optional[str] = None
+    step_number: Optional[int] = Field(None, ge=1)
+
+
+class InstructionStepResponse(BaseModel):
+    id: int
+    instruction_id: int
+    step_number: int
+    title: Optional[str] = None
+    description: Optional[str] = None
+    canvas_json: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class InstructionCreate(BaseModel):
+    """Empty body permitted — creates the row, frontend can update later."""
+
+    title: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+
+
+class InstructionUpdate(BaseModel):
+    """Partial — same semantics as ``InstructionStepUpdate`` (no step_number)."""
+
+    title: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+
+
+class InstructionResponse(BaseModel):
+    id: int
+    project_id: int
+    title: Optional[str] = None
+    description: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    steps: list[InstructionStepResponse] = Field(default_factory=list)
+
+
 class JournalEntryCreate(BaseModel):
     title: str = Field(..., max_length=200)
     content_md: Optional[str] = None

--- a/stacks/projects-api/tests/test_instructions.py
+++ b/stacks/projects-api/tests/test_instructions.py
@@ -1,0 +1,420 @@
+"""Build-instructions CRUD tests (issue #178, Phase 0).
+
+Mirrors the fixture pattern in ``tests/test_videos.py``: a per-test
+project is created up front, then we exercise the instruction + step
+endpoints against it. The terms-gate test deliberately strips the
+``conftest.client`` bypass to confirm the gate fires on writes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture
+async def project_id(client) -> int:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Instruction Test Project"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# --- Instruction (singular) ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instruction_post_is_idempotent(client, project_id) -> None:
+    """A second POST returns the SAME row with 200, not 201."""
+    headers = make_auth_header()
+    first = await client.post(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "Assembly", "description": "How to build it"},
+        headers=headers,
+    )
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body["title"] == "Assembly"
+    assert first_body["description"] == "How to build it"
+    assert first_body["project_id"] == project_id
+    assert first_body["steps"] == []
+
+    second = await client.post(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "Different on second POST"},
+        headers=headers,
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    # Idempotent: same row id, original title preserved (no overwrite).
+    assert second_body["id"] == first_body["id"]
+    assert second_body["title"] == "Assembly"
+
+
+@pytest.mark.asyncio
+async def test_get_returns_404_when_no_instruction(client, project_id) -> None:
+    resp = await client.get(f"/api/projects/{project_id}/instruction")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_put_updates_title_and_description(client, project_id) -> None:
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "Initial"},
+        headers=headers,
+    )
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "Updated", "description": "New blurb"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["title"] == "Updated"
+    assert body["description"] == "New blurb"
+
+    get_resp = await client.get(f"/api/projects/{project_id}/instruction")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["title"] == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_instruction(client, project_id) -> None:
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/instruction", json={}, headers=headers
+    )
+    resp = await client.delete(
+        f"/api/projects/{project_id}/instruction", headers=headers
+    )
+    assert resp.status_code == 204
+
+    get_resp = await client.get(f"/api/projects/{project_id}/instruction")
+    assert get_resp.status_code == 404
+
+
+# --- Steps ---------------------------------------------------------------
+
+
+async def _create_instruction(client, project_id: int) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction", json={}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_steps_post_assigns_sequential_numbers(client, project_id) -> None:
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+
+    ids = []
+    for title in ("Step A", "Step B", "Step C"):
+        resp = await client.post(
+            f"/api/projects/{project_id}/instruction/steps",
+            json={"title": title},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        ids.append(resp.json()["id"])
+
+    list_resp = await client.get(
+        f"/api/projects/{project_id}/instruction/steps"
+    )
+    assert list_resp.status_code == 200
+    rows = list_resp.json()
+    assert [r["step_number"] for r in rows] == [1, 2, 3]
+    assert [r["id"] for r in rows] == ids
+
+
+@pytest.mark.asyncio
+async def test_step_put_step_number_reorders_and_renumbers(
+    client, project_id
+) -> None:
+    """Moving the third step to position 1 should renumber survivors so
+    the resulting sequence is 1..3 with the moved step first."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+
+    ids = []
+    for title in ("first", "second", "third"):
+        resp = await client.post(
+            f"/api/projects/{project_id}/instruction/steps",
+            json={"title": title},
+            headers=headers,
+        )
+        ids.append(resp.json()["id"])
+
+    # PUT step_number=1 on the third step.
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{ids[2]}",
+        json={"step_number": 1},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["step_number"] == 1
+
+    rows = (
+        await client.get(f"/api/projects/{project_id}/instruction/steps")
+    ).json()
+    assert [r["id"] for r in rows] == [ids[2], ids[0], ids[1]]
+    assert [r["step_number"] for r in rows] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_step_delete_leaves_gaps(client, project_id) -> None:
+    """Deleting the middle step leaves survivors with their original
+    numbers — gaps are allowed."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+
+    ids = []
+    for title in ("a", "b", "c"):
+        resp = await client.post(
+            f"/api/projects/{project_id}/instruction/steps",
+            json={"title": title},
+            headers=headers,
+        )
+        ids.append(resp.json()["id"])
+
+    # Delete the middle step (step_number=2).
+    resp = await client.delete(
+        f"/api/projects/{project_id}/instruction/steps/{ids[1]}",
+        headers=headers,
+    )
+    assert resp.status_code == 204
+
+    rows = (
+        await client.get(f"/api/projects/{project_id}/instruction/steps")
+    ).json()
+    assert [r["id"] for r in rows] == [ids[0], ids[2]]
+    # Numbers are unchanged — the survivors are still 1 and 3.
+    assert [r["step_number"] for r in rows] == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_step_put_step_number_zero_returns_422(client, project_id) -> None:
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "only step"},
+        headers=headers,
+    )
+    step_id = resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{step_id}",
+        json={"step_number": 0},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_step_put_step_number_clamps_past_end(client, project_id) -> None:
+    """Passing step_number well beyond the list length clamps to "last"
+    rather than 422 — the frontend's move-down button doesn't have to
+    know the current length."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    ids = []
+    for title in ("a", "b", "c"):
+        resp = await client.post(
+            f"/api/projects/{project_id}/instruction/steps",
+            json={"title": title},
+            headers=headers,
+        )
+        ids.append(resp.json()["id"])
+
+    # Move the first step to step_number=999 → should land last.
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{ids[0]}",
+        json={"step_number": 999},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["step_number"] == 3
+
+    rows = (
+        await client.get(f"/api/projects/{project_id}/instruction/steps")
+    ).json()
+    assert [r["id"] for r in rows] == [ids[1], ids[2], ids[0]]
+
+
+# --- Ownership + auth ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_owner_post_returns_403(client, project_id) -> None:
+    other = make_auth_header(username="someoneelse")
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "hijack"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_put_returns_403(client, project_id) -> None:
+    owner = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "ok"},
+        headers=owner,
+    )
+    other = make_auth_header(username="someoneelse")
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "hijacked"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_delete_returns_403(client, project_id) -> None:
+    owner = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/instruction", json={}, headers=owner
+    )
+    other = make_auth_header(username="someoneelse")
+    resp = await client.delete(
+        f"/api/projects/{project_id}/instruction", headers=other
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_step_writes_return_403(client, project_id) -> None:
+    owner = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/instruction", json={}, headers=owner
+    )
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "owner-added"},
+        headers=owner,
+    )
+    step_id = resp.json()["id"]
+
+    other = make_auth_header(username="someoneelse")
+    for verb, url, payload in (
+        ("post", f"/api/projects/{project_id}/instruction/steps", {"title": "x"}),
+        ("put", f"/api/projects/{project_id}/instruction/steps/{step_id}", {"title": "x"}),
+        ("delete", f"/api/projects/{project_id}/instruction/steps/{step_id}", None),
+    ):
+        method = getattr(client, verb)
+        if payload is None:
+            resp = await method(url, headers=other)
+        else:
+            resp = await method(url, json=payload, headers=other)
+        assert resp.status_code == 403, f"{verb} {url} should have been 403"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_can_read_instruction(client, project_id) -> None:
+    """Public GETs work without any auth header."""
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/instruction",
+        json={"title": "public read"},
+        headers=headers,
+    )
+    await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "first step"},
+        headers=headers,
+    )
+
+    # No auth header.
+    resp = await client.get(f"/api/projects/{project_id}/instruction")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "public read"
+
+    steps_resp = await client.get(
+        f"/api/projects/{project_id}/instruction/steps"
+    )
+    assert steps_resp.status_code == 200
+    assert len(steps_resp.json()) == 1
+
+
+# --- Terms gate ---------------------------------------------------------
+#
+# The default ``client`` fixture in ``conftest.py`` patches
+# ``require_terms_accepted`` to no-op so the bulk of the suite doesn't
+# need to first POST /api/users/me/accept-terms. This single test opts
+# back into the real gate (same pattern as ``tests/test_terms.py``)
+# and confirms an instruction-write hits 403 before acceptance.
+
+
+@pytest.mark.asyncio
+async def test_write_without_terms_acceptance_returns_403(client) -> None:
+    from projects_api import auth as auth_module
+
+    app = client._transport.app
+    for dep in (
+        auth_module.require_terms_accepted,
+        auth_module.require_terms_accepted_aged,
+    ):
+        app.dependency_overrides.pop(dep, None)
+
+    headers = make_auth_header("alice")
+
+    # Accept terms so the project itself can be created (POST /api/projects
+    # is also gated by ``require_terms_accepted``).
+    acc = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert acc.status_code == 200, acc.text
+    proj = await client.post(
+        "/api/projects",
+        json={"title": "Gated Instruction Project"},
+        headers=headers,
+    )
+    assert proj.status_code == 201, proj.text
+    pid = proj.json()["id"]
+
+    # Now strip the user's terms acceptance to simulate a stale state.
+    # Easiest way: create a brand-new user (different sub) with no
+    # acceptance record and try to write to bob's project — fails 403
+    # because bob isn't the owner. We need the same user to hit
+    # not-accepted, so instead bump the version and have alice's
+    # 1.0 acceptance go stale.
+    from projects_api import config as config_module
+    from projects_api.routers import users as users_router
+
+    def _fake_get_settings():
+        s = config_module.Settings()
+        return s.model_copy(update={"current_terms_version": "2.0"})
+
+    import pytest as _pytest
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr(config_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(auth_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(users_router, "get_settings", _fake_get_settings)
+
+    try:
+        resp = await client.post(
+            f"/api/projects/{pid}/instruction",
+            json={"title": "should be blocked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail")
+        assert isinstance(detail, dict)
+        assert detail.get("detail") == "terms_not_accepted"
+    finally:
+        monkeypatch.undo()

--- a/web/assets/css/project-editor.css
+++ b/web/assets/css/project-editor.css
@@ -801,3 +801,32 @@ body:has(.CodeMirror-fullscreen) .col-lg-8 {
 #completeness-next a:hover {
   text-decoration: underline;
 }
+
+/* --- Build Instructions (issue #178, Phase 0) ------------------------- */
+
+#instruction-steps-list .step-card {
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.5rem;
+  background: #fff;
+}
+
+#instruction-steps-list .step-number-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: var(--bs-primary, #0d6efd);
+  color: #fff;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+#instruction-steps-list .step-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -94,6 +94,16 @@
       loadFiles();
       loadImages();
       loadJournal();
+      // Issue #178 Phase 0: bring up the instruction-builder section.
+      // Lives in its own module (project-instructions.js) to avoid
+      // piling more behaviour onto this file ahead of Phase 1's
+      // Fabric.js canvas work. isOwner is implicit here — the editor
+      // page only opens for the logged-in user, and the backend
+      // rejects non-owner writes with 403 (mirrors the other sections
+      // above, which don't track ownership client-side either).
+      if (window.ProjectInstructions && typeof window.ProjectInstructions.init === 'function') {
+        window.ProjectInstructions.init(currentProject.id, true);
+      }
     } catch (e) {
       console.error('Failed to load project:', e);
     }

--- a/web/assets/js/project-instructions.js
+++ b/web/assets/js/project-instructions.js
@@ -1,0 +1,373 @@
+/**
+ * Build-instructions section (issue #178, Phase 0).
+ *
+ * Deliberately a per-section module rather than another block inside the
+ * 2765-line project-editor.js — Phase 1 will add Fabric.js canvas code
+ * which MUST live somewhere modular and not pile on top of the editor
+ * monolith. This file establishes that pattern.
+ *
+ * Public surface:
+ *   window.ProjectInstructions.init(projectId, isOwner)
+ *
+ * Backend contract: see stacks/projects-api/projects_api/routers/instructions.py.
+ * Idempotent POST on the instruction means we can lazily create it on
+ * first input — no need to "create first" up-front.
+ */
+(function () {
+  'use strict';
+
+  var API = 'https://projects.kevsrobots.com';
+
+  // Use ProjectAuth.apiFetch when present (sends cookies + dev token) and
+  // run 403 responses through TermsGate.handleResponse so a logged-in
+  // user who hasn't accepted the T&Cs sees the modal rather than a
+  // silent failure. Falls back to plain fetch for unauthenticated reads.
+  function apiFetch(url, opts) {
+    opts = opts || {};
+    if (window.ProjectAuth && typeof window.ProjectAuth.apiFetch === 'function') {
+      return window.ProjectAuth.apiFetch(url, opts);
+    }
+    opts.credentials = opts.credentials || 'include';
+    return fetch(url, opts);
+  }
+
+  async function apiFetchWithTermsRetry(url, opts) {
+    var resp = await apiFetch(url, opts);
+    if (resp.status === 403 && window.TermsGate && typeof window.TermsGate.handleResponse === 'function') {
+      try {
+        var retry = await window.TermsGate.handleResponse(resp);
+        if (retry) return apiFetch(url, opts);
+      } catch (_) { /* swallow — original 403 will surface to caller */ }
+    }
+    return resp;
+  }
+
+  // --- Tiny helpers -------------------------------------------------------
+
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return '';
+    var d = document.createElement('div');
+    d.textContent = String(s);
+    return d.innerHTML;
+  }
+
+  // Per-input debounce so blur saves don't queue multiple PUTs on the
+  // same field. Key is a string identifier; value is the active timer.
+  var _debounces = {};
+  function debounce(key, fn, ms) {
+    if (_debounces[key]) clearTimeout(_debounces[key]);
+    _debounces[key] = setTimeout(function () {
+      delete _debounces[key];
+      fn();
+    }, ms);
+  }
+
+  // Flash a "Saved" indicator next to an input. Matches the visual
+  // language of project-editor.js's showSaveStatus(...) without
+  // coupling to its (closure-scoped) implementation.
+  function flashSaved(indicatorEl) {
+    if (!indicatorEl) return;
+    indicatorEl.classList.remove('d-none');
+    if (indicatorEl._fadeTimer) clearTimeout(indicatorEl._fadeTimer);
+    indicatorEl._fadeTimer = setTimeout(function () {
+      indicatorEl.classList.add('d-none');
+    }, 1500);
+  }
+
+  // --- Module state -------------------------------------------------------
+
+  var state = {
+    projectId: null,
+    isOwner: false,
+    instructionId: null,  // null until the instruction row exists server-side
+    steps: [],            // last-fetched ordered list (cache for move-up/down)
+  };
+
+  // --- DOM handles --------------------------------------------------------
+
+  var dom = {};
+  function bindDom() {
+    dom.section = document.getElementById('editor-instructions-section');
+    dom.title = document.getElementById('instruction-title');
+    dom.description = document.getElementById('instruction-description');
+    dom.metaSaved = document.getElementById('instruction-meta-saved');
+    dom.stepsList = document.getElementById('instruction-steps-list');
+    dom.addBtn = document.getElementById('add-instruction-step');
+  }
+
+  // --- Backend calls ------------------------------------------------------
+
+  async function fetchInstruction() {
+    var resp = await apiFetch(API + '/api/projects/' + state.projectId + '/instruction');
+    if (resp.status === 404) return null;
+    if (!resp.ok) throw new Error('Failed to load instruction: HTTP ' + resp.status);
+    return resp.json();
+  }
+
+  async function ensureInstruction() {
+    // Idempotent: backend returns the existing row with 200 if one already
+    // exists for this project. Safe to call repeatedly under double-click.
+    if (state.instructionId) return state.instructionId;
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + state.projectId + '/instruction',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: dom.title.value || null,
+          description: dom.description.value || null,
+        }),
+      }
+    );
+    if (!resp.ok) throw new Error('Failed to create instruction: HTTP ' + resp.status);
+    var body = await resp.json();
+    state.instructionId = body.id;
+    return body.id;
+  }
+
+  async function putInstructionFields(fields) {
+    await ensureInstruction();
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + state.projectId + '/instruction',
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fields),
+      }
+    );
+    if (!resp.ok) throw new Error('Failed to save instruction: HTTP ' + resp.status);
+    return resp.json();
+  }
+
+  async function fetchSteps() {
+    var resp = await apiFetch(
+      API + '/api/projects/' + state.projectId + '/instruction/steps'
+    );
+    if (!resp.ok) throw new Error('Failed to list steps: HTTP ' + resp.status);
+    return resp.json();
+  }
+
+  async function postStep() {
+    await ensureInstruction();
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + state.projectId + '/instruction/steps',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: '', description: '' }),
+      }
+    );
+    if (!resp.ok) throw new Error('Failed to add step: HTTP ' + resp.status);
+    return resp.json();
+  }
+
+  async function putStep(stepId, fields) {
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + state.projectId + '/instruction/steps/' + stepId,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fields),
+      }
+    );
+    if (!resp.ok) throw new Error('Failed to update step: HTTP ' + resp.status);
+    return resp.json();
+  }
+
+  async function deleteStep(stepId) {
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + state.projectId + '/instruction/steps/' + stepId,
+      { method: 'DELETE' }
+    );
+    if (!resp.ok && resp.status !== 204) {
+      throw new Error('Failed to delete step: HTTP ' + resp.status);
+    }
+  }
+
+  // --- Rendering ----------------------------------------------------------
+
+  function renderSteps(steps) {
+    state.steps = steps.slice();
+    if (!dom.stepsList) return;
+    if (steps.length === 0) {
+      dom.stepsList.innerHTML =
+        '<p class="text-muted small fst-italic mb-0">' +
+        'No steps yet &mdash; click <strong>Add step</strong> below to start outlining your build.' +
+        '</p>';
+      return;
+    }
+    var disabledAttr = state.isOwner ? '' : ' disabled';
+    var hideActions = state.isOwner ? '' : ' style="display:none"';
+    dom.stepsList.innerHTML = steps.map(function (s, idx) {
+      var isFirst = idx === 0;
+      var isLast = idx === steps.length - 1;
+      return (
+        '<div class="step-card" data-step-id="' + s.id + '">' +
+          '<div class="d-flex align-items-start gap-2">' +
+            '<span class="step-number-badge">' + s.step_number + '</span>' +
+            '<div class="flex-grow-1">' +
+              '<input class="form-control form-control-sm mb-1 step-title" ' +
+                     'placeholder="Step title" maxlength="200" ' +
+                     'value="' + escapeHtml(s.title || '') + '"' + disabledAttr + '>' +
+              '<textarea class="form-control form-control-sm step-description" ' +
+                        'rows="2" placeholder="Describe what happens in this step…"' +
+                        disabledAttr + '>' + escapeHtml(s.description || '') + '</textarea>' +
+              '<div class="step-saved text-success small mt-1 d-none">' +
+                '<i class="fas fa-check me-1"></i>Saved</div>' +
+            '</div>' +
+            '<div class="step-actions"' + hideActions + '>' +
+              '<button class="btn btn-sm btn-outline-secondary step-up" ' +
+                      'title="Move up"' +
+                      (isFirst ? ' disabled' : '') + '>' +
+                '<i class="fas fa-arrow-up"></i></button>' +
+              '<button class="btn btn-sm btn-outline-secondary step-down" ' +
+                      'title="Move down"' +
+                      (isLast ? ' disabled' : '') + '>' +
+                '<i class="fas fa-arrow-down"></i></button>' +
+              '<button class="btn btn-sm btn-outline-danger step-delete" ' +
+                      'title="Delete step">' +
+                '<i class="fas fa-trash"></i></button>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+    }).join('');
+
+    // Wire per-step handlers. Event delegation would also work, but
+    // direct binding keeps the closure scope clean and avoids leaking
+    // step ids into shared dataset attributes.
+    Array.prototype.forEach.call(
+      dom.stepsList.querySelectorAll('.step-card'),
+      function (card) {
+        var stepId = parseInt(card.dataset.stepId, 10);
+        var titleInput = card.querySelector('.step-title');
+        var descInput = card.querySelector('.step-description');
+        var savedInd = card.querySelector('.step-saved');
+
+        if (titleInput) {
+          titleInput.addEventListener('blur', function () {
+            debounce('step-title-' + stepId, function () {
+              putStep(stepId, { title: titleInput.value || null })
+                .then(function () { flashSaved(savedInd); })
+                .catch(function () { /* let the user see stale state — they'll retry */ });
+            }, 500);
+          });
+        }
+        if (descInput) {
+          descInput.addEventListener('blur', function () {
+            debounce('step-desc-' + stepId, function () {
+              putStep(stepId, { description: descInput.value || null })
+                .then(function () { flashSaved(savedInd); })
+                .catch(function () { });
+            }, 500);
+          });
+        }
+
+        if (!state.isOwner) return;
+
+        var upBtn = card.querySelector('.step-up');
+        var downBtn = card.querySelector('.step-down');
+        var delBtn = card.querySelector('.step-delete');
+
+        if (upBtn) upBtn.addEventListener('click', function () {
+          var idx = state.steps.findIndex(function (s) { return s.id === stepId; });
+          if (idx <= 0) return;
+          var newPos = state.steps[idx - 1].step_number;
+          putStep(stepId, { step_number: newPos })
+            .then(reloadSteps)
+            .catch(function () { });
+        });
+        if (downBtn) downBtn.addEventListener('click', function () {
+          var idx = state.steps.findIndex(function (s) { return s.id === stepId; });
+          if (idx < 0 || idx >= state.steps.length - 1) return;
+          var newPos = state.steps[idx + 1].step_number;
+          putStep(stepId, { step_number: newPos })
+            .then(reloadSteps)
+            .catch(function () { });
+        });
+        if (delBtn) delBtn.addEventListener('click', function () {
+          if (!window.confirm('Delete this step? This cannot be undone.')) return;
+          deleteStep(stepId).then(reloadSteps).catch(function () { });
+        });
+      }
+    );
+  }
+
+  async function reloadSteps() {
+    try {
+      var steps = await fetchSteps();
+      renderSteps(steps);
+    } catch (e) {
+      // Network blip — render the empty-state hint rather than a stack
+      // trace. The user can refresh to retry.
+      renderSteps([]);
+    }
+  }
+
+  // --- Init ---------------------------------------------------------------
+
+  function wireMetaInputs() {
+    if (!dom.title || !dom.description) return;
+
+    function saveMeta(field, value) {
+      putInstructionFields({ [field]: value || null })
+        .then(function () { flashSaved(dom.metaSaved); })
+        .catch(function () { });
+    }
+
+    dom.title.addEventListener('blur', function () {
+      debounce('instruction-title', function () {
+        saveMeta('title', dom.title.value);
+      }, 500);
+    });
+    dom.description.addEventListener('blur', function () {
+      debounce('instruction-description', function () {
+        saveMeta('description', dom.description.value);
+      }, 500);
+    });
+  }
+
+  function wireAddButton() {
+    if (!dom.addBtn) return;
+    dom.addBtn.addEventListener('click', function () {
+      dom.addBtn.disabled = true;
+      postStep()
+        .then(reloadSteps)
+        .catch(function () { })
+        .then(function () { dom.addBtn.disabled = false; });
+    });
+  }
+
+  function applyOwnerGating() {
+    if (state.isOwner) return;
+    if (dom.title) dom.title.disabled = true;
+    if (dom.description) dom.description.disabled = true;
+    if (dom.addBtn) dom.addBtn.classList.add('d-none');
+  }
+
+  async function init(projectId, isOwner) {
+    state.projectId = projectId;
+    state.isOwner = isOwner !== false;  // default to owner if unspecified
+    bindDom();
+    if (!dom.section) return;  // page didn't render the section — nothing to do
+    applyOwnerGating();
+    wireMetaInputs();
+    wireAddButton();
+
+    try {
+      var instruction = await fetchInstruction();
+      if (instruction) {
+        state.instructionId = instruction.id;
+        dom.title.value = instruction.title || '';
+        dom.description.value = instruction.description || '';
+        renderSteps(instruction.steps || []);
+      } else {
+        renderSteps([]);
+      }
+    } catch (e) {
+      renderSteps([]);
+    }
+  }
+
+  window.ProjectInstructions = { init: init };
+})();

--- a/web/projects/editor.html
+++ b/web/projects/editor.html
@@ -10,7 +10,7 @@ hide_nibsy: true
 
 {% include nav_projects.html %}
 
-<link rel="stylesheet" href="/assets/css/project-editor.css">
+<link rel="stylesheet" href="/assets/css/project-editor.css?v={{ site.time | date: '%s' }}">
 <link rel="stylesheet" href="/assets/css/circuit-editor.css">
 <link rel="stylesheet" href="/assets/css/image-viewer.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
@@ -132,6 +132,38 @@ hide_nibsy: true
         <textarea id="content-editor"></textarea>
         <div id="image-picker-container" class="d-none">
           <div id="image-picker-list"></div>
+        </div>
+      </div>
+
+      <!-- Build Instructions (issue #178, Phase 0 — data plumbing only) -->
+      <div class="card mb-4" id="editor-instructions-section">
+        <div class="card-header py-2">
+          <i class="fas fa-list-ol me-1"></i> Build Instructions
+        </div>
+        <div class="card-body">
+          <p class="text-muted small mb-3">
+            Outline the build steps for your project. In this phase you can
+            add step titles and descriptions. The visual canvas &mdash;
+            overlays, arrows, photo annotations &mdash; is coming next.
+          </p>
+
+          <div id="instructions-meta" class="mb-3">
+            <label for="instruction-title" class="form-label fw-semibold small text-muted">Instruction set title</label>
+            <input type="text" class="form-control form-control-sm mb-2" id="instruction-title"
+                   placeholder="e.g. Assembling the SMARS chassis" maxlength="200">
+            <label for="instruction-description" class="form-label fw-semibold small text-muted">Description</label>
+            <textarea class="form-control form-control-sm" id="instruction-description" rows="2"
+                      placeholder="Optional. One-line summary shown above the steps."></textarea>
+            <div id="instruction-meta-saved" class="text-success small mt-1 d-none"><i class="fas fa-check me-1"></i>Saved</div>
+          </div>
+
+          <h6 class="mt-4 mb-2 text-muted text-uppercase small">Steps</h6>
+          <div id="instruction-steps-list">
+            <!-- Populated by project-instructions.js -->
+          </div>
+          <button id="add-instruction-step" type="button" class="btn btn-outline-primary btn-sm mt-2">
+            <i class="fas fa-plus me-1"></i> Add step
+          </button>
         </div>
       </div>
 
@@ -373,6 +405,10 @@ hide_nibsy: true
 <script src="/assets/js/circuit-components.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/circuit-editor.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/badge-toast.js?v={{ site.time | date: '%s' }}"></script>
+<!-- Issue #178 Phase 0: instruction-section module. Loaded BEFORE
+     project-editor.js so the latter's boot flow can call
+     ProjectInstructions.init(projectId, isOwner). -->
+<script src="/assets/js/project-instructions.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-editor.js?v={{ site.time | date: '%s' }}"></script>
 <script>
 // Editor TOC — live-updates from markdown source as the user types
@@ -413,6 +449,11 @@ hide_nibsy: true
 
     // Extra non-markdown anchors (page sections rendered outside the editor)
     const extraLinks = [];
+    // Issue #178 Phase 0: surface the Build Instructions card. Always
+    // present (unlike BOM / videos which appear only when populated)
+    // because the card itself is always rendered and the user-facing
+    // flow is "scroll here to start outlining the build".
+    extraLinks.push(`<a class="toc-h1 toc-extra" data-scroll-to="editor-instructions-section">Build Instructions</a>`);
     const bomRows = document.querySelectorAll('#bom-body tr').length;
     if (bomRows > 0) {
       extraLinks.push(`<a class="toc-h1 toc-extra" data-scroll-to="editor-bom-section">Bill of Materials</a>`);


### PR DESCRIPTION
## Summary

First slice of the Instruction Builder epic (#178). **Data plumbing only — no canvas, no overlays, no exports.**

- New `instructions` + `instruction_steps` tables (unique FK keeps it 1:1 per project for now); FastAPI router at `/api/projects/{pid}/instruction` with idempotent POST and a server-side renumber-on-reorder PUT.
- New "Build Instructions" card in the project editor (between Story and Files & Models) with title/description autosave and step cards supporting title/description autosave, move-up/down, delete, and "Add step".
- All logic lives in a new `project-instructions.js` module exposing `window.ProjectInstructions.init(projectId, isOwner)` — Phase 1's Fabric.js canvas code will land alongside it rather than piling onto the 2765-line `project-editor.js` monolith.

## Test plan

- [x] `pytest tests/test_instructions.py -x` — 15 new tests pass (idempotent POST, reorder/renumber, delete-leaves-gaps, `step_number=0` → 422, `step_number=999` clamps, ownership, terms gate, public GET).
- [x] Full suite: 394 passed, no regressions.
- [x] `node --check web/assets/js/project-instructions.js`.
- [ ] **Manual (browser)** — open the editor on a draft project; "Build Instructions" card appears between markdown editor and Files & Models; "Build Instructions" appears in the left TOC.
- [ ] Type a title + description, blur each field → "Saved" check fades in/out.
- [ ] Click "Add step" three times → step badges `1`, `2`, `3`. Edit titles/descriptions → per-step "Saved" indicator flashes.
- [ ] Move-up on step 3 → list reorders, badges remain `1`, `2`, `3`. First-step move-up and last-step move-down are disabled.
- [ ] Delete the middle step → survivors keep original badges (gap allowed). `window.confirm` prompts before delete.
- [ ] Reload page → state persists in the same order.

## Implementation notes for review

- **Models use `mapped_column`** matching the SQLAlchemy 2.0 style already in `models.py`.
- **Schemas use plain `BaseModel`** with `model_validate(obj, from_attributes=True)` at the router — matches the existing `VideoResponse` / `LinkResponse` pattern.
- **Idempotent POST returns 200** on both first-create and re-create. Simplifies the frontend's "open Instructions tab → ensure exists" call.
- **`isOwner` is hard-coded `true`** from `project-editor.js`, consistent with how existing sections (BOM/links/videos) rely on backend 403 enforcement. The module implements the read-only branch but the call site doesn't yet exercise it — easy follow-up if we want stricter client-side gating.
- **CSS cache-bust** added to the existing `project-editor.css` `<link>` so new styles aren't masked by year-long browser caches.
- **No migration helper needed** — both tables are new, so `Base.metadata.create_all()` handles them per the CLAUDE.md migration rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)