### PR TITLE
feat(instructions): GIF + MP4 export + branded final slide

### DIFF
--- a/stacks/projects-api/Dockerfile
+++ b/stacks/projects-api/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl ffmpeg fonts-dejavu-core && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/stacks/projects-api/projects_api/instructions_branding.py
+++ b/stacks/projects-api/projects_api/instructions_branding.py
@@ -1,0 +1,155 @@
+"""Branded "Made with kevsrobots.com/projects" slide renderer.
+
+Issue #178, Phase 3b/3c: every instruction export (PDF / GIF / MP4)
+ends with the same branded slide so projects shared from kevsrobots.com
+carry attribution back to the platform. The slide is generated
+server-side as a PNG via Pillow rather than hand-authored as an asset
+so it can include the per-project title (and so a future polish PR
+can layer locale / theme / accent tweaks without touching frontend
+build).
+
+Pure text on a dark background — deliberately no logo file dependency.
+Robust against missing fonts (falls back to ``ImageFont.load_default()``
+if DejaVuSans-Bold isn't installed) so it works in CI / dev machines
+even when the Dockerfile's ``fonts-dejavu-core`` apt package isn't
+present.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image, ImageDraw, ImageFont
+
+# Brand palette — deliberately kept inline so this module has no
+# config dependency. Dark background reads well against the kevsrobots
+# orange/red accent without needing the accent itself; the headline and
+# subtext stay white / light grey for high contrast.
+_BG_COLOR = (13, 27, 42)          # #0d1b2a — dark navy
+_HEADLINE_COLOR = (255, 255, 255) # white
+_SUBTEXT_COLOR = (192, 200, 209)  # light grey
+_FOOTNOTE_COLOR = (148, 163, 184) # softer grey
+_TOPNOTE_COLOR = (148, 163, 184)
+
+# Font sizes are derived from the canvas width so the slide reads well
+# at any resolution the caller picks.
+_HEADLINE_SCALE = 0.055   # ~5.5% of width — fits "Made with kevsrobots.com/projects" on one line
+_SUBTEXT_SCALE = 0.030    # ~3.0% of width
+_FOOTNOTE_SCALE = 0.024   # smaller wordmark / footer
+_TOPNOTE_SCALE = 0.024    # italic top line for project title
+
+_FONT_BOLD_NAMES = ("DejaVuSans-Bold.ttf", "DejaVuSansBold.ttf", "DejaVuSans-Bold")
+_FONT_REGULAR_NAMES = ("DejaVuSans.ttf", "DejaVuSans")
+_FONT_ITALIC_NAMES = ("DejaVuSans-Oblique.ttf", "DejaVuSans-Italic.ttf")
+
+
+def _try_truetype(names: tuple[str, ...], size: int) -> ImageFont.ImageFont:
+    """Best-effort truetype load with a graceful fallback.
+
+    Pillow's ``ImageFont.truetype`` raises ``OSError`` when the font
+    isn't found via its lookup paths; we cycle through each candidate
+    and fall back to ``load_default()`` so the slide still renders on
+    machines without the DejaVu package (e.g. CI runners, fresh dev
+    boxes). The default font is bitmap and small — but it's only a
+    fallback, the Dockerfile installs DejaVu for production.
+    """
+    for name in names:
+        try:
+            return ImageFont.truetype(name, size)
+        except (OSError, IOError):  # noqa: PERF203 — at most 3 attempts
+            continue
+    return ImageFont.load_default()
+
+
+def _measure(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) -> tuple[int, int]:
+    """Return (width, height) of the rendered text in pixels.
+
+    Uses ``textbbox`` (modern Pillow) when available, falling back to
+    ``textsize`` for older versions. The bbox is (x0, y0, x1, y1) at
+    the supplied anchor; the size is just the diff.
+    """
+    if hasattr(draw, "textbbox"):
+        bbox = draw.textbbox((0, 0), text, font=font)
+        return bbox[2] - bbox[0], bbox[3] - bbox[1]
+    # Very old Pillow — keep the fallback for completeness.
+    return draw.textsize(text, font=font)  # type: ignore[attr-defined]
+
+
+def render_made_with_slide(
+    width: int = 1200,
+    height: int = 900,
+    project_title: str | None = None,
+) -> bytes:
+    """Return PNG bytes for the 'Made with kevsrobots.com/projects' slide.
+
+    The dimensions default to the canvas size the Instruction Builder
+    uses (1200x900), so the slide composes well alongside step PNGs
+    without aspect-ratio surprises in the GIF / MP4 pipeline.
+
+    ``project_title`` shows up as a small italic line at the top
+    ("Instructions for <title>") when supplied. The headline + subtitle
+    + wordmark are unconditional.
+    """
+    img = Image.new("RGB", (width, height), _BG_COLOR)
+    draw = ImageDraw.Draw(img)
+
+    headline_font = _try_truetype(_FONT_BOLD_NAMES, max(16, int(width * _HEADLINE_SCALE)))
+    subtext_font = _try_truetype(_FONT_REGULAR_NAMES, max(12, int(width * _SUBTEXT_SCALE)))
+    footnote_font = _try_truetype(_FONT_REGULAR_NAMES, max(10, int(width * _FOOTNOTE_SCALE)))
+    topnote_font = _try_truetype(_FONT_ITALIC_NAMES, max(10, int(width * _TOPNOTE_SCALE)))
+
+    # Top: optional "Instructions for <title>" line.
+    if project_title:
+        # Trim aggressively — anything longer than ~60 chars at the
+        # default width starts to wrap weirdly.
+        title_clean = project_title.strip()
+        if len(title_clean) > 60:
+            title_clean = title_clean[:57].rstrip() + "…"
+        top_line = f"Instructions for {title_clean}"
+        tw, th = _measure(draw, top_line, topnote_font)
+        # Top padding ~7% of height.
+        ty = int(height * 0.07)
+        draw.text(
+            ((width - tw) // 2, ty),
+            top_line,
+            font=topnote_font,
+            fill=_TOPNOTE_COLOR,
+        )
+
+    # Centre: headline + subtitle, vertically centred.
+    headline = "Made with kevsrobots.com/projects"
+    subtext = "Build your own at kevsrobots.com/projects"
+
+    hw, hh = _measure(draw, headline, headline_font)
+    sw, sh = _measure(draw, subtext, subtext_font)
+    gap = int(height * 0.035)
+    block_h = hh + gap + sh
+    block_top = (height - block_h) // 2
+
+    draw.text(
+        ((width - hw) // 2, block_top),
+        headline,
+        font=headline_font,
+        fill=_HEADLINE_COLOR,
+    )
+    draw.text(
+        ((width - sw) // 2, block_top + hh + gap),
+        subtext,
+        font=subtext_font,
+        fill=_SUBTEXT_COLOR,
+    )
+
+    # Footer wordmark — small, centred near the bottom.
+    wordmark = "kevsrobots"
+    ww, wh = _measure(draw, wordmark, footnote_font)
+    wy = height - int(height * 0.08) - wh
+    draw.text(
+        ((width - ww) // 2, wy),
+        wordmark,
+        font=footnote_font,
+        fill=_FOOTNOTE_COLOR,
+    )
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()

--- a/stacks/projects-api/projects_api/instructions_pdf.py
+++ b/stacks/projects-api/projects_api/instructions_pdf.py
@@ -33,6 +33,7 @@ from reportlab.platypus import (
     Spacer,
 )
 
+from .instructions_branding import render_made_with_slide
 from .schemas import InstructionExportRequest, InstructionExportStep
 
 # A4 minus 15mm margins on every side. Recomputed once here so the
@@ -291,6 +292,14 @@ def _make_doc(buffer: io.BytesIO, steps_per_page: int) -> BaseDocTemplate:
     )
     cover_template = PageTemplate(id="Cover", frames=[cover_frame])
 
+    # The Made-with / "branding" template reuses the cover frame layout
+    # (single full-page frame, no page number) so the final slide reads
+    # like a closing-credits card rather than a numbered content page.
+    branding_frame = Frame(
+        _MARGIN, _MARGIN, _CONTENT_W, _CONTENT_H, id="branding", showBoundary=0
+    )
+    branding_template = PageTemplate(id="Branding", frames=[branding_frame])
+
     if steps_per_page == 4:
         cell_w = (_CONTENT_W - 6 * mm) / 2
         cell_h = (_CONTENT_H - 6 * mm) / 2
@@ -314,7 +323,7 @@ def _make_doc(buffer: io.BytesIO, steps_per_page: int) -> BaseDocTemplate:
     content_template = PageTemplate(
         id="Content", frames=content_frames, onPage=_draw_page_number
     )
-    doc.addPageTemplates([cover_template, content_template])
+    doc.addPageTemplates([cover_template, content_template, branding_template])
     return doc
 
 
@@ -372,6 +381,26 @@ def render_instructions_pdf(
         flowables.extend(_two_per_page(request.steps, styles))
     else:  # 4
         flowables.extend(_four_per_page(request.steps, styles))
+
+    # Phase 3b/3c: append the "Made with kevsrobots.com/projects" slide
+    # as a final page. The slide is a PNG generated server-side via
+    # Pillow (see ``instructions_branding``) and embedded as a single
+    # proportional Image flowable that fills the printable area.
+    #
+    # We switch the template to the dedicated "Branding" page so the
+    # page-number callback doesn't fire — the closing card stays clean
+    # like the cover.
+    flowables.append(_NextPageTemplate("Branding"))
+    flowables.append(PageBreak())
+    slide_png = render_made_with_slide(project_title=request.project_title)
+    slide_buf = io.BytesIO(slide_png)
+    slide_img = Image(
+        slide_buf,
+        width=_CONTENT_W,
+        height=_CONTENT_H,
+        kind="proportional",
+    )
+    flowables.append(slide_img)
 
     doc.build(flowables)
     return buffer.getvalue()

--- a/stacks/projects-api/projects_api/instructions_video.py
+++ b/stacks/projects-api/projects_api/instructions_video.py
@@ -1,0 +1,263 @@
+"""Animated GIF / H.264 MP4 rendering for instruction exports.
+
+Issue #178, Phase 3b/3c: takes the same array of PNG dataURLs the PDF
+export already accepts and assembles them into a video format via
+FFmpeg. The branded "Made with kevsrobots.com/projects" slide is
+appended as the closing frame, held for ~3s so it lingers on the
+viewer's screen at the end.
+
+**Why subprocess + FFmpeg rather than pyav / imageio?**
+
+FFmpeg is one apt-install (already shipped in the projects-api
+Dockerfile alongside ``fonts-dejavu-core``), the binary is rock-solid,
+and the CLI is well-documented for both palettegen GIFs and yuv420p
+H.264. The Python wrappers add a dependency and a bug surface for
+something that's already trivially scripted as ``subprocess.run`` with
+list-form arguments. List-form is mandatory — no ``shell=True`` — so
+even though we don't accept arbitrary paths from clients, there is
+zero shell-injection or path-traversal surface.
+
+Heavy lifting (subprocess.run + decode loop) is synchronous; the
+FastAPI route wraps the call in ``asyncio.to_thread`` so the event
+loop stays responsive while FFmpeg runs.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+
+from .instructions_branding import render_made_with_slide
+from .schemas import InstructionExportRequest
+
+logger = logging.getLogger(__name__)
+
+# Cap each FFmpeg subprocess at 120s wall-clock. A 50-step build with
+# the default 2s/frame settles at ~100s of video; encode time is a
+# small multiple of that on a Pi 5. The cap is well above the realistic
+# worst case and well below the load-balancer's 60s proxy timeout × 2.
+_FFMPEG_TIMEOUT_S = 120
+
+_PNG_DATAURL_PREFIX = "data:image/png;base64,"
+
+# Target canvas the video frames render at. The browser's Fabric.js
+# canvas is 1200x900 and ``renderAllStepsToDataUrls`` uses multiplier:2,
+# so step PNGs arrive at 2400x1800. We resize them down (or up) to a
+# consistent 1200x900 for the encoder — varying frame sizes crash
+# libavfilter's palettegen/paletteuse pair and libx264 alike. The slide
+# is rendered at the same dimensions to match.
+_VIDEO_W = 1200
+_VIDEO_H = 900
+
+
+def _decode_data_url(data_url: str) -> bytes:
+    """Strip the dataURL prefix and base64-decode the payload."""
+    if not data_url.startswith(_PNG_DATAURL_PREFIX):
+        raise ValueError("image_data_url must start with 'data:image/png;base64,'")
+    raw = data_url[len(_PNG_DATAURL_PREFIX):]
+    return base64.b64decode(raw)
+
+
+def _normalise_frame(png_bytes: bytes) -> bytes:
+    """Resize / letterbox the supplied PNG to ``(_VIDEO_W, _VIDEO_H)``.
+
+    Aspect-preserving fit on a white canvas — same colour the browser's
+    Fabric canvas uses as its background — so a step screenshot from
+    an unusual aspect ratio doesn't get stretched. The output is always
+    exact-sized RGB so libx264's yuv420p / paletteuse don't trip on a
+    mid-stream parameter change.
+    """
+    try:
+        src = Image.open(io.BytesIO(png_bytes))
+        src.load()
+    except Exception as exc:  # noqa: BLE001 — Pillow's exceptions are varied
+        raise ValueError("frame is not a valid PNG") from exc
+
+    # Convert to RGB on a white canvas so any RGBA inputs flatten
+    # cleanly. ``thumbnail`` would mutate in-place and not pad to the
+    # target dimensions; we want exact dimensions every time.
+    canvas = Image.new("RGB", (_VIDEO_W, _VIDEO_H), (255, 255, 255))
+    src_w, src_h = src.size
+    if src_w == 0 or src_h == 0:
+        raise ValueError("frame has zero width or height")
+
+    scale = min(_VIDEO_W / src_w, _VIDEO_H / src_h)
+    new_w = max(1, int(src_w * scale))
+    new_h = max(1, int(src_h * scale))
+    resized = src.convert("RGBA").resize((new_w, new_h), Image.Resampling.LANCZOS)
+
+    x = (_VIDEO_W - new_w) // 2
+    y = (_VIDEO_H - new_h) // 2
+    # Paste with the alpha channel as the mask so any transparency
+    # blends onto white rather than appearing as black.
+    canvas.paste(resized, (x, y), resized)
+    buf = io.BytesIO()
+    canvas.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _write_frames(
+    request: InstructionExportRequest,
+    workdir: Path,
+    final_slide_holds: int,
+) -> int:
+    """Write step PNGs + the duplicated Made-with slide to ``workdir``.
+
+    Each frame is normalised to ``_VIDEO_W x _VIDEO_H`` so FFmpeg can
+    treat the directory as a uniform image sequence — varying frame
+    sizes crash both palettegen/paletteuse (GIF) and libx264 (MP4).
+
+    Returns the total number of frames written. The frames are named
+    ``frame-001.png``, ``frame-002.png``, … so FFmpeg's ``-i frame-%03d.png``
+    image-sequence demuxer picks them up in order.
+    """
+    n = 0
+    for step in request.steps:
+        n += 1
+        png_bytes = _normalise_frame(_decode_data_url(step.image_data_url))
+        (workdir / f"frame-{n:03d}.png").write_bytes(png_bytes)
+
+    # Made-with slide — generate once at the same canvas size as the
+    # normalised step frames, duplicate for the hold.
+    slide_bytes = render_made_with_slide(
+        width=_VIDEO_W, height=_VIDEO_H, project_title=request.project_title
+    )
+    for _ in range(max(1, final_slide_holds)):
+        n += 1
+        (workdir / f"frame-{n:03d}.png").write_bytes(slide_bytes)
+    return n
+
+
+def _run_ffmpeg(args: list[str], stage: str) -> None:
+    """Invoke FFmpeg with list-form arguments + timeout + error logging.
+
+    The caller surfaces failures as HTTP 500s without leaking the
+    FFmpeg stderr to the client — we log it here for ops debugging.
+    """
+    try:
+        subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            timeout=_FFMPEG_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.error("ffmpeg %s timed out after %ss: %s", stage, _FFMPEG_TIMEOUT_S, exc)
+        raise RuntimeError(f"ffmpeg {stage} timed out") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
+        logger.error("ffmpeg %s failed (rc=%s): %s", stage, exc.returncode, stderr)
+        raise RuntimeError(f"ffmpeg {stage} failed") from exc
+    except FileNotFoundError as exc:
+        # FFmpeg not on PATH — production has it via the Dockerfile;
+        # local dev / CI without it gets a clear error rather than a
+        # cryptic missing-binary trace.
+        logger.error("ffmpeg binary not found on PATH")
+        raise RuntimeError("ffmpeg is not installed") from exc
+
+
+def render_instructions_video(
+    request: InstructionExportRequest,
+    project_id: int,  # noqa: ARG001 — accepted for parity / future filename use
+    output_format: str,
+    frame_seconds: float | None = None,
+    final_slide_seconds: float | None = None,
+) -> bytes:
+    """Return GIF or MP4 binary for the supplied instruction steps.
+
+    ``output_format`` must be ``'gif'`` or ``'mp4'``. The branded
+    final-slide is appended unconditionally — Phase 3 doesn't expose
+    an "include_branding" toggle.
+
+    The ``frame_seconds`` / ``final_slide_seconds`` arguments override
+    the values on ``request`` if supplied; otherwise the request values
+    (themselves defaulting to 2.0 / 3.0) drive timing.
+    """
+    if output_format not in ("gif", "mp4"):
+        raise ValueError(f"output_format must be 'gif' or 'mp4', got {output_format!r}")
+    if not request.steps:
+        raise ValueError("steps must be non-empty")
+
+    fs = frame_seconds if frame_seconds is not None else request.frame_seconds
+    ss = final_slide_seconds if final_slide_seconds is not None else request.final_slide_seconds
+    if fs <= 0:
+        raise ValueError("frame_seconds must be positive")
+    if ss <= 0:
+        raise ValueError("final_slide_seconds must be positive")
+
+    # Number of times to duplicate the closing slide so the hold is
+    # ``ss`` seconds at the step framerate of ``1/fs`` fps. Always at
+    # least 1 — even with a tiny ss/fs ratio the slide should appear
+    # on screen for at least one frame slot.
+    holds = max(1, round(ss / fs))
+
+    with tempfile.TemporaryDirectory(prefix="ib-export-") as tmp:
+        workdir = Path(tmp)
+        total_frames = _write_frames(request, workdir, holds)
+        assert total_frames >= 2  # at least one step + the slide
+
+        framerate = f"1/{fs}" if fs >= 1 else f"{1.0 / fs:.6f}"
+
+        if output_format == "gif":
+            palette = workdir / "palette.png"
+            # Two-pass: palettegen then paletteuse. The default GIF
+            # global palette is 256 colours; this pair gives noticeably
+            # better quality than a single-pass encode on the kinds of
+            # screenshots Fabric.js produces (flat-colour backgrounds +
+            # antialiased text). ``-update 1`` + ``-frames:v 1`` tell
+            # FFmpeg 6+/8 that ``palette.png`` is a single image rather
+            # than a misnamed image sequence — otherwise the encoder
+            # warns "filename doesn't contain a pattern" on FFmpeg 8.
+            _run_ffmpeg(
+                [
+                    "ffmpeg", "-y",
+                    "-framerate", framerate,
+                    "-i", str(workdir / "frame-%03d.png"),
+                    "-vf", "palettegen",
+                    "-update", "1",
+                    "-frames:v", "1",
+                    str(palette),
+                ],
+                stage="palettegen",
+            )
+            out_path = workdir / "out.gif"
+            _run_ffmpeg(
+                [
+                    "ffmpeg", "-y",
+                    "-framerate", framerate,
+                    "-i", str(workdir / "frame-%03d.png"),
+                    "-i", str(palette),
+                    "-lavfi", "paletteuse",
+                    "-loop", "0",
+                    str(out_path),
+                ],
+                stage="gif-encode",
+            )
+            return out_path.read_bytes()
+
+        # MP4 — single-pass H.264. ``yuv420p`` is required for broad
+        # player compatibility (QuickTime, mobile browsers); ``faststart``
+        # moves the moov atom to the front so the file plays without a
+        # full download. ``-vf scale`` pads odd-pixel inputs to an
+        # even-pixel grid, which libx264 requires under yuv420p.
+        out_path = workdir / "out.mp4"
+        _run_ffmpeg(
+            [
+                "ffmpeg", "-y",
+                "-framerate", framerate,
+                "-i", str(workdir / "frame-%03d.png"),
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+                "-movflags", "+faststart",
+                str(out_path),
+            ],
+            stage="mp4-encode",
+        )
+        return out_path.read_bytes()

--- a/stacks/projects-api/projects_api/routers/instructions.py
+++ b/stacks/projects-api/projects_api/routers/instructions.py
@@ -28,6 +28,8 @@ remain valid.
 
 from __future__ import annotations
 
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,6 +38,7 @@ from sqlalchemy.orm import selectinload
 from ..auth import require_terms_accepted
 from ..db import get_session
 from ..instructions_pdf import render_instructions_pdf
+from ..instructions_video import render_instructions_video
 from ..models import Instruction, InstructionStep, Project
 from ..schemas import (
     InstructionCreate,
@@ -424,6 +427,114 @@ async def export_pdf(
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
+
+
+# --- GIF / MP4 export (issue #178, Phase 3b/3c) ---------------------------
+#
+# Same shape as the PDF endpoint — same payload, same auth/T&Cs/owner
+# gate, same per-step PNG dataURL validation. The output binary is
+# assembled by FFmpeg via subprocess (see ``instructions_video.py``); the
+# blocking subprocess call is offloaded to a thread so the FastAPI event
+# loop stays responsive for other requests while a 10-60s render runs.
+
+
+def _validate_video_payload(body: InstructionExportRequest) -> None:
+    """Mirror the PDF endpoint's payload checks for the video routes."""
+    if not body.steps:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="steps must be non-empty",
+        )
+    for step in body.steps:
+        if not step.image_data_url.startswith("data:image/png;base64,"):
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="each image_data_url must start with 'data:image/png;base64,'",
+            )
+    payload_size = sum(len(s.image_data_url) for s in body.steps)
+    if payload_size > _MAX_EXPORT_PAYLOAD_BYTES:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="export payload too large",
+        )
+
+
+async def _render_video_threaded(
+    body: InstructionExportRequest,
+    project_id: int,
+    output_format: str,
+) -> bytes:
+    """``render_instructions_video`` lifted onto a worker thread.
+
+    FFmpeg subprocess.run blocks for the entire encode duration —
+    keeping it out of the event loop matters when multiple users
+    export at once.
+    """
+    try:
+        return await asyncio.to_thread(
+            render_instructions_video,
+            body,
+            project_id,
+            output_format,
+        )
+    except ValueError as exc:
+        # ValueError comes from the renderer's own input validation
+        # (bad dataURL prefix, empty steps, …). Surface as 422 so the
+        # frontend behaves consistently across the three export
+        # formats.
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+    except RuntimeError as exc:
+        # FFmpeg failure / timeout / missing binary. Don't leak the
+        # underlying message to the client — the renderer already
+        # logged the stderr.
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Video generation failed.",
+        ) from exc
+
+
+@router.post("/export/gif")
+async def export_gif(
+    project_id: int,
+    body: InstructionExportRequest,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Render the supplied step PNGs to an animated GIF + closing slide."""
+    await _check_owner(session, project_id, user)
+    _validate_video_payload(body)
+    gif_bytes = await _render_video_threaded(body, project_id, "gif")
+    filename = f"instructions-{project_id}.gif"
+    return Response(
+        content=gif_bytes,
+        media_type="image/gif",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
+
+
+@router.post("/export/mp4")
+async def export_mp4(
+    project_id: int,
+    body: InstructionExportRequest,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Render the supplied step PNGs to an H.264 MP4 + closing slide."""
+    await _check_owner(session, project_id, user)
+    _validate_video_payload(body)
+    mp4_bytes = await _render_video_threaded(body, project_id, "mp4")
+    filename = f"instructions-{project_id}.mp4"
+    return Response(
+        content=mp4_bytes,
+        media_type="video/mp4",
         headers={
             "Content-Disposition": f'attachment; filename="{filename}"',
         },

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -384,18 +384,29 @@ class InstructionExportStep(BaseModel):
 
 
 class InstructionExportRequest(BaseModel):
-    """Body of POST /api/projects/{id}/instruction/export/pdf.
+    """Body of POST /api/projects/{id}/instruction/export/{pdf,gif,mp4}.
 
     ``steps_per_page`` must be 1, 2, or 4 — anything else is 422'd in
     the route. ``project_title`` is supplied by the client because the
     export endpoint doesn't otherwise load the project body, and the
     title page wants something better than "Instructions" by default.
+
+    ``frame_seconds`` / ``final_slide_seconds`` are only meaningful for
+    GIF / MP4 — the PDF route ignores them. Defaults match the spec
+    (2s per step, 3s closing slide hold) so the frontend doesn't need
+    to send these to get sensible behaviour.
     """
 
     steps: list[InstructionExportStep]
     steps_per_page: int = 1
     include_title_page: bool = True
     project_title: Optional[str] = None
+    # Phase 3b/3c — video timing knobs. Bounds are intentionally generous;
+    # the frontend doesn't expose either today but a future "Speed: slow /
+    # normal / fast" toggle could ride on the same field without a new
+    # schema bump.
+    frame_seconds: float = Field(2.0, ge=0.5, le=10.0)
+    final_slide_seconds: float = Field(3.0, ge=1.0, le=10.0)
 
 
 class JournalEntryCreate(BaseModel):

--- a/stacks/projects-api/tests/test_instructions_video.py
+++ b/stacks/projects-api/tests/test_instructions_video.py
@@ -1,0 +1,351 @@
+"""Instruction GIF / MP4 export tests (issue #178, Phase 3b/3c).
+
+Covers the FFmpeg-backed video pipeline at the route level. Mirrors
+the fixture pattern from ``tests/test_instructions_export.py``:
+per-test project, exercise the export endpoints against it.
+
+Skips the happy-path tests when FFmpeg isn't on ``$PATH`` — the
+production Docker image installs it via the Dockerfile, but local
+dev / CI without it would otherwise hard-fail. Validation tests
+(empty steps, bad PNG prefix, bad frame_seconds, auth) run regardless
+because they fail before FFmpeg is invoked.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from .conftest import make_auth_header
+
+# A 1x1 transparent PNG — smallest valid PNG payload. The video
+# pipeline doesn't care about visual content, only that the bytes
+# round-trip through Pillow / FFmpeg's image-sequence demuxer.
+_TINY_PNG_DATAURL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+_FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+_skip_no_ffmpeg = pytest.mark.skipif(
+    not _FFMPEG_AVAILABLE,
+    reason="ffmpeg binary not on PATH — install ffmpeg to exercise the video pipeline",
+)
+
+
+@pytest.fixture
+async def project_id(client) -> int:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Video Export Project"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    pid = resp.json()["id"]
+    inst = await client.post(
+        f"/api/projects/{pid}/instruction",
+        json={"title": "Assembly"},
+        headers=headers,
+    )
+    assert inst.status_code == 200, inst.text
+    return pid
+
+
+def _one_step_payload(**overrides) -> dict:
+    base = {
+        "steps": [
+            {
+                "step_number": 1,
+                "title": "Bolt the chassis",
+                "description": "Use four M3x8 screws.",
+                "image_data_url": _TINY_PNG_DATAURL,
+            }
+        ],
+        "steps_per_page": 1,
+        "include_title_page": True,
+        "project_title": "My Project",
+        # Tight timing — keeps the test encode well under 1s with only
+        # a couple of frames in play.
+        "frame_seconds": 0.5,
+        "final_slide_seconds": 1.0,
+    }
+    base.update(overrides)
+    return base
+
+
+# --- Happy paths --------------------------------------------------------
+
+
+@_skip_no_ffmpeg
+@pytest.mark.asyncio
+async def test_export_gif_one_step_returns_gif(client, project_id) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/gif",
+        json=_one_step_payload(),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "image/gif"
+    cd = resp.headers.get("content-disposition", "")
+    assert "attachment" in cd
+    assert f"instructions-{project_id}.gif" in cd
+    body = resp.content
+    # GIF magic — either GIF87a or GIF89a; FFmpeg writes 89a.
+    assert body[:6] in (b"GIF87a", b"GIF89a"), body[:6]
+    # Even a 2-frame GIF (1 step + 1 slide hold) has a non-trivial header.
+    assert len(body) > 1000
+
+
+@_skip_no_ffmpeg
+@pytest.mark.asyncio
+async def test_export_mp4_one_step_returns_mp4(client, project_id) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/mp4",
+        json=_one_step_payload(),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "video/mp4"
+    cd = resp.headers.get("content-disposition", "")
+    assert "attachment" in cd
+    assert f"instructions-{project_id}.mp4" in cd
+    body = resp.content
+    # ISO BMFF marker: 'ftyp' box appears within the first ~32 bytes of
+    # any well-formed MP4. Faststart hoists it to the front so a casual
+    # contains check is enough.
+    assert b"ftyp" in body[:32], body[:32]
+    assert len(body) > 1000
+
+
+@_skip_no_ffmpeg
+@pytest.mark.asyncio
+async def test_export_gif_multiple_steps(client, project_id) -> None:
+    """Smoke test with a couple of steps — both frame sequence
+    handling and the closing-slide hold should round-trip cleanly."""
+    headers = make_auth_header()
+    payload = {
+        "steps": [
+            {
+                "step_number": i,
+                "title": f"Step {i}",
+                "description": f"Body {i}",
+                "image_data_url": _TINY_PNG_DATAURL,
+            }
+            for i in range(1, 3)
+        ],
+        "steps_per_page": 1,
+        "include_title_page": True,
+        "project_title": "Multi-step",
+        "frame_seconds": 0.5,
+        "final_slide_seconds": 1.0,
+    }
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/gif",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.content[:6] in (b"GIF87a", b"GIF89a")
+
+
+# --- Validation -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+async def test_export_video_empty_steps_returns_422(client, project_id, fmt) -> None:
+    headers = make_auth_header()
+    payload = _one_step_payload()
+    payload["steps"] = []
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+@pytest.mark.parametrize("bad", [0, -1, 999])
+async def test_export_video_invalid_frame_seconds_returns_422(
+    client, project_id, fmt, bad
+) -> None:
+    headers = make_auth_header()
+    payload = _one_step_payload(frame_seconds=bad)
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+@pytest.mark.parametrize("bad", [0, 999])
+async def test_export_video_invalid_slide_seconds_returns_422(
+    client, project_id, fmt, bad
+) -> None:
+    headers = make_auth_header()
+    payload = _one_step_payload(final_slide_seconds=bad)
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+async def test_export_video_bad_image_prefix_returns_422(
+    client, project_id, fmt
+) -> None:
+    headers = make_auth_header()
+    payload = _one_step_payload()
+    payload["steps"][0]["image_data_url"] = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    )
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+async def test_export_video_jpeg_prefix_returns_422(
+    client, project_id, fmt
+) -> None:
+    """A valid JPEG dataURL is still rejected — we only accept PNG."""
+    headers = make_auth_header()
+    payload = _one_step_payload()
+    payload["steps"][0]["image_data_url"] = (
+        "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAA=="
+    )
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+# --- Auth + ownership ------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+async def test_export_video_non_owner_returns_403(client, project_id, fmt) -> None:
+    other = make_auth_header(username="someoneelse")
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=_one_step_payload(),
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+async def test_export_video_anonymous_returns_401(client, project_id, fmt) -> None:
+    """No auth header — auth dep rejects before the route runs."""
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/export/{fmt}",
+        json=_one_step_payload(),
+    )
+    assert resp.status_code == 401
+
+
+# --- Terms gate ------------------------------------------------------
+#
+# Mirrors the gate test in ``test_instructions_export.py`` — opt back
+# into the real ``require_terms_accepted`` dependency for both the GIF
+# and MP4 routes.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["gif", "mp4"])
+async def test_export_video_without_terms_acceptance_returns_403(
+    client, fmt
+) -> None:
+    from projects_api import auth as auth_module
+
+    app = client._transport.app
+    for dep in (
+        auth_module.require_terms_accepted,
+        auth_module.require_terms_accepted_aged,
+    ):
+        app.dependency_overrides.pop(dep, None)
+
+    headers = make_auth_header("alice")
+    acc = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert acc.status_code == 200, acc.text
+    proj = await client.post(
+        "/api/projects",
+        json={"title": "Gated Video Project"},
+        headers=headers,
+    )
+    assert proj.status_code == 201, proj.text
+    pid = proj.json()["id"]
+
+    from projects_api import config as config_module
+    from projects_api.routers import users as users_router
+
+    def _fake_get_settings():
+        s = config_module.Settings()
+        return s.model_copy(update={"current_terms_version": "2.0"})
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(config_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(auth_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(users_router, "get_settings", _fake_get_settings)
+
+    try:
+        resp = await client.post(
+            f"/api/projects/{pid}/instruction/export/{fmt}",
+            json=_one_step_payload(),
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail")
+        assert isinstance(detail, dict)
+        assert detail.get("detail") == "terms_not_accepted"
+    finally:
+        monkeypatch.undo()
+
+
+# --- Branding slide module --------------------------------------------
+#
+# Exercise the Pillow slide renderer directly (no FFmpeg needed). The
+# slide is generated identically for PDF / GIF / MP4 so it's worth a
+# tiny unit test guarding the fallback-font path.
+
+
+def test_render_made_with_slide_returns_png_bytes() -> None:
+    from projects_api.instructions_branding import render_made_with_slide
+
+    png = render_made_with_slide(project_title="Test Build")
+    assert png.startswith(b"\x89PNG\r\n\x1a\n"), png[:8]
+    # Headline + subtitle + wordmark + project title — even at the
+    # default 1200x900 a meaningful slide is well over 5KB.
+    assert len(png) > 5000
+
+
+def test_render_made_with_slide_without_title() -> None:
+    """Optional ``project_title`` must not be required."""
+    from projects_api.instructions_branding import render_made_with_slide
+
+    png = render_made_with_slide()
+    assert png.startswith(b"\x89PNG\r\n\x1a\n")

--- a/web/assets/js/instruction-builder.js
+++ b/web/assets/js/instruction-builder.js
@@ -1091,6 +1091,60 @@
     }
   }
 
+  // Phase 3b/3c — Animated GIF / MP4 video export. Same render-then-POST
+  // pipeline as the PDF path; the server runs FFmpeg over the supplied
+  // PNG sequence + branded closing slide. ``format`` is either 'gif' or
+  // 'mp4' and chooses the endpoint suffix + filename extension +
+  // download MIME type.
+  async function exportVideo(format) {
+    var label = (format === 'mp4') ? 'MP4 video' : 'animated GIF';
+    setExportProgress('Preparing export…');
+    try {
+      await flushPendingCanvasSave();
+      var steps = await loadStepsForExport();
+      var dataUrls = await renderAllStepsToDataUrls(steps);
+
+      // Video encodes take noticeably longer than PDFs (FFmpeg + a
+      // two-pass GIF palettegen or an H.264 single pass) — keep the
+      // user informed so they don't think the page is hung. The
+      // backend caps each FFmpeg invocation at 120s; the frontend
+      // doesn't set its own fetch timeout — we let the server be the
+      // source of truth on "too long".
+      setExportProgress('Encoding ' + label + '… this can take a minute');
+      var payload = {
+        steps: steps.map(function (s, i) {
+          return {
+            step_number: s.step_number || (i + 1),
+            title: s.title || null,
+            description: s.description || null,
+            image_data_url: dataUrls[i],
+          };
+        }),
+        steps_per_page: 1,
+        include_title_page: false,
+        project_title: (state.project && state.project.title) || null,
+      };
+      var resp = await apiFetchWithTermsRetry(
+        API + '/api/projects/' + state.projectId + '/instruction/export/' + format,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }
+      );
+      if (!resp.ok) {
+        throw new Error('Server returned HTTP ' + resp.status);
+      }
+      var blob = await resp.blob();
+      setExportProgress('Downloading…');
+      triggerDownload(blob, 'instructions-' + state.projectId + '.' + format);
+      hideExportProgress(1500);
+    } catch (e) {
+      setExportProgress('Export failed — please try again', 'error');
+      hideExportProgress(4000);
+    }
+  }
+
   async function exportZip() {
     if (typeof window.JSZip === 'undefined') {
       setExportProgress('ZIP library failed to load — try the PDF option instead', 'error');
@@ -1145,6 +1199,8 @@
         if (kind === 'pdf') {
           var layout = parseInt(item.dataset.layout, 10) || 1;
           exportPdf(layout);
+        } else if (kind === 'gif' || kind === 'mp4') {
+          exportVideo(kind);
         } else if (kind === 'zip') {
           exportZip();
         }

--- a/web/projects/instructions/edit.html
+++ b/web/projects/instructions/edit.html
@@ -40,6 +40,10 @@ hide_nibsy: true
           <li><a class="dropdown-item" href="#" data-export="pdf" data-layout="2">2 steps per page</a></li>
           <li><a class="dropdown-item" href="#" data-export="pdf" data-layout="4">4 steps per page</a></li>
           <li><hr class="dropdown-divider"></li>
+          <li><h6 class="dropdown-header">Video</h6></li>
+          <li><a class="dropdown-item" href="#" data-export="gif">Animated GIF</a></li>
+          <li><a class="dropdown-item" href="#" data-export="mp4">MP4 video</a></li>
+          <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="#" data-export="zip">Image series (ZIP)</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary

- Adds animated GIF and MP4 export to the Instruction Builder, alongside the existing PDF + ZIP options.
- Brands all three export formats (PDF, GIF, MP4) with a "Made with kevsrobots.com/projects" final slide rendered server-side via Pillow.
- Backend uses FFmpeg via `subprocess.run` (list-form, no shell) — two-pass palettegen for GIF, libx264 + yuv420p for MP4. `asyncio.to_thread` keeps the FastAPI event loop responsive during multi-second encodes.

## ⚠️ Production deploy needs a Dockerfile-aware rebuild

The Dockerfile now installs `ffmpeg` + `fonts-dejavu-core` via apt. The pip layer cache is unaffected, but the apt layer is invalidated. A normal `docker build` will pick it up. Symptom of forgetting: `/export/gif` and `/export/mp4` return 500 with `"ffmpeg is not installed"` in `docker logs`.

## Test plan

- [ ] Open an instruction with 3+ steps → Export → Animated GIF → file downloads, plays in browser, ends on the "Made with kevsrobots.com/projects" slide.
- [ ] Same project → Export → MP4 video → plays in QuickTime / mobile Safari, ends on the branded slide.
- [ ] Same project → Export → PDF (1 step per page) → final page is the Made-with slide (no page number on that page).
- [ ] Anonymous → `/export/gif` → 401; non-owner → 403; missing T&Cs → 403.
- [ ] Empty `steps` / non-PNG `image_data_url` / `frame_seconds=999` → 422.
- [ ] 27 new video tests pass; full backend suite 432/432.

## Implementation notes

- **FFmpeg 8 quirks resolved:** `palettegen` needs `-update 1 -frames:v 1`; all frames must be a uniform size (step PNGs are 2400×1800 from `multiplier: 2`, slide is generated at 1200×900). Added a `_normalise_frame` helper that resizes/letterboxes everything onto a 1200×900 white canvas via Pillow before encoding.
- **`include_title_page=False`** is hard-coded on video payloads from the frontend — the closing slide doubles as the cover.
- **Pillow font fallback:** uses `DejaVuSans-Bold.ttf` via fonts-dejavu-core; falls back to `ImageFont.load_default()` if the font isn't installed.
- **`subprocess.run` is list-form**, no shell. FFmpeg args come only from validated payload. 120s timeout per encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)