### PR TITLE
feat(projects): rename now syncs the URL slug, preserves old links (#190)

### DIFF
--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -87,6 +87,41 @@ class Project(Base):
     )
 
 
+# --- Project slug history (issue #190) -----------------------------------
+#
+# Every slug a project has ever used. When a project's title (and therefore
+# its slug) changes we insert a row here so the OLD slug keeps resolving via
+# the by-slug lookup — the route emits a 301 to the canonical URL so shared
+# links / search results don't break the moment an owner renames.
+#
+# Composite (author_username, slug) would in practice be unique most of the
+# time, but we deliberately DO NOT enforce uniqueness: if a project is
+# renamed back to a previous title, the history just gains another row and
+# the most-recent retirement timestamp wins. The router resolves by slug
+# alone (scoped by author via the FK join), so duplicates don't break the
+# lookup.
+#
+# Brand-new table — ``create_all`` handles it, no ALTER helper required.
+
+
+class ProjectSlugHistory(Base):
+    __tablename__ = "project_slug_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # The slug that USED to point at this project. Indexed for the
+    # by-slug-fallback lookup ("does any historical row claim this slug?").
+    slug: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    # Captured at the time the slug stopped being canonical.
+    retired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
 class ProjectReport(Base):
     __tablename__ = "project_reports"
 

--- a/stacks/projects-api/projects_api/routers/by_slug.py
+++ b/stacks/projects-api/projects_api/routers/by_slug.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import Optional
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import get_optional_user
@@ -48,7 +49,7 @@ from . import journal as journal_router_module
 from . import links as links_router_module
 from . import makes as makes_router_module
 from . import projects as projects_router_module
-from .projects import resolve_project_id
+from .projects import resolve_project_id, resolve_project_id_with_redirect
 
 router = APIRouter(prefix="/api/projects", tags=["projects-by-slug"])
 
@@ -62,14 +63,29 @@ async def get_project_by_slug(
     slug: str,
     user: Optional[str] = Depends(get_optional_user),
     session: AsyncSession = Depends(get_session),
-) -> ProjectResponse:
+):
     """Look up a project by ``(owner, slug)``.
 
     Returned shape matches the id-based ``GET /api/projects/{id}`` so
     the frontend can call either endpoint and converge on the same
     rendering code.
+
+    Issue #190: if ``slug`` is a historical (retired) slug the response
+    is a 301 redirect to the project's canonical ``(owner, current_slug)``
+    URL so browsers update the URL bar and SEO consolidates on the
+    latest slug. The nested-resource endpoints below intentionally do
+    NOT redirect — they're called server-to-server by the public view
+    page after it has already followed the redirect on the parent
+    resource, so a second redirect would be wasted work.
     """
-    project_id = await resolve_project_id(session, owner, slug)
+    project_id, canonical_slug = await resolve_project_id_with_redirect(
+        session, owner, slug
+    )
+    if canonical_slug is not None and canonical_slug != slug:
+        return RedirectResponse(
+            url=f"/api/projects/by-slug/{owner}/{canonical_slug}",
+            status_code=301,
+        )
     return await projects_router_module.get_project(
         project_id=project_id, user=user, session=session
     )

--- a/stacks/projects-api/projects_api/routers/projects.py
+++ b/stacks/projects-api/projects_api/routers/projects.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..auth import get_current_user, get_optional_user, require_terms_accepted
 from ..badges import evaluate_user
 from ..db import get_session
-from ..models import Download, Project, ProjectTag, UserFollow
+from ..models import Download, Project, ProjectSlugHistory, ProjectTag, UserFollow
 from ..schemas import (
     ProjectCreate,
     ProjectListItem,
@@ -33,12 +33,21 @@ async def resolve_project_id(
 
     Raises :class:`HTTPException` with 404 when no project matches.
 
+    Issue #190: if the (owner, slug) doesn't match a *current* project we
+    fall back to ``project_slug_history`` so old shared links resolve
+    silently. The fallback is silent here because every machine-facing
+    nested-resource route (BOM, images, files, links, journal, makes)
+    calls this helper — those callers don't need a redirect, they just
+    need the row. Page-facing routes that want to nudge the browser
+    toward the canonical URL call :func:`resolve_project_id_with_redirect`
+    instead.
+
     This is the central helper for the issue #152 by-slug routes — every
     nested resource handler (BOM, images, files, links, journal, makes)
     wraps the existing id-based router by calling here first and then
     forwarding to the id-based path. Keeping the lookup in one place
     means a change to the slug-resolution rules (case-folding, alias
-    table, …) only has to happen here.
+    table, history fallback, …) only has to happen here.
     """
     project_id = await session.scalar(
         select(Project.id).where(
@@ -46,9 +55,73 @@ async def resolve_project_id(
             Project.slug == slug,
         )
     )
-    if project_id is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
-    return int(project_id)
+    if project_id is not None:
+        return int(project_id)
+
+    # Issue #190: fall back to the slug-history table. A project may have
+    # used this slug in the past and been renamed; we still want the link
+    # to resolve. Scope by author via a join on ``projects`` so a slug
+    # retired under one user doesn't bleed across to another's namespace.
+    historical_id = await session.scalar(
+        select(ProjectSlugHistory.project_id)
+        .join(Project, Project.id == ProjectSlugHistory.project_id)
+        .where(
+            Project.author_username == owner,
+            ProjectSlugHistory.slug == slug,
+        )
+        .order_by(ProjectSlugHistory.retired_at.desc())
+        .limit(1)
+    )
+    if historical_id is not None:
+        return int(historical_id)
+
+    raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+
+
+async def resolve_project_id_with_redirect(
+    session: AsyncSession,
+    owner: str,
+    slug: str,
+) -> tuple[int, Optional[str]]:
+    """Like :func:`resolve_project_id` but signals whether the caller's
+    slug is historical.
+
+    Returns ``(project_id, canonical_slug)`` where ``canonical_slug`` is:
+
+    * ``None`` when the supplied slug IS the project's current slug (no
+      redirect needed).
+    * the project's current slug when the supplied slug matched only via
+      the ``project_slug_history`` fallback — the caller should respond
+      with a 301 to the canonical ``(owner, canonical_slug)`` URL.
+
+    Used by the public-facing GET routes in ``by_slug.py`` so browsers
+    update their URL bar and SEO consolidates onto the latest slug.
+    """
+    current = await session.execute(
+        select(Project.id, Project.slug).where(
+            Project.author_username == owner,
+            Project.slug == slug,
+        )
+    )
+    row = current.first()
+    if row is not None:
+        return int(row[0]), None
+
+    historical = await session.execute(
+        select(Project.id, Project.slug)
+        .join(ProjectSlugHistory, ProjectSlugHistory.project_id == Project.id)
+        .where(
+            Project.author_username == owner,
+            ProjectSlugHistory.slug == slug,
+        )
+        .order_by(ProjectSlugHistory.retired_at.desc())
+        .limit(1)
+    )
+    hrow = historical.first()
+    if hrow is not None:
+        return int(hrow[0]), hrow[1]
+
+    raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
 
 
 async def _download_count(session: AsyncSession, project_id: int) -> int:
@@ -334,24 +407,47 @@ async def update_project(
 
     update_data = body.model_dump(exclude_unset=True)
     tags = update_data.pop("tags", None)
-    # Issue #152: ``regenerate_slug`` is a control flag, not a column —
-    # never assign it to the ORM row. Slug stays sticky on title rename
-    # unless the caller explicitly opts in (preserves inbound links from
-    # blogs / search engines).
-    regenerate_slug = bool(update_data.pop("regenerate_slug", False))
+    # Issue #152 / #190: ``regenerate_slug`` started life as the explicit
+    # opt-in for re-slugifying on rename. As of #190 a title change ALWAYS
+    # regenerates the slug — the old slug is preserved in
+    # ``project_slug_history`` so inbound links keep working via a 301
+    # redirect. We still pop the flag so it never lands on the ORM row;
+    # callers that pass ``regenerate_slug: true`` without a new title get
+    # the same auto-regen against the existing title (a no-op when the
+    # computed slug already matches).
+    explicit_regen = bool(update_data.pop("regenerate_slug", False))
+    title_changed = "title" in update_data and update_data["title"] != project.title
     previous_status = project.status
+    previous_slug = project.slug
     for field, value in update_data.items():
         setattr(project, field, value)
     project.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
 
-    if regenerate_slug:
+    # Issue #190: regenerate the slug whenever the title actually changed.
+    # The legacy ``regenerate_slug=true`` opt-in still forces a refresh so
+    # callers can re-slugify after a slugify_title rule change without
+    # editing the title.
+    if title_changed or explicit_regen:
         base = slugify_title(project.title)
-        project.slug = await unique_slug_for_author(
+        new_slug = await unique_slug_for_author(
             session,
             author_username=project.author_username,
             base_slug=base,
             exclude_project_id=project.id,
         )
+        if new_slug != previous_slug:
+            # Stash the OLD slug so historic links keep resolving via
+            # ``project_slug_history`` and 301 to the canonical URL.
+            # No-op when ``previous_slug`` is None (legacy rows that
+            # have never had a slug have nothing worth archiving).
+            if previous_slug:
+                session.add(
+                    ProjectSlugHistory(
+                        project_id=project.id,
+                        slug=previous_slug,
+                    )
+                )
+            project.slug = new_slug
 
     if tags is not None:
         await _set_tags(session, project.id, tags)

--- a/stacks/projects-api/tests/test_project_slug_history.py
+++ b/stacks/projects-api/tests/test_project_slug_history.py
@@ -1,0 +1,333 @@
+"""Tests for the issue #190 rename-syncs-slug behaviour.
+
+When a project owner changes the title:
+
+* The slug regenerates from the new title.
+* The OLD slug is preserved in ``project_slug_history`` so inbound links
+  keep resolving.
+* The by-slug GET endpoint returns a 301 redirect from the historical
+  slug to the canonical current slug.
+
+These tests live in a sibling file to ``test_project_slugs.py`` (which
+covers the issue #152 create-time + structural slug behaviour) so the
+two feature areas can evolve independently.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from projects_api.models import ProjectSlugHistory
+
+from .conftest import make_auth_header
+
+
+# ---- Spaces-in-title → dash separators (issue #190 explicit requirement) -
+
+
+@pytest.mark.asyncio
+async def test_spaces_in_title_become_dashes_in_slug(client) -> None:
+    """Locks the "replace spaces with `-`" requirement from issue #190."""
+    response = await client.post(
+        "/api/projects",
+        json={"title": "Hello World"},
+        headers=make_auth_header(),
+    )
+    assert response.status_code == 201
+    assert response.json()["slug"] == "hello-world"
+
+
+# ---- Title change auto-regenerates slug + writes history ----------------
+
+
+@pytest.mark.asyncio
+async def test_title_change_writes_history_and_updates_slug(
+    client, session
+) -> None:
+    headers = make_auth_header()
+    created = await client.post(
+        "/api/projects",
+        json={"title": "BurgerBot 2"},
+        headers=headers,
+    )
+    pid = created.json()["id"]
+    assert created.json()["slug"] == "burgerbot-2"
+
+    response = await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "BurgerBot 3000"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["slug"] == "burgerbot-3000"
+
+    rows = (
+        await session.execute(
+            select(ProjectSlugHistory).where(
+                ProjectSlugHistory.project_id == pid
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].slug == "burgerbot-2"
+
+
+# ---- No-op when the computed slug doesn't change ------------------------
+
+
+@pytest.mark.asyncio
+async def test_title_edit_that_yields_same_slug_writes_no_history(
+    client, session
+) -> None:
+    """Whitespace-only or case-only title edits don't pollute history."""
+    headers = make_auth_header()
+    created = await client.post(
+        "/api/projects",
+        json={"title": "Hello World"},
+        headers=headers,
+    )
+    pid = created.json()["id"]
+
+    # Trailing whitespace + a different case → same slug.
+    response = await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "  HELLO   World  "},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["slug"] == "hello-world"
+
+    rows = (
+        await session.execute(
+            select(ProjectSlugHistory).where(
+                ProjectSlugHistory.project_id == pid
+            )
+        )
+    ).scalars().all()
+    assert rows == []
+
+
+# ---- Rename to a colliding slug must NOT count the project itself -------
+
+
+@pytest.mark.asyncio
+async def test_rename_does_not_collide_with_own_current_slug(client) -> None:
+    """If the rename's new slug equals the project's own current slug, it
+    must NOT be bumped to `-2`. (Regression guard for the
+    ``exclude_project_id`` plumbing through ``unique_slug_for_author``.)
+    """
+    headers = make_auth_header()
+    created = await client.post(
+        "/api/projects",
+        json={"title": "My Project"},
+        headers=headers,
+    )
+    pid = created.json()["id"]
+    assert created.json()["slug"] == "my-project"
+
+    # Same title typed again (no actual change) — the in-place rename path
+    # must not bump itself.
+    response = await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "My Project"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["slug"] == "my-project"
+
+
+@pytest.mark.asyncio
+async def test_rename_collides_with_other_project_gets_suffix(client) -> None:
+    """Renaming to match an existing sibling's title bumps to ``-2``."""
+    headers = make_auth_header()
+    other = await client.post(
+        "/api/projects",
+        json={"title": "Taken Title"},
+        headers=headers,
+    )
+    assert other.json()["slug"] == "taken-title"
+
+    me = await client.post(
+        "/api/projects",
+        json={"title": "Original"},
+        headers=headers,
+    )
+    me_id = me.json()["id"]
+
+    response = await client.put(
+        f"/api/projects/{me_id}",
+        json={"title": "Taken Title"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["slug"] == "taken-title-2"
+
+
+# ---- Old slug → 301 to canonical URL ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_old_slug_redirects_to_canonical(client) -> None:
+    headers = make_auth_header()  # testuser
+    created = await client.post(
+        "/api/projects",
+        json={"title": "Initial Name"},
+        headers=headers,
+    )
+    pid = created.json()["id"]
+
+    await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "Renamed Project"},
+        headers=headers,
+    )
+
+    # GET on the historical slug returns 301 to the canonical one.
+    response = await client.get(
+        "/api/projects/by-slug/testuser/initial-name",
+        follow_redirects=False,
+    )
+    assert response.status_code == 301
+    assert (
+        response.headers["location"]
+        == "/api/projects/by-slug/testuser/renamed-project"
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_slug_does_not_redirect(client) -> None:
+    """Sanity check: the new canonical URL serves a 200, not a redirect
+    loop."""
+    headers = make_auth_header()
+    created = await client.post(
+        "/api/projects",
+        json={"title": "Stable Name"},
+        headers=headers,
+    )
+    await client.put(
+        f"/api/projects/{created.json()['id']}",
+        json={"title": "Now Different"},
+        headers=headers,
+    )
+
+    response = await client.get(
+        "/api/projects/by-slug/testuser/now-different",
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert response.json()["slug"] == "now-different"
+
+
+# ---- Renaming back to a previous title ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_back_to_previous_title_writes_new_history_row(
+    client, session
+) -> None:
+    """A → B → A leaves two history rows (one per retirement) and the
+    project ends up back on slug A. (Titles padded to ProjectCreate's
+    5-char minimum.)"""
+    headers = make_auth_header()
+    created = await client.post(
+        "/api/projects",
+        json={"title": "AlphaBot"},
+        headers=headers,
+    )
+    pid = created.json()["id"]
+    assert created.json()["slug"] == "alphabot"
+
+    await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "BetaBot"},
+        headers=headers,
+    )
+    final = await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "AlphaBot"},
+        headers=headers,
+    )
+    assert final.json()["slug"] == "alphabot"
+
+    rows = (
+        await session.execute(
+            select(ProjectSlugHistory)
+            .where(ProjectSlugHistory.project_id == pid)
+            .order_by(ProjectSlugHistory.id)
+        )
+    ).scalars().all()
+    retired = [r.slug for r in rows]
+    # Both transitions were captured: alphabot→betabot retired
+    # "alphabot", and betabot→alphabot retired "betabot". Order of
+    # insertion is preserved.
+    assert retired == ["alphabot", "betabot"]
+
+
+# ---- Non-owner can't trigger a rename -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_owner_rename_403_does_not_change_slug(client, session) -> None:
+    owner = make_auth_header("alice")
+    intruder = make_auth_header("bob")
+
+    created = await client.post(
+        "/api/projects",
+        json={"title": "Owned By Alice"},
+        headers=owner,
+    )
+    pid = created.json()["id"]
+    original_slug = created.json()["slug"]
+
+    response = await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "Hijacked"},
+        headers=intruder,
+    )
+    assert response.status_code == 403
+
+    fetched = await client.get(f"/api/projects/{pid}")
+    assert fetched.json()["slug"] == original_slug
+
+    rows = (
+        await session.execute(
+            select(ProjectSlugHistory).where(
+                ProjectSlugHistory.project_id == pid
+            )
+        )
+    ).scalars().all()
+    assert rows == []
+
+
+# ---- Nested by-slug endpoints still resolve via history -----------------
+
+
+@pytest.mark.asyncio
+async def test_nested_endpoints_resolve_via_historical_slug(client) -> None:
+    """The machine-callers (BOM etc.) don't redirect, but they still
+    resolve the project so the existing /projects/<owner>/<slug>/<...>
+    endpoints don't die the moment the owner renames."""
+    headers = make_auth_header()  # testuser
+    created = await client.post(
+        "/api/projects",
+        json={"title": "Has BOM"},
+        headers=headers,
+    )
+    pid = created.json()["id"]
+    await client.post(
+        f"/api/projects/{pid}/bom",
+        json={"name": "Servo", "quantity": 2},
+        headers=headers,
+    )
+
+    await client.put(
+        f"/api/projects/{pid}",
+        json={"title": "Renamed BOM"},
+        headers=headers,
+    )
+
+    # Old-slug nested fetch silently serves the project (no redirect).
+    response = await client.get("/api/projects/testuser/has-bom/bom")
+    assert response.status_code == 200
+    assert response.json()[0]["name"] == "Servo"

--- a/stacks/projects-api/tests/test_project_slugs.py
+++ b/stacks/projects-api/tests/test_project_slugs.py
@@ -131,8 +131,13 @@ async def test_get_by_slug_404_for_unknown(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_title_does_not_regenerate_slug_by_default(client) -> None:
-    """Renaming a project leaves the slug alone so inbound links stay live."""
+async def test_update_title_auto_regenerates_slug(client) -> None:
+    """Issue #190: a title change automatically refreshes the slug.
+
+    Inbound links to the old slug still work via the
+    ``project_slug_history`` fallback + 301 redirect — see
+    ``test_old_slug_redirects_to_canonical`` below.
+    """
     headers = make_auth_header()
     created = await client.post(
         "/api/projects",
@@ -149,7 +154,7 @@ async def test_update_title_does_not_regenerate_slug_by_default(client) -> None:
         headers=headers,
     )
     assert response.status_code == 200
-    assert response.json()["slug"] == "old-title"
+    assert response.json()["slug"] == "brand-new-title"
 
 
 @pytest.mark.asyncio

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -148,6 +148,13 @@
       if (!projectId) {
         history.replaceState(null, '', '?id=' + currentProject.id);
       }
+      // Issue #190: a title save can change the slug, so refresh the
+      // "View live" / view-toggle links from the (possibly new) slug.
+      // updateStatusBadge already reads currentProject.slug to rebuild
+      // both hrefs, so a single call here keeps the displayed public
+      // URL in sync silently — no page reload required. The editor's
+      // own URL stays at /projects/editor.html?id=<id>, so we do NOT
+      // history.replaceState anything slug-shaped here.
       updateStatusBadge(currentProject.status);
       showSaveStatus('saved', 'Saved');
       // Issue #106: surface any badges awarded by this save (typically


### PR DESCRIPTION
## Summary

Closes #190.

- Changing a project's title in the editor now auto-regenerates the URL slug — `slugify_title(title)` is applied on every title-change PUT, and `unique_slug_for_author` ignores the project's own id so an in-place rename doesn't collide with itself.
- A new `project_slug_history` table (brand-new — no ALTER helper needed) records every retired slug. The by-slug GET endpoint falls back to this history when the current slug doesn't match and returns a `301 Moved Permanently` to the canonical URL, so old shared links keep resolving and SEO consolidates onto the latest URL.
- The editor's existing `updateStatusBadge` already rebuilds the "View live" / preview-toggle hrefs from `currentProject.slug`; calling it after the PUT response silently refreshes the displayed public URL without a page reload. The editor's own URL stays at `/projects/editor.html?id=<id>`.

Spaces in titles already become `-` via `slugify_title` (issue #152 work); locked in by a regression test.

## Test plan

- [x] `pytest tests/` from `stacks/projects-api/` — 442 passed (25 slug-related: 15 prior + 10 new history tests)
- [x] `node --check web/assets/js/project-editor.js`
- [ ] Manual smoke: create a project titled "BurgerBot 2", rename to "BurgerBot 3000", confirm:
  - [ ] Editor's "View live" button now points at `/projects/<owner>/burgerbot-3000`
  - [ ] Visiting the old `/api/projects/by-slug/<owner>/burgerbot-2` returns 301 → canonical URL
  - [ ] The view.html 404-redirector ferries users to the new slug

## Notes

- `resolve_project_id` keeps its silent contract (machine callers unaffected); only the public GET in `by_slug.py` uses the new `resolve_project_id_with_redirect` sibling to emit 301s.
- Existing `test_update_title_does_not_regenerate_slug_by_default` was flipped to `test_update_title_auto_regenerates_slug` since #190 inverts the contract; the explicit `regenerate_slug: true` opt-in test stays as a back-compat guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)