### PR TITLE
feat(files): per-file descriptions with inline editing (#187)

### DIFF
--- a/stacks/projects-api/projects_api/db.py
+++ b/stacks/projects-api/projects_api/db.py
@@ -949,3 +949,44 @@ async def add_user_currency_preference_if_missing() -> None:
                 'ALTER TABLE "user_profiles" '
                 'ADD COLUMN "preferred_currency" CHAR(3)'
             ))
+
+
+async def add_project_file_description_if_missing() -> None:
+    """Additive migration for issue #187 (per-file descriptions).
+
+    Adds ``description`` (TEXT, nullable) to the existing ``project_files``
+    table when it does not already exist. SQLAlchemy's ``create_all`` does
+    not ALTER existing tables, so this lightweight idempotent helper keeps
+    existing Postgres deployments in sync. Safe to run on every startup;
+    no-op when the column is already present. Postgres-only — SQLite test
+    runs use a fresh in-memory DB which already includes the new column
+    via ``create_all``.
+
+    Mirrors ``add_bom_part_id_if_missing`` / ``add_remix_columns_if_missing``
+    — same probe-then-ALTER pattern.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.begin() as conn:
+        table_check = await conn.execute(text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = 'project_files'"
+        ))
+        if table_check.first() is None:
+            # Brand-new deployment — create_all on the same startup pass
+            # will build the table with the new column already present.
+            return
+
+        existing = await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'project_files' "
+            "AND column_name = 'description'"
+        ))
+        if existing.first() is None:
+            logger.warning(
+                "Adding project_files.description column (issue #187)"
+            )
+            await conn.execute(text(
+                'ALTER TABLE "project_files" ADD COLUMN "description" TEXT'
+            ))

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -20,6 +20,7 @@ from .db import (
     add_part_category_family_if_missing,
     add_part_status_columns_if_missing,
     add_project_featured_columns_if_missing,
+    add_project_file_description_if_missing,
     add_project_slug_if_missing,
     add_remix_columns_if_missing,
     add_supplier_country_if_missing,
@@ -112,6 +113,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Issue #122 Phase 2: supplier link-health columns + lifecycle columns.
     await add_supplier_health_columns_if_missing()
     await add_part_status_columns_if_missing()
+    # Issue #187: ensure project_files.description column exists on legacy
+    # Postgres deployments. No-op on fresh deploys / SQLite tests.
+    await add_project_file_description_if_missing()
     # Issue #106: seed the badge catalog (idempotent upsert by slug).
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/stacks/projects-api/projects_api/routers/files.py
+++ b/stacks/projects-api/projects_api/routers/files.py
@@ -16,7 +16,7 @@ from ..auth import get_current_user, get_optional_user, require_terms_accepted
 from ..config import get_settings
 from ..db import get_session
 from ..models import Download, Project, ProjectFile
-from ..schemas import FileResponse
+from ..schemas import FileResponse, FileUpdate
 from ..storage import (
     delete_file,
     generate_filename,
@@ -216,6 +216,60 @@ async def download_file(
         content=data,
         media_type="application/octet-stream",
         headers={"Content-Disposition": f'attachment; filename="{record.filename}"'},
+    )
+
+
+@router.put("/{file_id}", response_model=FileResponse)
+async def update_file(
+    project_id: int,
+    file_id: int,
+    body: FileUpdate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> FileResponse:
+    """Partial-update an uploaded file's metadata (issue #187).
+
+    Owner-only. Today only ``description`` is mutable — the file itself is
+    immutable post-upload (filename/size/type are stamped at write time).
+    Partial-update semantics match ``LinkUpdate``: fields omitted from the
+    body (``exclude_unset``) are left untouched; an explicit empty string
+    clears the description; ``None`` is treated as "don't touch" (because
+    Pydantic only sets fields the client actually included in the JSON).
+    """
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    if project.author_username != user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
+
+    record = await session.get(ProjectFile, file_id)
+    if record is None or record.project_id != project_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+
+    # ``exclude_unset`` so a missing field stays missing rather than being
+    # patched to None — partial-update semantics. An explicit "" still
+    # comes through and clears the description.
+    payload = body.model_dump(exclude_unset=True)
+    for field, value in payload.items():
+        setattr(record, field, value)
+    await session.commit()
+    await session.refresh(record)
+
+    download_count = int(
+        (
+            await session.execute(
+                select(func.count(Download.id)).where(Download.file_id == record.id)
+            )
+        ).scalar_one()
+    )
+    return FileResponse(
+        id=record.id,
+        filename=record.filename,
+        file_size=record.file_size,
+        file_type=record.file_type,
+        description=record.description,
+        uploaded_at=record.uploaded_at,
+        download_count=download_count,
     )
 
 

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -434,6 +434,18 @@ class FileResponse(BaseModel):
     download_count: int = 0
 
 
+class FileUpdate(BaseModel):
+    """Partial-update body for ``PUT /api/projects/{id}/files/{file_id}``
+    (issue #187). Only ``description`` is mutable today; every other file
+    field is fixed at upload time. Mirrors the ``LinkUpdate`` / BOM partial
+    semantics — fields omitted (``exclude_unset``) are left untouched, an
+    explicit empty string clears the description, ``None`` is treated as
+    omitted (don't touch). Long descriptions are allowed up to 2000 chars
+    — the editor textarea wraps in the column rather than truncating."""
+
+    description: Optional[str] = Field(None, max_length=2000)
+
+
 class ImageResponse(BaseModel):
     id: int
     filename: str

--- a/stacks/projects-api/tests/test_files_images.py
+++ b/stacks/projects-api/tests/test_files_images.py
@@ -130,3 +130,138 @@ async def test_list_images(client, project_id) -> None:
     resp = await client.get(f"/api/projects/{project_id}/images")
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
+
+
+# --- Per-file descriptions (issue #187) ----------------------------------
+#
+# Partial-update semantics chosen here:
+#   * ``description: null`` from the client means "field omitted" (we don't
+#     touch the existing value). Pydantic only puts fields the client
+#     actually included in ``model_dump(exclude_unset=True)``.
+#   * ``description: ""`` (explicit empty string) clears the description
+#     to the empty string rather than NULL. The frontend treats both null
+#     and "" as "no description" so the user-visible behaviour is
+#     identical, but the backend keeps the distinction so an empty-string
+#     clear can't accidentally re-pull a previously-cleared description.
+#   * Omitting the key entirely leaves the row unchanged.
+
+
+@pytest.fixture
+async def uploaded_file(client, project_id):
+    """A single file upload, returns the file_id."""
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/files",
+        files={"file": ("blueprint.pdf", b"%PDF-1.4 fake pdf", "application/pdf")},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_uploaded_file_description_defaults_to_none(
+    client, project_id, uploaded_file
+) -> None:
+    resp = await client.get(f"/api/projects/{project_id}/files")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["id"] == uploaded_file
+    assert rows[0]["description"] is None
+
+
+@pytest.mark.asyncio
+async def test_set_file_description_persists(
+    client, project_id, uploaded_file
+) -> None:
+    headers = make_auth_header()
+    resp = await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={"description": "Pin diagram for v1.0"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "Pin diagram for v1.0"
+    # And it persists on a subsequent GET.
+    get_resp = await client.get(f"/api/projects/{project_id}/files")
+    assert get_resp.json()[0]["description"] == "Pin diagram for v1.0"
+
+
+@pytest.mark.asyncio
+async def test_empty_string_clears_file_description(
+    client, project_id, uploaded_file
+) -> None:
+    headers = make_auth_header()
+    # First set a description.
+    await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={"description": "Initial description"},
+        headers=headers,
+    )
+    # Now clear it with an explicit empty string.
+    resp = await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={"description": ""},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    # Spec: empty string clears to "" (not None) — locking the semantic in
+    # so a future refactor can't silently flip behaviour.
+    assert resp.json()["description"] == ""
+
+
+@pytest.mark.asyncio
+async def test_omitting_description_leaves_existing_value_untouched(
+    client, project_id, uploaded_file
+) -> None:
+    headers = make_auth_header()
+    # Set an initial value.
+    await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={"description": "Wiring guide"},
+        headers=headers,
+    )
+    # PUT an empty body — no field included means no change.
+    resp = await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "Wiring guide"
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_update_file_description(
+    client, project_id, uploaded_file
+) -> None:
+    other = make_auth_header("intruder")
+    resp = await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={"description": "Hijacked!"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_public_list_surfaces_file_description(
+    client, project_id, uploaded_file
+) -> None:
+    """Anonymous GET of the file list shows the description for files that
+    have one set — the public view page reads exactly this response."""
+    headers = make_auth_header()
+    await client.put(
+        f"/api/projects/{project_id}/files/{uploaded_file}",
+        json={"description": "Drill template (PDF)"},
+        headers=headers,
+    )
+    # No auth header — same shape the public view page hits.
+    resp = await client.get(f"/api/projects/{project_id}/files")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert any(
+        r["id"] == uploaded_file and r["description"] == "Drill template (PDF)"
+        for r in rows
+    )

--- a/web/assets/css/project-editor.css
+++ b/web/assets/css/project-editor.css
@@ -830,3 +830,31 @@ body:has(.CodeMirror-fullscreen) .col-lg-8 {
   gap: 0.25rem;
 }
 
+/* Issue #187: per-file descriptions in the Files & Models table.
+ * The cell wraps long text instead of stretching the column, and the
+ * clickable affordance gets a subtle hover state so users discover the
+ * inline-edit interaction. */
+#editor-files-section .file-description {
+  white-space: normal;
+  word-break: break-word;
+  max-width: 24em;
+}
+
+#editor-files-section .file-description .kr-file-desc {
+  display: inline-block;
+  min-width: 8em;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  cursor: text;
+}
+
+#editor-files-section .file-description .kr-file-desc:hover,
+#editor-files-section .file-description .kr-file-desc:focus {
+  background-color: rgba(13, 110, 253, 0.08);
+  outline: none;
+}
+
+#editor-files-section .file-description .kr-file-desc-input {
+  width: 100%;
+}
+

--- a/web/assets/js/project-editor.js
+++ b/web/assets/js/project-editor.js
@@ -1109,16 +1109,151 @@
     const files = await resp.json();
     const list = document.getElementById('file-list');
     if (files.length === 0) { list.innerHTML = ''; return; }
-    list.innerHTML = `<table class="table table-single table-narrow table-hover mb-0"><tbody>${files.map(f => `
-      <tr>
-        <td class="text-muted" style="width:20px"><i class="${fileIcon(f.filename)}"></i></td>
-        <td><a href="${API}/api/projects/${currentProject.id}/files/${f.id}/download">${f.filename}</a></td>
-        <td class="text-muted small">${fileKind(f.filename)}</td>
-        <td class="text-muted small text-end" style="width:70px">${(f.file_size / 1024).toFixed(1)} KB</td>
-        <td style="width:30px"><button class="btn btn-sm text-danger p-0" onclick="deleteFile(${f.id})"><i class="fas fa-trash fa-xs"></i></button></td>
-      </tr>
-    `).join('')}</tbody></table>`;
+    // Issue #187: render a Description column with an inline-editable
+    // cell. Click the muted placeholder ("Add a description…") or the
+    // existing text to flip into an input; Enter / blur saves; Escape
+    // cancels. Long descriptions wrap in the column via the
+    // .file-description CSS rule (max-width + word-break).
+    list.innerHTML = `<table class="table table-single table-narrow table-hover mb-0">
+      <thead>
+        <tr>
+          <th style="width:20px"></th>
+          <th>File</th>
+          <th>Description</th>
+          <th class="text-muted small">Kind</th>
+          <th class="text-muted small text-end" style="width:70px">Size</th>
+          <th style="width:30px"></th>
+        </tr>
+      </thead>
+      <tbody>${files.map(f => `
+        <tr data-file-id="${f.id}">
+          <td class="text-muted" style="width:20px"><i class="${fileIcon(f.filename)}"></i></td>
+          <td><a href="${API}/api/projects/${currentProject.id}/files/${f.id}/download">${escapeHtmlAttr(f.filename)}</a></td>
+          <td class="file-description" data-file-id="${f.id}">${renderFileDescription(f.description)}</td>
+          <td class="text-muted small">${fileKind(f.filename)}</td>
+          <td class="text-muted small text-end" style="width:70px">${(f.file_size / 1024).toFixed(1)} KB</td>
+          <td style="width:30px"><button class="btn btn-sm text-danger p-0" onclick="deleteFile(${f.id})"><i class="fas fa-trash fa-xs"></i></button></td>
+        </tr>
+      `).join('')}</tbody></table>`;
   }
+
+  // Render the description cell's "view" state — a span the user clicks
+  // to edit. Empty values get a muted placeholder so the affordance is
+  // discoverable; non-empty values render the description verbatim.
+  function renderFileDescription(desc) {
+    const hasText = desc != null && String(desc).length > 0;
+    if (hasText) {
+      return `<span class="kr-file-desc" tabindex="0" role="button"
+        title="Click to edit description">${escapeHtmlAttr(desc)}</span>`;
+    }
+    return `<span class="kr-file-desc text-muted fst-italic" tabindex="0"
+      role="button" title="Click to add a description"
+      data-empty="1">Add a description…</span>`;
+  }
+
+  // Track in-flight PUTs per row so a fast typer doesn't fire overlapping
+  // requests — serialise per-row by chaining onto the previous promise.
+  // Same idea as the BOM / links autosave debouncer.
+  const _fileDescSavePending = {};
+
+  async function saveFileDescription(fileId, newValue) {
+    if (!currentProject) return null;
+    const prev = _fileDescSavePending[fileId] || Promise.resolve();
+    const next = prev.then(async () => {
+      const resp = await apiFetch(
+        API + '/api/projects/' + currentProject.id + '/files/' + fileId,
+        {
+          method: 'PUT',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ description: newValue }),
+        }
+      );
+      if (!resp.ok) throw new Error('save failed: ' + resp.status);
+      return resp.json();
+    });
+    _fileDescSavePending[fileId] = next;
+    return next;
+  }
+
+  // Inline-edit handler: wired via event delegation on #file-list so it
+  // survives loadFiles() re-renders without re-binding listeners.
+  function setupFileDescriptionEditing() {
+    const list = document.getElementById('file-list');
+    if (!list || list.dataset.descBound === '1') return;
+    list.dataset.descBound = '1';
+
+    list.addEventListener('click', e => {
+      const span = e.target.closest('.kr-file-desc');
+      if (!span) return;
+      // Already editing? Don't re-enter.
+      if (span.dataset.editing === '1') return;
+      beginFileDescriptionEdit(span);
+    });
+    list.addEventListener('keydown', e => {
+      const span = e.target.closest('.kr-file-desc');
+      if (!span || span.dataset.editing === '1') return;
+      // Enter / Space activates the editor for keyboard users.
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        beginFileDescriptionEdit(span);
+      }
+    });
+  }
+
+  function beginFileDescriptionEdit(span) {
+    const cell = span.closest('.file-description');
+    if (!cell) return;
+    const fileId = parseInt(cell.dataset.fileId, 10);
+    if (!Number.isFinite(fileId)) return;
+    const original = span.dataset.empty === '1' ? '' : (span.textContent || '');
+    span.dataset.editing = '1';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'form-control form-control-sm kr-file-desc-input';
+    input.value = original;
+    input.maxLength = 2000;
+    input.placeholder = 'Describe this file…';
+    cell.innerHTML = '';
+    cell.appendChild(input);
+    input.focus();
+    input.select();
+
+    let finished = false;
+    const finish = async (commit) => {
+      if (finished) return;
+      finished = true;
+      if (!commit) {
+        cell.innerHTML = renderFileDescription(original || null);
+        return;
+      }
+      const next = input.value;
+      if (next === original) {
+        cell.innerHTML = renderFileDescription(original || null);
+        return;
+      }
+      // Optimistic re-render with the new value; if the save fails the
+      // reload at the end of the catch reconciles with the server.
+      cell.innerHTML = renderFileDescription(next || null);
+      try {
+        await saveFileDescription(fileId, next);
+      } catch (_) {
+        loadFiles();
+      }
+    };
+
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+      else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+    });
+    input.addEventListener('blur', () => finish(true));
+  }
+
+  // Bind the delegated handler once at module init — the file-list
+  // element exists from page load even before any files have been
+  // uploaded.
+  setupFileDescriptionEditing();
 
   window.deleteFile = async function(fileId) {
     await apiFetch(API + '/api/projects/' + currentProject.id + '/files/' + fileId, {

--- a/web/projects/view.html
+++ b/web/projects/view.html
@@ -1279,7 +1279,10 @@ description: View project details
     document.getElementById('view-files').innerHTML = `<table class="table table-single table-narrow table-hover mb-0"><tbody>${files.map(f => `
       <tr>
         <td class="text-muted" style="width:20px"><i class="${fIcon(f.filename)}"></i></td>
-        <td><a href="${API}/api/projects/${projectId}/files/${f.id}/download">${esc(f.filename)}</a></td>
+        <td>
+          <a href="${API}/api/projects/${projectId}/files/${f.id}/download">${esc(f.filename)}</a>
+          ${f.description ? `<small class="text-muted d-block">${esc(f.description)}</small>` : ''}
+        </td>
         <td class="text-muted small">${fKind(f.filename)}</td>
         <td class="text-muted small text-end" style="width:90px" title="Downloads"><i class="fas fa-download"></i> ${(f.download_count || 0)}</td>
         <td class="text-muted small text-end" style="width:70px">${(f.file_size / 1024).toFixed(1)} KB</td>


### PR DESCRIPTION
## Summary

Closes #187.

- Adds a per-file `description` column to `project_files`. The ORM already declared the column (back to scaffold #93), but the idempotent ALTER helper `add_project_file_description_if_missing` is added defensively per the CLAUDE.md pattern so any legacy DB that drifted picks it up on next deploy.
- `PUT /api/projects/{pid}/files/{fid}` now accepts `description` as a partial-update field (mirrors `LinkUpdate` semantics: `exclude_unset` leaves untouched, `""` explicit-clears). Owner + T&Cs gating unchanged.
- Editor's Files & Models table gains a Description column between filename and kind. Click to edit, **Enter** or **blur** to autosave, **Escape** cancels. Empty rows show a muted "Add a description…" placeholder.
- Long descriptions wrap in the column via CSS (`max-width: 24em` + `word-break: break-word`) — they don't stretch the table.
- Public `view.html` files list surfaces non-empty descriptions as a muted sub-line under each filename.

## Test plan

- [x] `pytest tests/test_files_images.py` — 15 passed (6 new description tests)
- [x] `pytest tests/` — 438 passed, no regressions
- [x] `node --check web/assets/js/project-editor.js`
- [ ] Editor: upload a file, click description cell, type, Enter → persists across reload.
- [ ] Editor: click description, Escape → no PUT fires.
- [ ] Long description (>100 chars) wraps in the column rather than stretching it.
- [ ] Public view page shows the description as a muted sub-line under each filename.
- [ ] Anonymous GET `/api/projects/{id}/files` returns description for files that have one.

## Notes

- The "downloads" column the issue mentioned exists on the public view page, not the editor. Description went into the editor's existing 5-column layout (icon / filename / kind / size / trash) between filename and kind — didn't expand scope to add a downloads column.
- Semantic for `description=""` vs `description=null` documented at the top of the new tests: explicit `""` clears, omitting the key leaves existing untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)