### PR TITLE
feat(instructions): Phase 2a — public slideshow viewer on view.html

### DIFF
--- a/web/assets/css/instruction-viewer.css
+++ b/web/assets/css/instruction-viewer.css
@@ -1,0 +1,302 @@
+/*
+ * Instruction Viewer — Phase 2a (issue #178).
+ *
+ * Read-only slideshow shown inline on the project view page. Each step
+ * is pre-rendered to a PNG dataURL at init time, so this stylesheet
+ * styles a sequence of <img> elements (one visible at a time) plus
+ * navigation controls — there's no Fabric.js runtime in the viewer DOM.
+ */
+
+#instruction-slideshow-section {
+  margin-bottom: 1.5rem;
+}
+
+#instruction-slideshow-section h4 {
+  margin-bottom: 0.75rem;
+}
+
+.iv-frame {
+  position: relative;
+  background: #ffffff;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  margin: 0 auto;
+  max-width: 900px;
+}
+
+.iv-stage {
+  position: relative;
+  width: 100%;
+  /* 1200x900 canvas → 4:3 aspect ratio */
+  aspect-ratio: 4 / 3;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.iv-stage img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  display: block;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+/* Soft grey panel for steps with no canvas_json (text-only) — keeps the
+   slideshow shell consistent while making it clear there's no diagram. */
+.iv-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.5rem;
+  background: #f1f3f5;
+  color: #495057;
+}
+
+.iv-placeholder-title {
+  font-size: 1.4rem;
+  font-weight: 500;
+  max-width: 80%;
+}
+
+/* "Step N of M" badge — top-left corner of the frame. */
+.iv-step-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  background: rgba(33, 37, 41, 0.85);
+  color: #ffffff;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Fullscreen toggle — top-right corner. */
+.iv-fullscreen-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #495057;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.15s, color 0.15s;
+}
+
+.iv-fullscreen-btn:hover {
+  background: #ffffff;
+  color: #212529;
+}
+
+/* Prev / Next arrow buttons — overlaid on the left/right edges of the
+   frame, vertically centred. */
+.iv-nav-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid #dee2e6;
+  background: rgba(255, 255, 255, 0.9);
+  color: #495057;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.15s, color 0.15s, opacity 0.15s;
+}
+
+.iv-nav-btn:hover {
+  background: #ffffff;
+  color: #212529;
+}
+
+.iv-nav-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.iv-nav-prev { left: 10px; }
+.iv-nav-next { right: 10px; }
+
+/* Loading spinner overlay while pre-rendering. */
+.iv-spinner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: #f8f9fa;
+  color: #6c757d;
+  z-index: 3;
+}
+
+/* Dot indicators below the frame — one per step. */
+.iv-dots {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  margin: 0.75rem auto 0;
+  max-width: 900px;
+  padding: 0 0.5rem;
+}
+
+.iv-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background: #ced4da;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s, transform 0.15s;
+}
+
+.iv-dot:hover {
+  background: #adb5bd;
+}
+
+.iv-dot.is-active {
+  background: #4A90D9;
+  transform: scale(1.2);
+}
+
+/* Step title + description under the slideshow. */
+.iv-step-meta {
+  max-width: 900px;
+  margin: 1rem auto 0;
+  padding: 0 0.25rem;
+}
+
+.iv-step-meta h4 {
+  margin-bottom: 0.35rem;
+  color: #212529;
+}
+
+.iv-step-meta .iv-step-description {
+  color: #495057;
+  margin-bottom: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+/* Text-only fallback list (Fabric failed to load). */
+.iv-fallback-list {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+}
+
+.iv-fallback-list ol {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.iv-fallback-list li {
+  margin-bottom: 0.75rem;
+}
+
+.iv-fallback-list li:last-child {
+  margin-bottom: 0;
+}
+
+.iv-fallback-list .iv-fallback-desc {
+  display: block;
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin-top: 0.15rem;
+  white-space: pre-wrap;
+}
+
+/* Fullscreen mode — dark backdrop, canvas centred and scaled to viewport. */
+.iv-frame:fullscreen {
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  border-radius: 0;
+  background: #1a1a1a;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.iv-frame:fullscreen .iv-stage {
+  aspect-ratio: 4 / 3;
+  width: auto;
+  height: 100%;
+  max-width: calc(100vh * 4 / 3);
+  max-height: 100%;
+  background: #ffffff;
+  border-radius: 4px;
+}
+
+.iv-frame:fullscreen .iv-step-badge {
+  top: 24px;
+  left: 24px;
+  font-size: 1rem;
+  padding: 6px 14px;
+}
+
+.iv-frame:fullscreen .iv-fullscreen-btn {
+  top: 24px;
+  right: 24px;
+  width: 40px;
+  height: 40px;
+}
+
+.iv-frame:fullscreen .iv-nav-btn {
+  width: 48px;
+  height: 48px;
+}
+
+/* Safari / older WebKit fullscreen vendor variant. */
+.iv-frame:-webkit-full-screen {
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  background: #1a1a1a;
+}
+
+@media (max-width: 575px) {
+  .iv-nav-btn {
+    width: 36px;
+    height: 36px;
+  }
+  .iv-step-badge {
+    font-size: 0.72rem;
+    padding: 3px 8px;
+  }
+  .iv-step-meta h4 {
+    font-size: 1.1rem;
+  }
+}

--- a/web/assets/js/instruction-viewer.js
+++ b/web/assets/js/instruction-viewer.js
@@ -1,0 +1,460 @@
+/**
+ * Instruction Viewer — Phase 2a (issue #178).
+ *
+ * Public, read-only slideshow consumer for the build-instructions feature.
+ * Lives on web/projects/view.html and is initialised once the project
+ * record has loaded. Pulls the public GET /api/projects/{pid}/instruction
+ * endpoint, pre-renders each step's canvas_json to a PNG dataURL via an
+ * off-screen Fabric.js canvas, then renders the slideshow as <img>
+ * swapping for fast navigation.
+ *
+ * Out of scope for Phase 2a: PDF export (2b), image series ZIP (2c),
+ * editing affordances, STL viewer, per-step likes/comments.
+ *
+ * Public surface:
+ *   window.InstructionViewer.init(projectId)
+ *
+ * Behaviour summary:
+ *   * 404 from API or empty step list → section stays hidden, silent bail.
+ *   * Fabric.js v6 is lazy-loaded from CDN only after we confirm there is
+ *     at least one step to render. Projects without instructions don't
+ *     pay the ~280KB cost.
+ *   * If Fabric fails to load, we degrade to a plain text step list so
+ *     the section still surfaces *something* useful.
+ *   * Each step is rendered to a PNG once at init time; the visible
+ *     slideshow then just swaps <img> sources — flat in step count.
+ */
+(function () {
+  'use strict';
+
+  // -------- Constants -----------------------------------------------------
+
+  var API = 'https://projects.kevsrobots.com';
+  // Match the builder's coordinate space exactly so the pre-render frames
+  // the scene the way the author saw it.
+  var CANVAS_W = 1200;
+  var CANVAS_H = 900;
+  var FABRIC_CDN = 'https://cdn.jsdelivr.net/npm/fabric@6.4.0/dist/index.min.js';
+
+  // -------- Module state --------------------------------------------------
+
+  var state = {
+    projectId: null,
+    steps: [],         // array of { step_number, title, description, image (dataURL or null) }
+    activeIdx: 0,
+    initialised: false,
+  };
+
+  // -------- DOM handles ---------------------------------------------------
+
+  var dom = {};
+
+  function bindDom() {
+    dom.section = document.getElementById('instruction-slideshow-section');
+    dom.frame = document.getElementById('iv-frame');
+    dom.stage = document.getElementById('iv-stage');
+    dom.spinner = document.getElementById('iv-spinner');
+    dom.badge = document.getElementById('iv-step-badge');
+    dom.prev = document.getElementById('iv-prev');
+    dom.next = document.getElementById('iv-next');
+    dom.fullscreen = document.getElementById('iv-fullscreen');
+    dom.dots = document.getElementById('iv-dots');
+    dom.title = document.getElementById('iv-step-title');
+    dom.description = document.getElementById('iv-step-description');
+    dom.fallback = document.getElementById('iv-fallback');
+  }
+
+  // -------- Public entry --------------------------------------------------
+
+  function init(projectId) {
+    if (state.initialised) return;
+    state.initialised = true;
+    state.projectId = projectId;
+    bindDom();
+    if (!dom.section) {
+      // view.html didn't include the slideshow markup — nothing to do.
+      return;
+    }
+    loadInstruction().catch(function () {
+      // Any unhandled rejection ends with the section staying hidden,
+      // which is the desired graceful failure mode.
+    });
+  }
+
+  // -------- Fetch + bootstrap --------------------------------------------
+
+  function loadInstruction() {
+    // Public endpoint — no credentials, no auth header.
+    return fetch(API + '/api/projects/' + encodeURIComponent(state.projectId) + '/instruction')
+      .then(function (resp) {
+        if (resp.status === 404) return null;
+        if (!resp.ok) {
+          // Any other non-2xx → behave like 404 (section stays hidden).
+          return null;
+        }
+        return resp.json();
+      })
+      .then(function (instruction) {
+        if (!instruction || !Array.isArray(instruction.steps) || instruction.steps.length === 0) {
+          // No instruction or no steps — section stays hidden.
+          return;
+        }
+        // Normalise + sort defensively by step_number (the API already
+        // orders them, but we don't want a server-side bug to scramble
+        // the slideshow).
+        var sorted = instruction.steps.slice().sort(function (a, b) {
+          return (a.step_number || 0) - (b.step_number || 0);
+        });
+        state.steps = sorted.map(function (s, i) {
+          return {
+            step_number: s.step_number || (i + 1),
+            title: s.title || ('Step ' + (s.step_number || (i + 1))),
+            description: s.description || '',
+            canvas_json: s.canvas_json || null,
+            image: null,
+          };
+        });
+        revealSection();
+        return prerenderAll().then(function () {
+          // If pre-render dropped all images and we don't have Fabric,
+          // prerenderAll's catch path has already shown the fallback.
+          // Otherwise, wire up the slideshow.
+          if (dom.section.classList.contains('iv-fallback-mode')) return;
+          buildDots();
+          wireControls();
+          showStep(0);
+        });
+      });
+  }
+
+  function revealSection() {
+    dom.section.classList.remove('d-none');
+  }
+
+  // -------- Pre-render ----------------------------------------------------
+
+  function loadFabric() {
+    if (window.fabric && window.fabric.StaticCanvas) {
+      return Promise.resolve(window.fabric);
+    }
+    return new Promise(function (resolve, reject) {
+      var existing = document.querySelector('script[data-iv-fabric]');
+      if (existing) {
+        existing.addEventListener('load', function () {
+          window.fabric ? resolve(window.fabric) : reject(new Error('Fabric global missing'));
+        });
+        existing.addEventListener('error', function () { reject(new Error('Fabric load failed')); });
+        return;
+      }
+      var s = document.createElement('script');
+      s.src = FABRIC_CDN;
+      s.async = true;
+      s.setAttribute('data-iv-fabric', '1');
+      s.onload = function () {
+        if (window.fabric && window.fabric.StaticCanvas) {
+          resolve(window.fabric);
+        } else {
+          reject(new Error('Fabric global missing after load'));
+        }
+      };
+      s.onerror = function () { reject(new Error('Fabric load failed')); };
+      document.head.appendChild(s);
+    });
+  }
+
+  // Parse a canvas_json blob defensively. Returns the parsed object or
+  // null if the string is empty / unparseable / has no objects worth
+  // rendering. Treating "empty {}" as null lets text-only steps fall
+  // through to the placeholder branch cleanly.
+  function parseCanvasJson(raw) {
+    if (!raw) return null;
+    var trimmed = String(raw).trim();
+    if (!trimmed) return null;
+    if (trimmed === '{}' || trimmed === '[]' || trimmed === 'null') return null;
+    try {
+      var parsed = JSON.parse(trimmed);
+      if (!parsed) return null;
+      // Fabric scenes typically have an `objects` array; if it's empty
+      // and there's no backgroundImage either, treat as a blank canvas
+      // and use the placeholder instead.
+      var objs = Array.isArray(parsed.objects) ? parsed.objects : [];
+      if (objs.length === 0 && !parsed.backgroundImage && !parsed.background) {
+        return null;
+      }
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // Pre-render each step to a PNG dataURL. We lazy-load Fabric here
+  // because everything before this point can be done without it.
+  function prerenderAll() {
+    // Are there any steps that actually need Fabric? If every step is
+    // text-only we don't need to fetch the library at all.
+    var needsFabric = state.steps.some(function (s) {
+      return parseCanvasJson(s.canvas_json) !== null;
+    });
+
+    if (!needsFabric) {
+      // All steps are placeholder-only — image stays null on each.
+      hideSpinner();
+      return Promise.resolve();
+    }
+
+    return loadFabric()
+      .then(function (fabric) {
+        // Create one off-screen canvas and reuse it across steps to keep
+        // the pre-render cost down. StaticCanvas accepts an HTMLCanvasElement
+        // in v6 (it also accepts a string id, but new HTMLCanvasElement is
+        // safer because we don't need to attach it to the DOM).
+        var offEl = document.createElement('canvas');
+        offEl.width = CANVAS_W;
+        offEl.height = CANVAS_H;
+        var off = new fabric.StaticCanvas(offEl, {
+          width: CANVAS_W,
+          height: CANVAS_H,
+          backgroundColor: '#ffffff',
+          enableRetinaScaling: false,
+        });
+
+        // Render one step at a time, sequentially. We use a serial chain
+        // because Fabric's loadFromJSON mutates the canvas in place and
+        // running concurrent renders against the same canvas would race.
+        var chain = Promise.resolve();
+        state.steps.forEach(function (step, idx) {
+          chain = chain.then(function () { return renderStep(off, step); })
+            .then(function (dataUrl) {
+              state.steps[idx].image = dataUrl;
+            })
+            .catch(function () {
+              // A single step failing to render shouldn't break the rest.
+              state.steps[idx].image = null;
+            });
+        });
+        return chain.then(function () {
+          try { off.dispose(); } catch (_) {}
+          hideSpinner();
+        });
+      })
+      .catch(function () {
+        // Fabric refused to load (offline, CDN blocked, CSP, …). Fall
+        // back to a plain text step list so the section still shows
+        // useful content rather than a broken loader.
+        renderFallback();
+      });
+  }
+
+  function renderStep(off, step) {
+    var parsed = parseCanvasJson(step.canvas_json);
+    if (!parsed) {
+      // Text-only step — leave image=null; the slideshow renders the
+      // placeholder panel in this case.
+      return Promise.resolve(null);
+    }
+    return new Promise(function (resolve) {
+      try {
+        off.loadFromJSON(parsed, function () {
+          try {
+            off.renderAll();
+            var url = off.toDataURL({ format: 'png', multiplier: 1 });
+            resolve(url);
+          } catch (e) {
+            resolve(null);
+          }
+          // Clear the canvas so the next step starts from a clean slate.
+          try { off.clear(); off.backgroundColor = '#ffffff'; } catch (_) {}
+        });
+      } catch (_) {
+        resolve(null);
+      }
+    });
+  }
+
+  function hideSpinner() {
+    if (dom.spinner) dom.spinner.classList.add('d-none');
+  }
+
+  // -------- Fallback (Fabric failed to load) -----------------------------
+
+  function renderFallback() {
+    if (!dom.fallback) return;
+    dom.section.classList.add('iv-fallback-mode');
+    // Hide the slideshow shell entirely — the fallback list replaces it.
+    if (dom.frame) dom.frame.classList.add('d-none');
+    if (dom.dots) dom.dots.classList.add('d-none');
+    var stepMeta = document.getElementById('iv-step-meta');
+    if (stepMeta) stepMeta.classList.add('d-none');
+
+    var html = '<ol>';
+    state.steps.forEach(function (s) {
+      html += '<li><strong>' + escapeHtml(s.title || ('Step ' + s.step_number)) + '</strong>';
+      if (s.description) {
+        html += '<span class="iv-fallback-desc">' + escapeHtml(s.description) + '</span>';
+      }
+      html += '</li>';
+    });
+    html += '</ol>';
+    dom.fallback.innerHTML = html;
+    dom.fallback.classList.remove('d-none');
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement('div');
+    d.textContent = String(s == null ? '' : s);
+    return d.innerHTML;
+  }
+
+  // -------- Slideshow render ---------------------------------------------
+
+  function showStep(idx) {
+    if (idx < 0 || idx >= state.steps.length) return;
+    state.activeIdx = idx;
+    var step = state.steps[idx];
+    var total = state.steps.length;
+
+    // Wipe whatever's in the stage and rebuild it for this step. The
+    // stage is small (one <img> or one placeholder div) so re-creating
+    // is cheaper than tracking which mode was previously rendered.
+    while (dom.stage.firstChild) dom.stage.removeChild(dom.stage.firstChild);
+
+    if (step.image) {
+      var img = document.createElement('img');
+      img.src = step.image;
+      img.alt = step.title || ('Step ' + step.step_number);
+      img.loading = 'lazy';
+      dom.stage.appendChild(img);
+    } else {
+      // Placeholder panel — step has no canvas content (text-only).
+      var ph = document.createElement('div');
+      ph.className = 'iv-placeholder';
+      var title = document.createElement('div');
+      title.className = 'iv-placeholder-title';
+      title.textContent = step.title || ('Step ' + step.step_number);
+      ph.appendChild(title);
+      dom.stage.appendChild(ph);
+    }
+
+    // Badge + meta + dots.
+    if (dom.badge) {
+      dom.badge.textContent = 'Step ' + (idx + 1) + ' of ' + total;
+    }
+    if (dom.title) {
+      dom.title.textContent = step.title || ('Step ' + step.step_number);
+    }
+    if (dom.description) {
+      var desc = (step.description || '').trim();
+      if (desc) {
+        dom.description.textContent = desc;
+        dom.description.classList.remove('d-none');
+      } else {
+        dom.description.textContent = '';
+        dom.description.classList.add('d-none');
+      }
+    }
+    if (dom.prev) dom.prev.disabled = (idx === 0);
+    if (dom.next) dom.next.disabled = (idx === total - 1);
+    updateDotsActive();
+  }
+
+  function buildDots() {
+    if (!dom.dots) return;
+    dom.dots.innerHTML = '';
+    state.steps.forEach(function (_, i) {
+      var b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'iv-dot';
+      b.setAttribute('aria-label', 'Go to step ' + (i + 1));
+      b.dataset.idx = String(i);
+      b.addEventListener('click', function () { showStep(i); });
+      dom.dots.appendChild(b);
+    });
+  }
+
+  function updateDotsActive() {
+    if (!dom.dots) return;
+    Array.prototype.forEach.call(dom.dots.children, function (el, i) {
+      if (i === state.activeIdx) el.classList.add('is-active');
+      else el.classList.remove('is-active');
+    });
+  }
+
+  // -------- Controls (buttons, keyboard, swipe, fullscreen) --------------
+
+  function wireControls() {
+    if (dom.prev) {
+      dom.prev.addEventListener('click', function () { showStep(state.activeIdx - 1); });
+    }
+    if (dom.next) {
+      dom.next.addEventListener('click', function () { showStep(state.activeIdx + 1); });
+    }
+    if (dom.fullscreen) {
+      dom.fullscreen.addEventListener('click', toggleFullscreen);
+    }
+
+    // Keyboard arrows — only when the section is in view. We attach to
+    // window so the user doesn't have to focus the slideshow first; the
+    // visibility check prevents stealing arrow keys when the user is
+    // scrolled elsewhere on the page (e.g. reading the description).
+    window.addEventListener('keydown', function (e) {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      // Don't hijack arrows while a form field has focus.
+      var ae = document.activeElement;
+      if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;
+      if (!isSectionInView()) return;
+      if (e.key === 'ArrowLeft') showStep(state.activeIdx - 1);
+      else showStep(state.activeIdx + 1);
+    });
+
+    // Touch swipe — track delta on touchend. We require a horizontal
+    // displacement of at least 40px and that |dx| > |dy| so vertical
+    // page-scroll gestures don't get hijacked.
+    var touchStart = null;
+    if (dom.frame) {
+      dom.frame.addEventListener('touchstart', function (e) {
+        if (e.touches.length !== 1) { touchStart = null; return; }
+        var t = e.touches[0];
+        touchStart = { x: t.clientX, y: t.clientY, time: Date.now() };
+      }, { passive: true });
+      dom.frame.addEventListener('touchend', function (e) {
+        if (!touchStart) return;
+        var t = e.changedTouches[0];
+        var dx = t.clientX - touchStart.x;
+        var dy = t.clientY - touchStart.y;
+        touchStart = null;
+        if (Math.abs(dx) < 40) return;
+        if (Math.abs(dy) > Math.abs(dx)) return;
+        if (dx < 0) showStep(state.activeIdx + 1);
+        else showStep(state.activeIdx - 1);
+      }, { passive: true });
+      dom.frame.addEventListener('touchcancel', function () { touchStart = null; });
+    }
+  }
+
+  function isSectionInView() {
+    if (!dom.section) return false;
+    var rect = dom.section.getBoundingClientRect();
+    var viewH = window.innerHeight || document.documentElement.clientHeight;
+    return rect.bottom > 0 && rect.top < viewH;
+  }
+
+  function toggleFullscreen() {
+    if (!dom.frame) return;
+    var inFs = document.fullscreenElement || document.webkitFullscreenElement;
+    if (inFs) {
+      var exit = document.exitFullscreen || document.webkitExitFullscreen;
+      if (exit) {
+        try { exit.call(document); } catch (_) {}
+      }
+    } else {
+      var req = dom.frame.requestFullscreen || dom.frame.webkitRequestFullscreen;
+      if (req) {
+        try { req.call(dom.frame); } catch (_) {}
+      }
+    }
+  }
+
+  // -------- Export --------------------------------------------------------
+
+  window.InstructionViewer = { init: init };
+})();

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -9,6 +9,7 @@ description: View project details
 <link rel="stylesheet" href="/assets/css/project-editor.css?v={{ site.time | date: '%s' }}">
 <link rel="stylesheet" href="/assets/css/image-viewer.css?v={{ site.time | date: '%s' }}">
 <link rel="stylesheet" href="/assets/css/featured-projects.css?v={{ site.time | date: '%s' }}">
+<link rel="stylesheet" href="/assets/css/instruction-viewer.css?v={{ site.time | date: '%s' }}">
 <script src="/assets/js/featured-projects.js?v={{ site.time | date: '%s' }}"></script>
 
 <div class="container py-4">
@@ -114,6 +115,44 @@ description: View project details
             <i class="fas fa-download me-1"></i> Total downloads: <span id="view-files-total-count">0</span>
           </div>
           <div id="view-files" class="list-group"></div>
+        </div>
+
+        <!-- Build Instructions (issue #178, Phase 2a) — read-only slideshow.
+             Hidden by default; instruction-viewer.js fetches the public
+             /api/projects/{id}/instruction endpoint and reveals the shell
+             only once an instruction with at least one step is confirmed.
+             The slideshow itself is just <img> swapping (each step's
+             canvas_json is pre-rendered to a PNG at init time). -->
+        <div id="instruction-slideshow-section" class="mb-4 d-none">
+          <h4><i class="fas fa-list-ol me-3 text-primary"></i> Build Instructions</h4>
+          <div id="iv-frame" class="iv-frame">
+            <div id="iv-step-badge" class="iv-step-badge">Step 1 of 1</div>
+            <button type="button" id="iv-fullscreen" class="iv-fullscreen-btn"
+                    aria-label="View fullscreen" title="View fullscreen">
+              <i class="fas fa-expand"></i>
+            </button>
+            <button type="button" id="iv-prev" class="iv-nav-btn iv-nav-prev"
+                    aria-label="Previous step" title="Previous step">
+              <i class="fas fa-chevron-left"></i>
+            </button>
+            <button type="button" id="iv-next" class="iv-nav-btn iv-nav-next"
+                    aria-label="Next step" title="Next step">
+              <i class="fas fa-chevron-right"></i>
+            </button>
+            <div id="iv-stage" class="iv-stage"></div>
+            <div id="iv-spinner" class="iv-spinner">
+              <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading instructions&hellip;</span>
+              </div>
+              <div class="small">Preparing slideshow&hellip;</div>
+            </div>
+          </div>
+          <div id="iv-dots" class="iv-dots" role="tablist" aria-label="Instruction steps"></div>
+          <div id="iv-step-meta" class="iv-step-meta">
+            <h4 id="iv-step-title"></h4>
+            <p id="iv-step-description" class="iv-step-description d-none"></p>
+          </div>
+          <div id="iv-fallback" class="iv-fallback-list d-none"></div>
         </div>
 
         <!-- BOM -->
@@ -533,6 +572,7 @@ description: View project details
 <script src="/assets/js/image-viewer.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/project-interactions.js?v={{ site.time | date: '%s' }}"></script>
 <script src="/assets/js/badge-toast.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/instruction-viewer.js?v={{ site.time | date: '%s' }}"></script>
 <script>
 (function() {
   const API = 'https://projects.kevsrobots.com';
@@ -796,6 +836,12 @@ description: View project details
       loadVideos();
       loadJournal();
       loadMakes(project);
+
+      // Issue #178 Phase 2a — public read-only slideshow viewer for
+      // build instructions. Self-hides if no instruction / no steps.
+      if (window.InstructionViewer && typeof window.InstructionViewer.init === 'function') {
+        try { window.InstructionViewer.init(project.id); } catch (_) {}
+      }
 
       // Load interactions (likes + comments) via Chatter
       var projectUrl = 'projects/view.html?id=' + projectId;


### PR DESCRIPTION
## Summary

- Third slice of the Instruction Builder epic (#178). Adds a read-only slideshow to `web/projects/view.html` so visitors can finally see what owners build with the Phase 1 canvas.
- Pre-renders each step's `canvas_json` to a PNG dataURL via an off-screen Fabric.js canvas at init time; the visible slideshow is just `<img>` swapping for fast navigation that scales flat in step count.
- Lazy-loads Fabric.js v6 from CDN only after the API confirms an instruction with steps, so projects without instructions don't pay the ~280KB cost; falls back to a plain text step list if Fabric is unreachable.
- Controls: prev/next buttons, dot indicators, keyboard arrows, mobile swipe, Fullscreen API. Steps with no canvas (text-only outline from Phase 0) render a soft grey placeholder panel.
- No backend changes — the public `GET /api/projects/{pid}/instruction` from Phase 0 already serves everything we need.

## Test plan

- [ ] Project with no instruction → slideshow section stays hidden, no console errors.
- [ ] Project with instruction but zero steps → section stays hidden.
- [ ] Multi-step project → slideshow reveals, step 1 of N renders, badge reads "Step 1 of N".
- [ ] Prev/next buttons advance, disable at boundaries; dot indicators stay in sync.
- [ ] Clicking a dot jumps directly to that step.
- [ ] Keyboard ← / → advances when section is in view; ignored when an input/textarea has focus.
- [ ] Swipe left/right on mobile advances; vertical scroll gestures are not hijacked.
- [ ] Fullscreen button enters/exits fullscreen, layout restores on exit.
- [ ] Step with `canvas_json = null` or `{}` renders the grey placeholder panel with the step title centred; description still shows below if present.
- [ ] Step description hidden when null/empty (no empty `<p>`).
- [ ] Block Fabric.js CDN (devtools network rule) → fallback text list appears, no broken UI.
- [ ] No regressions on other view.html sections (videos carousel, BOM, files, comments, makes still load).

## Implementation notes

- **Placement** ended up after Files and before BOM rather than literally "between videos and BOM" — the videos section actually lives above the description on view.html, so the section sequence becomes videos → description → content → files → **instructions** → BOM → links, which reads naturally.
- **Single `StaticCanvas` reused** across steps during pre-render, then disposed — bounded memory cost regardless of step count.
- **Defensive parse** treats `null`, `""`, `"{}"`, `"[]"`, `"null"`, unparseable, and "zero objects + no background" all as "no canvas" → placeholder.
- **All-text-only optimisation:** if every step has empty `canvas_json`, Fabric is never loaded — slideshow renders entirely from placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)