### PR TITLE
feat(instructions): B3 — step types (photo/schematic/text/video/blank)

### DIFF
--- a/stacks/projects-api/projects_api/db.py
+++ b/stacks/projects-api/projects_api/db.py
@@ -951,6 +951,86 @@ async def add_user_currency_preference_if_missing() -> None:
             ))
 
 
+async def add_instruction_step_type_if_missing() -> None:
+    """Additive migration for B3 (instruction step types).
+
+    Adds ``step_type`` / ``body`` / ``video_url`` / ``schematic_id`` columns
+    to ``instruction_steps``. Postgres only; no-op on SQLite test DB which
+    is recreated from Base.metadata.create_all per test.
+
+    Each ALTER is independently IF NOT EXISTS so re-runs are safe.
+    The step_type default is ``'photo'`` so existing rows backfill
+    correctly under both NOT NULL and the default clause.
+
+    Idempotent: probing ``information_schema.columns`` before each ALTER
+    means calling this helper a second time is a cheap series of SELECTs
+    with no writes — see ``test_step_type_migration_helper_is_idempotent``
+    in ``tests/test_instructions.py``.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.begin() as conn:
+        table_check = await conn.execute(text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = 'instruction_steps'"
+        ))
+        if table_check.first() is None:
+            # Brand-new deployment — create_all on the same startup pass
+            # will build the table with every column already present.
+            return
+
+        existing = await conn.execute(text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = 'instruction_steps'"
+        ))
+        cols = {row[0] for row in existing.fetchall()}
+
+        # Each ALTER in its own try block so a failure on one doesn't
+        # abort the others. The NOT NULL + default on step_type means
+        # legacy rows without the column backfill to 'photo' atomically
+        # as part of the ALTER.
+        if "step_type" not in cols:
+            try:
+                logger.warning("Adding instruction_steps.step_type column (B3)")
+                await conn.execute(text(
+                    'ALTER TABLE "instruction_steps" ADD COLUMN IF NOT EXISTS '
+                    '"step_type" VARCHAR(20) NOT NULL DEFAULT \'photo\''
+                ))
+            except Exception as exc:  # noqa: BLE001 — log + continue
+                logger.warning("Failed to add instruction_steps.step_type: %s", exc)
+        if "body" not in cols:
+            try:
+                logger.warning("Adding instruction_steps.body column (B3)")
+                await conn.execute(text(
+                    'ALTER TABLE "instruction_steps" ADD COLUMN IF NOT EXISTS '
+                    '"body" TEXT'
+                ))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to add instruction_steps.body: %s", exc)
+        if "video_url" not in cols:
+            try:
+                logger.warning("Adding instruction_steps.video_url column (B3)")
+                await conn.execute(text(
+                    'ALTER TABLE "instruction_steps" ADD COLUMN IF NOT EXISTS '
+                    '"video_url" VARCHAR(500)'
+                ))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to add instruction_steps.video_url: %s", exc)
+        if "schematic_id" not in cols:
+            try:
+                logger.warning("Adding instruction_steps.schematic_id column (B3)")
+                # No FK constraint here — the ``schematics`` table doesn't
+                # exist yet (lands in E2). The column lives so the API can
+                # round-trip values; the FK will be added by E2's helper.
+                await conn.execute(text(
+                    'ALTER TABLE "instruction_steps" ADD COLUMN IF NOT EXISTS '
+                    '"schematic_id" INTEGER'
+                ))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to add instruction_steps.schematic_id: %s", exc)
+
+
 async def add_project_file_description_if_missing() -> None:
     """Additive migration for issue #187 (per-file descriptions).
 

--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -17,6 +17,7 @@ from .db import (
     add_bom_currency_if_missing,
     add_bom_part_id_if_missing,
     add_bom_supplier_id_if_missing,
+    add_instruction_step_type_if_missing,
     add_part_category_family_if_missing,
     add_part_status_columns_if_missing,
     add_project_featured_columns_if_missing,
@@ -116,6 +117,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Issue #187: ensure project_files.description column exists on legacy
     # Postgres deployments. No-op on fresh deploys / SQLite tests.
     await add_project_file_description_if_missing()
+    # B3 (issue #178): ensure instruction_steps.step_type / body /
+    # video_url / schematic_id columns exist on legacy Postgres
+    # deployments. No-op on fresh deploys / SQLite tests.
+    await add_instruction_step_type_if_missing()
     # Issue #106: seed the badge catalog (idempotent upsert by slug).
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -303,6 +303,37 @@ class InstructionStep(Base):
     # Phase 1 will write Fabric.js canvas scene JSON here. Nullable so
     # Phase 0 text-only steps and Phase 1+ canvas steps coexist.
     canvas_json: Mapped[Optional[str]] = mapped_column(Text)
+    # B3: Step type discriminator. Values:
+    #   * ``photo``     — Fabric canvas with a drawn-on background image
+    #                     (the legacy default; existing rows backfill here).
+    #   * ``schematic`` — embedded project schematic (full editor lands in E2).
+    #   * ``text``      — rich-ish markdown body, no canvas.
+    #   * ``video``     — YouTube id or raw video URL.
+    #   * ``blank``     — empty canvas, annotations only.
+    # Validated at the Pydantic layer via a ``Literal[...]`` so a bad value
+    # 422s before reaching the DB. The default is preserved both at the
+    # ORM layer (``default=``) and at the SQL layer (``server_default=``)
+    # so legacy rows without the column backfill to ``"photo"``.
+    step_type: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        server_default="photo",
+        default="photo",
+    )
+    # Text step body. We deliberately store the raw markdown / plaintext
+    # here — server-side rendering is out of scope for B3, the frontend
+    # is responsible for any markdown rendering / sanitisation.
+    body: Mapped[Optional[str]] = mapped_column(Text)
+    # Video step URL — either a YouTube link / id or a raw video URL
+    # (e.g. an MP4 reachable via HTTPS). The frontend is responsible for
+    # extracting an embed id where applicable; we store whatever the
+    # client posted so changing the renderer doesn't require a migration.
+    video_url: Mapped[Optional[str]] = mapped_column(String(500))
+    # Schematic step — FK to the project's future schematic (E2). For B3
+    # the column lives but the FK constraint waits: SQLAlchemy treats a
+    # bare Integer column without ``ForeignKey`` as a plain int, which is
+    # what we want until the ``schematics`` table is introduced.
+    schematic_id: Mapped[Optional[int]] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/stacks/projects-api/projects_api/routers/instructions.py
+++ b/stacks/projects-api/projects_api/routers/instructions.py
@@ -260,6 +260,13 @@ async def add_step(
         title=body.title,
         description=body.description,
         canvas_json=body.canvas_json,
+        # B3: type discriminator + per-type fields. ``step_type`` defaults
+        # to "photo" at the schema layer so legacy clients (which don't
+        # send these fields) get the existing behaviour for free.
+        step_type=body.step_type,
+        body=body.body,
+        video_url=body.video_url,
+        schematic_id=body.schematic_id,
     )
     session.add(step)
     await session.commit()
@@ -364,6 +371,16 @@ async def delete_step(
 # a headless canvas runtime server-side) and POSTs the array here. We
 # stitch the PNGs into a layout-aware PDF with ReportLab and stream the
 # binary back.
+#
+# B3: with the new step types (text / video / schematic / blank) the
+# server doesn't actually know how to render anything other than a PNG
+# dataURL. That's deliberate — the export endpoints below stay
+# step_type-agnostic and render whatever PNG the frontend sends. The
+# frontend is responsible for pre-rendering text steps to a PNG of the
+# rendered text, video steps to a poster frame placeholder, blank steps
+# to an empty canvas, and schematic steps to a placeholder card. If a
+# future spec wants per-type server-side rendering it can layer on top
+# without changing this contract.
 #
 # Owner-only for now. A future Phase 2d could surface a public PDF on
 # view.html, but that requires server-side canvas rendering (e.g.

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -309,6 +309,12 @@ class InstructionStepCreate(BaseModel):
     title: Optional[str] = Field(None, max_length=200)
     description: Optional[str] = None
     canvas_json: Optional[str] = None
+    # B3: step type discriminator. Defaults to "photo" to preserve the
+    # legacy single-type behaviour for clients that don't set it.
+    step_type: Literal["photo", "schematic", "text", "video", "blank"] = "photo"
+    body: Optional[str] = None
+    video_url: Optional[str] = Field(None, max_length=500)
+    schematic_id: Optional[int] = None
 
 
 class InstructionStepUpdate(BaseModel):
@@ -318,12 +324,24 @@ class InstructionStepUpdate(BaseModel):
     target into the requested 1-based position and renumbers the survivors
     so the resulting sequence is 1..N gap-free. ``step_number`` must be
     >= 1; values larger than the current length clamp to "last".
+
+    B3: ``step_type`` is validated against the allowed set via
+    ``Literal[...]``. Passing an unrecognised value 422s before reaching
+    the DB; omitting the field leaves the current type untouched, which
+    keeps the partial-update semantics intact for callers only changing
+    title / description / canvas_json.
     """
 
     title: Optional[str] = Field(None, max_length=200)
     description: Optional[str] = None
     canvas_json: Optional[str] = None
     step_number: Optional[int] = Field(None, ge=1)
+    step_type: Optional[
+        Literal["photo", "schematic", "text", "video", "blank"]
+    ] = None
+    body: Optional[str] = None
+    video_url: Optional[str] = Field(None, max_length=500)
+    schematic_id: Optional[int] = None
 
 
 class InstructionStepResponse(BaseModel):
@@ -333,6 +351,13 @@ class InstructionStepResponse(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     canvas_json: Optional[str] = None
+    # B3: type-specific fields. ``step_type`` always populated (NOT NULL
+    # in the DB, defaults to "photo"); the other three are nullable and
+    # only meaningful when ``step_type`` matches.
+    step_type: str = "photo"
+    body: Optional[str] = None
+    video_url: Optional[str] = None
+    schematic_id: Optional[int] = None
     created_at: datetime
     updated_at: datetime
 

--- a/stacks/projects-api/tests/test_instructions.py
+++ b/stacks/projects-api/tests/test_instructions.py
@@ -418,3 +418,167 @@ async def test_write_without_terms_acceptance_returns_403(client) -> None:
         assert detail.get("detail") == "terms_not_accepted"
     finally:
         monkeypatch.undo()
+
+
+# --- B3: step types ------------------------------------------------------
+#
+# Step types are a discriminator field on InstructionStep that swaps the
+# editor's canvas area for different rendering modes (photo / schematic /
+# text / video / blank). The backend's job is to round-trip the type +
+# the per-type fields (``body``, ``video_url``, ``schematic_id``) and
+# 422 invalid types.
+
+
+@pytest.mark.asyncio
+async def test_step_default_type_is_photo(client, project_id) -> None:
+    """A newly created step has step_type='photo' so legacy clients that
+    don't send the field get the existing behaviour for free."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    resp = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "no type sent"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["step_type"] == "photo"
+    # The other type-specific fields default to None.
+    assert body["body"] is None
+    assert body["video_url"] is None
+    assert body["schematic_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_step_put_step_type_text_round_trips(client, project_id) -> None:
+    """PUT step_type='text' → response shows the new type; GET confirms
+    persistence across requests."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    create = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "starts as photo"},
+        headers=headers,
+    )
+    step_id = create.json()["id"]
+    assert create.json()["step_type"] == "photo"
+
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{step_id}",
+        json={"step_type": "text"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["step_type"] == "text"
+
+    # Re-GET to confirm the change was persisted, not just echoed.
+    steps = (
+        await client.get(f"/api/projects/{project_id}/instruction/steps")
+    ).json()
+    assert steps[0]["step_type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_step_put_step_type_invalid_returns_422(
+    client, project_id
+) -> None:
+    """An unrecognised step_type 422s at the Pydantic layer before
+    reaching the DB. Without this guard a typo would silently persist a
+    bogus value that the frontend wouldn't know how to render."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    create = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "one"},
+        headers=headers,
+    )
+    step_id = create.json()["id"]
+
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{step_id}",
+        json={"step_type": "invalid"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_step_put_body_round_trips_and_partial_update(
+    client, project_id
+) -> None:
+    """Setting ``body`` persists it; a subsequent PUT that omits body
+    leaves it untouched (partial-update semantics)."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    create = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "text step"},
+        headers=headers,
+    )
+    step_id = create.json()["id"]
+
+    # First PUT: set body.
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{step_id}",
+        json={"step_type": "text", "body": "# Hello"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["body"] == "# Hello"
+
+    # Second PUT: omit body — value should be unchanged.
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{step_id}",
+        json={"title": "renamed"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "renamed"
+    assert body["body"] == "# Hello"
+
+
+@pytest.mark.asyncio
+async def test_step_put_video_url_updates(client, project_id) -> None:
+    """PUT video_url updates the field. The server stores the raw URL —
+    the frontend is responsible for any youtube-id extraction."""
+    headers = make_auth_header()
+    await _create_instruction(client, project_id)
+    create = await client.post(
+        f"/api/projects/{project_id}/instruction/steps",
+        json={"title": "video step"},
+        headers=headers,
+    )
+    step_id = create.json()["id"]
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    resp = await client.put(
+        f"/api/projects/{project_id}/instruction/steps/{step_id}",
+        json={"step_type": "video", "video_url": url},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["step_type"] == "video"
+    assert body["video_url"] == url
+
+
+@pytest.mark.asyncio
+async def test_step_type_migration_helper_is_idempotent() -> None:
+    """The migration helper is callable twice in a row without side
+    effects. The second invocation is a no-op (every column already
+    exists when the table has been freshly built by ``create_all``).
+
+    Postgres-only behaviour, but the SQLite short-circuit is part of the
+    contract: calling the helper from the lifespan must be safe on every
+    dialect we run against (Postgres in prod, SQLite in tests).
+    """
+    from projects_api.db import add_instruction_step_type_if_missing
+
+    # Two calls back-to-back — the helper guards each ALTER behind an
+    # ``information_schema`` probe, so the second call walks the same
+    # probes and does no writes. We can't easily assert "no writes
+    # happened" but we *can* assert "no exception raised", which is the
+    # contract the lifespan relies on.
+    await add_instruction_step_type_if_missing()
+    await add_instruction_step_type_if_missing()

--- a/web/assets/css/instruction-builder.css
+++ b/web/assets/css/instruction-builder.css
@@ -1472,3 +1472,174 @@ body.instruction-builder-page > .container-fluid {
   .ib-inspector-hud { display: none !important; }
   .ib-image-toolbar { display: none !important; }
 }
+
+/* ====================================================================
+   B3: step types — picker radios + canvas-area alt views + filmstrip
+   badges. Designed to slot into the existing Schematic pane (formerly
+   "Circuit") without changing the rail layout.
+   ==================================================================== */
+
+/* Step-type radios in the Schematic pane. Each radio is a full-width
+   pill-ish row with an icon + label + small description. */
+.ib-step-type-radios {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ib-step-type-radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1.5px solid #dee2e6;
+  border-radius: 6px;
+  background: #f8f9fa;
+  cursor: pointer;
+  transition: border-color 0.1s, background 0.1s;
+  margin: 0;
+}
+.ib-step-type-radio:hover { background: #fff; border-color: #adb5bd; }
+.ib-step-type-radio input[type="radio"] { margin-top: 3px; flex: 0 0 auto; }
+.ib-step-type-radio:has(input:checked) {
+  border-color: var(--bs-primary, #c8312a);
+  background: #fff;
+}
+.ib-step-type-icon {
+  flex: 0 0 auto;
+  width: 18px;
+  text-align: center;
+  color: #495057;
+}
+.ib-step-type-radio:has(input:checked) .ib-step-type-icon {
+  color: var(--bs-primary, #c8312a);
+}
+.ib-step-type-label {
+  flex: 1;
+  font-size: 0.82rem;
+  line-height: 1.25;
+}
+.ib-step-type-label small { font-size: 0.7rem; }
+
+/* Schematic placeholder card in the Schematic pane. */
+.ib-step-schematic-card {
+  padding: 14px 12px;
+  background: #f0f4f9;
+  border: 1.5px dashed #adb5bd;
+  border-radius: 6px;
+  text-align: center;
+}
+.ib-step-schematic-icon {
+  font-size: 1.6rem;
+  color: #6c757d;
+  margin-bottom: 6px;
+}
+
+/* Text-step body input in the Schematic pane. */
+.ib-step-body-input { resize: vertical; font-family: inherit; font-size: 0.85rem; }
+
+/* Video-step URL input + preview in the Schematic pane. */
+.ib-step-video-preview { min-height: 0; }
+.ib-step-video-preview iframe.ib-step-video-iframe,
+.ib-step-video-preview video.ib-step-video-el {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  background: #000;
+}
+
+/* Canvas-area alt views — same outer shape as ib-canvas-frame so the
+   slideshow / canvas region keeps a stable footprint. */
+.ib-canvas-text,
+.ib-canvas-video,
+.ib-canvas-schematic {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  overflow: auto;
+}
+.ib-canvas-text-inner {
+  width: 100%;
+  max-width: 720px;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 24px 28px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}
+.ib-canvas-text-empty {
+  text-align: center;
+  color: #adb5bd;
+  font-size: 1rem;
+}
+.ib-canvas-text-empty i { display: block; font-size: 1.6rem; }
+.ib-canvas-text-body {
+  /* Preserve line breaks from the raw body without re-implementing
+     markdown. textContent + this CSS = readable plain-text steps. */
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #212529;
+}
+
+.ib-canvas-video-inner {
+  width: 100%;
+  max-width: 960px;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ib-canvas-video-iframe,
+.ib-canvas-video-el {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+.ib-canvas-video-empty {
+  color: #adb5bd;
+  text-align: center;
+}
+.ib-canvas-video-empty i { display: block; font-size: 1.6rem; margin-bottom: 6px; }
+
+.ib-canvas-schematic-inner {
+  text-align: center;
+  background: #fff;
+  border: 1.5px dashed #adb5bd;
+  border-radius: 8px;
+  padding: 36px 32px;
+  max-width: 480px;
+}
+.ib-canvas-schematic-icon {
+  font-size: 2.4rem;
+  color: #6c757d;
+  margin-bottom: 8px;
+}
+
+/* Filmstrip thumb type badges — small pill top-right of each tile. */
+.ib-step-tile-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 999px;
+  color: #6c757d;
+  font-size: 0.6rem;
+  pointer-events: none;
+}
+.ib-step-tile.is-active .ib-step-tile-badge {
+  border-color: var(--bs-primary, #c8312a);
+  color: var(--bs-primary, #c8312a);
+}

--- a/web/assets/css/instruction-viewer.css
+++ b/web/assets/css/instruction-viewer.css
@@ -300,3 +300,65 @@
     font-size: 1.1rem;
   }
 }
+
+/* --- B3: step type slot styles ------------------------------------
+   Text / video / schematic step types render via DOM elements inside
+   the same stage slot the photo step uses, so they pick up the
+   surrounding chrome (prev / next / dots / fullscreen) for free.
+   ------------------------------------------------------------------ */
+
+.iv-text-card {
+  width: 100%;
+  height: 100%;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 32px;
+  overflow: auto;
+}
+.iv-text-body {
+  max-width: 720px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: #212529;
+}
+.iv-text-empty {
+  color: #adb5bd;
+  font-size: 1.25rem;
+  text-align: center;
+}
+
+.iv-video-wrap {
+  width: 100%;
+  height: 100%;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.iv-video-iframe,
+.iv-video-el {
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+  border: 0;
+}
+
+.iv-schematic-card {
+  width: 100%;
+  height: 100%;
+  background: #f0f4f9;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 32px;
+  color: #495057;
+}
+.iv-schematic-icon { font-size: 3rem; color: #6c757d; margin-bottom: 12px; }
+.iv-schematic-title { font-size: 1.2rem; font-weight: 600; margin-bottom: 6px; }
+.iv-schematic-desc { max-width: 480px; color: #6c757d; font-size: 0.95rem; }

--- a/web/assets/js/instruction-builder.js
+++ b/web/assets/js/instruction-builder.js
@@ -180,6 +180,20 @@
     dom.canvasEl = document.getElementById('ib-canvas');
     dom.canvasFrame = document.getElementById('ib-canvas-frame');
     dom.canvasEmpty = document.getElementById('ib-canvas-empty');
+    // B3: alternate canvas-area views, one per non-photo step type.
+    dom.canvasText = document.getElementById('ib-canvas-text');
+    dom.canvasTextEmpty = document.getElementById('ib-canvas-text-empty');
+    dom.canvasTextBody = document.getElementById('ib-canvas-text-body');
+    dom.canvasVideo = document.getElementById('ib-canvas-video');
+    dom.canvasVideoInner = document.getElementById('ib-canvas-video-inner');
+    dom.canvasSchematic = document.getElementById('ib-canvas-schematic');
+
+    // Schematic pane (step-type picker)
+    dom.stepTypeRadios = document.querySelectorAll('input[name="ib-step-type"]');
+    dom.stepTypeConfigs = document.querySelectorAll('.ib-step-type-config');
+    dom.stepBodyInput = document.getElementById('ib-step-body-input');
+    dom.stepVideoInput = document.getElementById('ib-step-video-input');
+    dom.stepVideoPreview = document.getElementById('ib-step-video-preview');
     dom.inspectorHud = document.getElementById('ib-inspector-hud');
     dom.hudHeader = document.getElementById('ib-hud-header');
     dom.hudBody = document.getElementById('ib-hud-body');
@@ -976,6 +990,302 @@
               });
             })
             .catch(function () { setSaveStatus('error', 'Description save failed'); });
+        });
+      });
+    }
+  }
+
+  // ====================================================================
+  // 10b. STEP TYPES (B3) — type picker + canvas-area swap + per-type
+  //      body / video URL persistence. Lives next to wireStepFields
+  //      because it shares the autosave + step-undo plumbing.
+  // ====================================================================
+
+  // The five valid step types. Anything not in this set is treated as
+  // 'photo' (the legacy default + back-end fall-through).
+  var STEP_TYPES = ['photo', 'schematic', 'text', 'video', 'blank'];
+
+  // Track focus values for the body / video inputs so we only push a
+  // step-undo entry when the field actually changed. Mirrors the
+  // existing stepFieldFocusValues pattern for title / description.
+  var stepTypeFocusValues = { body: null, videoUrl: null, stepId: null };
+
+  function currentStepTypeOf(step) {
+    if (!step) return 'photo';
+    var t = step.step_type;
+    return STEP_TYPES.indexOf(t) >= 0 ? t : 'photo';
+  }
+
+  function activeStepObject() {
+    if (!state.activeStepId) return null;
+    return state.steps.find(function (s) { return s.id === state.activeStepId; });
+  }
+
+  // Extract a YouTube video id from any of the common URL shapes; null
+  // for non-YouTube URLs (which renders as a raw <video controls>).
+  function extractYouTubeId(url) {
+    if (!url) return null;
+    var m = String(url).match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([\w-]{11})/);
+    return m ? m[1] : null;
+  }
+
+  // Update the canvas area's visibility per step type. The Fabric
+  // canvas frame stays in the DOM in every case (so the rest of the
+  // builder still has something to reference) — we just hide it for
+  // text / video / schematic and show the corresponding alt panel.
+  function applyCanvasAreaForType(stepType) {
+    var fabricVisible = (stepType === 'photo' || stepType === 'blank');
+    if (dom.canvasFrame) dom.canvasFrame.classList.toggle('d-none', !fabricVisible);
+    if (dom.canvasText) dom.canvasText.classList.toggle('d-none', stepType !== 'text');
+    if (dom.canvasVideo) dom.canvasVideo.classList.toggle('d-none', stepType !== 'video');
+    if (dom.canvasSchematic) dom.canvasSchematic.classList.toggle('d-none', stepType !== 'schematic');
+    // Fabric tracks the CSS size of the canvas; if we just toggled
+    // visibility, give it a moment to settle and re-measure so pointer
+    // events map to the right scene coords.
+    if (fabricVisible) setTimeout(syncCanvasDisplaySize, 50);
+  }
+
+  // Apply the text-step body to the read-only preview slot in the
+  // canvas area. Plain-text rendering for B3 — markdown is acceptable
+  // for a follow-up. We render via textContent on a <pre>-ish element
+  // so we don't have to sanitise.
+  function renderCanvasTextBody(step) {
+    if (!dom.canvasTextBody || !dom.canvasTextEmpty) return;
+    var body = (step && step.body) || '';
+    if (!body.trim()) {
+      dom.canvasTextEmpty.classList.remove('d-none');
+      dom.canvasTextBody.classList.add('d-none');
+      dom.canvasTextBody.textContent = '';
+    } else {
+      dom.canvasTextEmpty.classList.add('d-none');
+      dom.canvasTextBody.classList.remove('d-none');
+      // Plain-text body for B3 — preserve line breaks via white-space CSS.
+      dom.canvasTextBody.textContent = body;
+    }
+  }
+
+  // Build the video embed inside the canvas area for video steps.
+  // YouTube → iframe, raw URLs → <video controls>, empty / unrecognised
+  // → empty-state placeholder.
+  function renderCanvasVideo(step) {
+    if (!dom.canvasVideoInner) return;
+    var url = (step && step.video_url) || '';
+    if (!url) {
+      dom.canvasVideoInner.innerHTML =
+        '<div class="ib-canvas-video-empty">' +
+        '  <i class="fas fa-video mb-2"></i>' +
+        '  <p class="mb-0">Paste a YouTube or MP4 URL in the <strong>Schematic</strong> pane.</p>' +
+        '</div>';
+      return;
+    }
+    var ytId = extractYouTubeId(url);
+    if (ytId) {
+      dom.canvasVideoInner.innerHTML =
+        '<iframe class="ib-canvas-video-iframe" ' +
+        '        src="https://www.youtube.com/embed/' + encodeURIComponent(ytId) + '" ' +
+        '        title="YouTube video" ' +
+        '        frameborder="0" ' +
+        '        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ' +
+        '        allowfullscreen></iframe>';
+    } else {
+      dom.canvasVideoInner.innerHTML =
+        '<video class="ib-canvas-video-el" controls preload="metadata" src="' + escapeHtml(url) + '"></video>';
+    }
+  }
+
+  // Build the small video preview inside the Schematic pane (below the
+  // URL input). Same id-extraction as the canvas-area renderer but
+  // styled smaller. Empty for an empty URL.
+  function renderVideoPreview(url) {
+    if (!dom.stepVideoPreview) return;
+    url = (url || '').trim();
+    if (!url) {
+      dom.stepVideoPreview.innerHTML = '';
+      return;
+    }
+    var ytId = extractYouTubeId(url);
+    if (ytId) {
+      dom.stepVideoPreview.innerHTML =
+        '<iframe class="ib-step-video-iframe" ' +
+        '        src="https://www.youtube.com/embed/' + encodeURIComponent(ytId) + '" ' +
+        '        title="YouTube preview" ' +
+        '        frameborder="0" allowfullscreen></iframe>';
+    } else if (/\.(mp4|webm|ogg)(\?|$)/i.test(url)) {
+      dom.stepVideoPreview.innerHTML =
+        '<video class="ib-step-video-el" controls preload="metadata" src="' + escapeHtml(url) + '"></video>';
+    } else {
+      dom.stepVideoPreview.innerHTML =
+        '<p class="small text-muted mb-0"><i class="fas fa-info-circle me-1"></i>' +
+        'URL doesn\'t look like a YouTube link or a video file — saved verbatim.</p>';
+    }
+  }
+
+  // Sync the type-picker pane's controls to the currently-active step.
+  // Called whenever the active step changes (switchToStep, init, etc.).
+  function syncStepTypePane() {
+    var step = activeStepObject();
+    var stepType = currentStepTypeOf(step);
+
+    // Radios
+    Array.prototype.forEach.call(dom.stepTypeRadios || [], function (input) {
+      input.checked = (input.value === stepType);
+    });
+
+    // Per-type config sections
+    Array.prototype.forEach.call(dom.stepTypeConfigs || [], function (section) {
+      section.classList.toggle('d-none', section.dataset.config !== stepType);
+    });
+
+    // Text body input
+    if (dom.stepBodyInput) {
+      dom.stepBodyInput.value = (step && step.body) || '';
+    }
+
+    // Video URL input + preview
+    if (dom.stepVideoInput) {
+      dom.stepVideoInput.value = (step && step.video_url) || '';
+    }
+    renderVideoPreview(step && step.video_url);
+
+    // Canvas area visibility
+    applyCanvasAreaForType(stepType);
+    if (stepType === 'text') renderCanvasTextBody(step);
+    if (stepType === 'video') renderCanvasVideo(step);
+  }
+
+  async function onStepTypeChange(newType) {
+    if (STEP_TYPES.indexOf(newType) < 0) return;
+    var step = activeStepObject();
+    if (!step) return;
+    var stepId = step.id;
+    var priorType = currentStepTypeOf(step);
+    if (priorType === newType) return;
+
+    setSaveStatus('saving', 'Saving…');
+    try {
+      // NB: we intentionally don't clear canvas_json when switching to
+      // text / video / schematic — flipping back to photo or blank
+      // restores any overlays the user had drawn. Same goes for body /
+      // video_url across the other direction.
+      var updated = await putStep(stepId, { step_type: newType });
+      // Update local cache.
+      step.step_type = updated.step_type;
+      setSaveStatus('saved');
+      syncStepTypePane();
+      renderFilmstrip();
+      pushStepUndo({
+        type: 'change-step-type',
+        apply: async function () {
+          var reverted = await putStep(stepId, { step_type: priorType });
+          var s = state.steps.find(function (x) { return x.id === stepId; });
+          if (s) s.step_type = reverted.step_type;
+          if (state.activeStepId === stepId) syncStepTypePane();
+          renderFilmstrip();
+          return 'Undid: changed step type';
+        },
+      });
+    } catch (_) {
+      setSaveStatus('error', 'Change step type failed');
+    }
+  }
+
+  function wireStepTypePane() {
+    // Radios — change fires immediately (no debounce; type switch is a
+    // single coarse-grained user action, not a stream of inputs).
+    Array.prototype.forEach.call(dom.stepTypeRadios || [], function (input) {
+      input.addEventListener('change', function () {
+        if (!input.checked) return;
+        onStepTypeChange(input.value);
+      });
+    });
+
+    // Text body — autosave on blur (debounce 500ms so a quick blur into
+    // a re-focus doesn't fire a save). Mirrors the existing
+    // wireStepFields pattern for title / description.
+    if (dom.stepBodyInput) {
+      dom.stepBodyInput.addEventListener('focus', function () {
+        stepTypeFocusValues.stepId = state.activeStepId;
+        stepTypeFocusValues.body = dom.stepBodyInput.value || '';
+      });
+      dom.stepBodyInput.addEventListener('blur', function () {
+        if (!state.activeStepId) return;
+        debounce('step-body', 500, function () {
+          var stepId = state.activeStepId;
+          var value = dom.stepBodyInput.value || null;
+          var prior = stepTypeFocusValues.stepId === stepId
+            ? stepTypeFocusValues.body
+            : null;
+          if ((prior || '') === (value || '')) return;
+          setSaveStatus('saving', 'Saving…');
+          putStep(stepId, { body: value })
+            .then(function (updated) {
+              var s = state.steps.find(function (x) { return x.id === stepId; });
+              if (s) s.body = updated.body;
+              if (state.activeStepId === stepId) renderCanvasTextBody(s);
+              setSaveStatus('saved');
+              pushStepUndo({
+                type: 'edit-body',
+                apply: async function () {
+                  await putStep(stepId, { body: prior || null });
+                  var s2 = state.steps.find(function (x) { return x.id === stepId; });
+                  if (s2) s2.body = prior || null;
+                  if (state.activeStepId === stepId && dom.stepBodyInput) {
+                    dom.stepBodyInput.value = prior || '';
+                  }
+                  if (state.activeStepId === stepId) renderCanvasTextBody(s2);
+                  return 'Undid: edited body';
+                },
+              });
+            })
+            .catch(function () { setSaveStatus('error', 'Body save failed'); });
+        });
+      });
+    }
+
+    // Video URL — same blur-save pattern; also re-renders the preview
+    // live on input so the user gets visual feedback before saving.
+    if (dom.stepVideoInput) {
+      dom.stepVideoInput.addEventListener('input', function () {
+        renderVideoPreview(dom.stepVideoInput.value);
+      });
+      dom.stepVideoInput.addEventListener('focus', function () {
+        stepTypeFocusValues.stepId = state.activeStepId;
+        stepTypeFocusValues.videoUrl = dom.stepVideoInput.value || '';
+      });
+      dom.stepVideoInput.addEventListener('blur', function () {
+        if (!state.activeStepId) return;
+        debounce('step-video', 500, function () {
+          var stepId = state.activeStepId;
+          var value = dom.stepVideoInput.value || null;
+          var prior = stepTypeFocusValues.stepId === stepId
+            ? stepTypeFocusValues.videoUrl
+            : null;
+          if ((prior || '') === (value || '')) return;
+          setSaveStatus('saving', 'Saving…');
+          putStep(stepId, { video_url: value })
+            .then(function (updated) {
+              var s = state.steps.find(function (x) { return x.id === stepId; });
+              if (s) s.video_url = updated.video_url;
+              if (state.activeStepId === stepId) renderCanvasVideo(s);
+              setSaveStatus('saved');
+              pushStepUndo({
+                type: 'edit-video-url',
+                apply: async function () {
+                  await putStep(stepId, { video_url: prior || null });
+                  var s2 = state.steps.find(function (x) { return x.id === stepId; });
+                  if (s2) s2.video_url = prior || null;
+                  if (state.activeStepId === stepId && dom.stepVideoInput) {
+                    dom.stepVideoInput.value = prior || '';
+                  }
+                  if (state.activeStepId === stepId) {
+                    renderVideoPreview(prior);
+                    renderCanvasVideo(s2);
+                  }
+                  return 'Undid: edited video URL';
+                },
+              });
+            })
+            .catch(function () { setSaveStatus('error', 'Video URL save failed'); });
         });
       });
     }
@@ -1856,16 +2166,37 @@
   // 19. FILMSTRIP — step thumbnails, reorder, add, collapse
   // ====================================================================
 
+  // B3: per-type badge for the filmstrip thumb. Returns an HTML snippet
+  // (the icon-only pill) or empty string for the blank type, which is
+  // unbadged by design (it's the same as photo-without-bg visually).
+  function stepTypeBadgeHtml(stepType) {
+    var iconMap = {
+      photo: 'fa-image',
+      schematic: 'fa-diagram-project',
+      text: 'fa-pen-to-square',
+      video: 'fa-video',
+    };
+    var icon = iconMap[stepType];
+    if (!icon) return '';  // blank or unknown → no badge
+    return (
+      '<span class="ib-step-tile-badge" title="' + escapeHtml(stepType) + '">' +
+      '<i class="fas ' + icon + '"></i>' +
+      '</span>'
+    );
+  }
+
   function renderFilmstrip() {
     if (!dom.filmstripTrack) return;
     var html = state.steps.map(function (s) {
       var isActive = (s.id === state.activeStepId);
       var caption = (s.title && s.title.trim()) ? s.title : 'Untitled';
+      var badge = stepTypeBadgeHtml(currentStepTypeOf(s));
       return (
         '<div class="ib-step-tile' + (isActive ? ' is-active' : '') + '"' +
         '     draggable="true"' +
         '     data-step-id="' + s.id + '">' +
         '  <div class="ib-step-tile-num">' + s.step_number + '</div>' +
+        badge +
         '  <div class="ib-step-tile-preview">' +
         '    <span>step ' + s.step_number + '</span>' +
         '  </div>' +
@@ -1992,6 +2323,8 @@
     if (dom.stepDescription) dom.stepDescription.value = step.description || '';
 
     await loadCanvasFromStep(step);
+    // B3: refresh the step-type pane + canvas-area swap for this step.
+    syncStepTypePane();
     renderFilmstrip();
     renderLayersList();
   }
@@ -4042,6 +4375,9 @@
     initCanvas();
     wireToolbar();
     wireStepFields();
+    // B3: step-type picker + per-type field handlers. Lives next to
+    // wireStepFields because it shares the autosave + step-undo paths.
+    wireStepTypePane();
     wireExportMenu();
     wireRail();
     wireSecondaryResize();
@@ -4070,6 +4406,8 @@
     if (dom.stepDescription) dom.stepDescription.value = state.steps[0].description || '';
     renderFilmstrip();
     await loadCanvasFromStep(state.steps[0]);
+    // B3: apply the initial step's type to the picker pane + canvas area.
+    syncStepTypePane();
 
     // Prime the Photos pane content even if it isn't visible — the first
     // user click into it should feel instant.

--- a/web/assets/js/instruction-viewer.js
+++ b/web/assets/js/instruction-viewer.js
@@ -106,11 +106,21 @@
           return (a.step_number || 0) - (b.step_number || 0);
         });
         state.steps = sorted.map(function (s, i) {
+          // B3: carry through the step_type discriminator + per-type
+          // fields so the slideshow renderer can swap behaviour. Unknown
+          // / missing types default to 'photo' (the legacy behaviour).
+          var stepType = s.step_type;
+          if (['photo', 'schematic', 'text', 'video', 'blank'].indexOf(stepType) < 0) {
+            stepType = 'photo';
+          }
           return {
             step_number: s.step_number || (i + 1),
             title: s.title || ('Step ' + (s.step_number || (i + 1))),
             description: s.description || '',
             canvas_json: s.canvas_json || null,
+            step_type: stepType,
+            body: s.body || '',
+            video_url: s.video_url || '',
             image: null,
           };
         });
@@ -187,14 +197,27 @@
     }
   }
 
+  // B3: photo + blank steps want a canvas pre-render to PNG. The other
+  // types (text / video / schematic) render inline via DOM elements at
+  // showStep time, so they don't need Fabric. This helper centralises
+  // the decision so prerenderAll + renderStep agree on what gets
+  // pre-rendered.
+  function stepNeedsCanvasPrerender(step) {
+    if (step.step_type === 'text' || step.step_type === 'video' || step.step_type === 'schematic') {
+      return false;
+    }
+    // photo + blank — pre-render iff there's actual canvas content. A
+    // blank step with no annotations falls through to the placeholder.
+    return parseCanvasJson(step.canvas_json) !== null;
+  }
+
   // Pre-render each step to a PNG dataURL. We lazy-load Fabric here
   // because everything before this point can be done without it.
   function prerenderAll() {
     // Are there any steps that actually need Fabric? If every step is
-    // text-only we don't need to fetch the library at all.
-    var needsFabric = state.steps.some(function (s) {
-      return parseCanvasJson(s.canvas_json) !== null;
-    });
+    // text / video / schematic / placeholder-blank we don't need to
+    // fetch the library at all.
+    var needsFabric = state.steps.some(stepNeedsCanvasPrerender);
 
     if (!needsFabric) {
       // All steps are placeholder-only — image stays null on each.
@@ -246,6 +269,11 @@
   }
 
   function renderStep(off, step) {
+    // B3: non-canvas types skip pre-render entirely — they render via
+    // DOM elements at showStep time.
+    if (!stepNeedsCanvasPrerender(step)) {
+      return Promise.resolve(null);
+    }
     var parsed = parseCanvasJson(step.canvas_json);
     if (!parsed) {
       // Text-only step — leave image=null; the slideshow renders the
@@ -307,6 +335,106 @@
 
   // -------- Slideshow render ---------------------------------------------
 
+  // B3: extract the YouTube video id from any of the common URL shapes;
+  // returns null for non-YouTube URLs (which render via <video controls>).
+  function extractYouTubeId(url) {
+    if (!url) return null;
+    var m = String(url).match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([\w-]{11})/);
+    return m ? m[1] : null;
+  }
+
+  // Build the stage content for a given step. The slideshow controls
+  // (prev / next / dots / keyboard / swipe / fullscreen) are shared
+  // across step types — only the stage child element changes.
+  function buildStageContent(step) {
+    var stepType = step.step_type || 'photo';
+
+    if (stepType === 'text') {
+      var card = document.createElement('div');
+      card.className = 'iv-text-card';
+      var body = (step.body || '').trim();
+      if (body) {
+        // Plain-text rendering for B3 — preserve line breaks via
+        // white-space: pre-wrap CSS rather than re-implementing
+        // markdown server-side. textContent + CSS is enough.
+        var pre = document.createElement('div');
+        pre.className = 'iv-text-body';
+        pre.textContent = body;
+        card.appendChild(pre);
+      } else {
+        // No body — render the step title as the only content so the
+        // slideshow shows *something* for this step.
+        var t = document.createElement('div');
+        t.className = 'iv-text-empty';
+        t.textContent = step.title || ('Step ' + step.step_number);
+        card.appendChild(t);
+      }
+      return card;
+    }
+
+    if (stepType === 'video') {
+      var wrap = document.createElement('div');
+      wrap.className = 'iv-video-wrap';
+      var url = (step.video_url || '').trim();
+      var ytId = extractYouTubeId(url);
+      if (ytId) {
+        var iframe = document.createElement('iframe');
+        iframe.className = 'iv-video-iframe';
+        iframe.src = 'https://www.youtube.com/embed/' + encodeURIComponent(ytId);
+        iframe.title = step.title || ('Step ' + step.step_number);
+        iframe.setAttribute('frameborder', '0');
+        iframe.setAttribute(
+          'allow',
+          'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+        );
+        iframe.setAttribute('allowfullscreen', '');
+        wrap.appendChild(iframe);
+      } else if (url) {
+        var video = document.createElement('video');
+        video.className = 'iv-video-el';
+        video.controls = true;
+        video.preload = 'metadata';
+        video.src = url;
+        wrap.appendChild(video);
+      } else {
+        var empty = document.createElement('div');
+        empty.className = 'iv-placeholder';
+        empty.textContent = 'No video set for this step.';
+        wrap.appendChild(empty);
+      }
+      return wrap;
+    }
+
+    if (stepType === 'schematic') {
+      var sch = document.createElement('div');
+      sch.className = 'iv-schematic-card';
+      sch.innerHTML =
+        '<i class="fas fa-diagram-project iv-schematic-icon"></i>' +
+        '<div class="iv-schematic-title">Embedded schematic</div>' +
+        '<div class="iv-schematic-desc">' +
+          'This step embeds the project schematic — visible once the schematic editor ships.' +
+        '</div>';
+      return sch;
+    }
+
+    // photo / blank — pre-rendered to PNG; if pre-render dropped (no
+    // canvas content), fall through to the placeholder panel.
+    if (step.image) {
+      var img = document.createElement('img');
+      img.src = step.image;
+      img.alt = step.title || ('Step ' + step.step_number);
+      img.loading = 'lazy';
+      return img;
+    }
+    var ph = document.createElement('div');
+    ph.className = 'iv-placeholder';
+    var phTitle = document.createElement('div');
+    phTitle.className = 'iv-placeholder-title';
+    phTitle.textContent = step.title || ('Step ' + step.step_number);
+    ph.appendChild(phTitle);
+    return ph;
+  }
+
   function showStep(idx) {
     if (idx < 0 || idx >= state.steps.length) return;
     state.activeIdx = idx;
@@ -314,26 +442,10 @@
     var total = state.steps.length;
 
     // Wipe whatever's in the stage and rebuild it for this step. The
-    // stage is small (one <img> or one placeholder div) so re-creating
-    // is cheaper than tracking which mode was previously rendered.
+    // stage is small (one DOM element) so re-creating is cheaper than
+    // tracking which mode was previously rendered.
     while (dom.stage.firstChild) dom.stage.removeChild(dom.stage.firstChild);
-
-    if (step.image) {
-      var img = document.createElement('img');
-      img.src = step.image;
-      img.alt = step.title || ('Step ' + step.step_number);
-      img.loading = 'lazy';
-      dom.stage.appendChild(img);
-    } else {
-      // Placeholder panel — step has no canvas content (text-only).
-      var ph = document.createElement('div');
-      ph.className = 'iv-placeholder';
-      var title = document.createElement('div');
-      title.className = 'iv-placeholder-title';
-      title.textContent = step.title || ('Step ' + step.step_number);
-      ph.appendChild(title);
-      dom.stage.appendChild(ph);
-    }
+    dom.stage.appendChild(buildStageContent(step));
 
     // Badge + meta + dots.
     if (dom.badge) {

--- a/web/projects/instructions/edit.html
+++ b/web/projects/instructions/edit.html
@@ -127,10 +127,14 @@ hide_nibsy: true
         <span class="ib-rail-icon"><i class="fas fa-puzzle-piece"></i></span>
         <span class="ib-rail-label">Assets</span>
       </button>
+      <!-- B3: the Schematic rail item is the step-type picker (the future
+           full schematic editor lands in E2). The label is "Schematic"
+           but the data-rail-pane key stays "circuit" for back-compat
+           with persisted UI state (kr-instructions-ui-state-v1). -->
       <button type="button" class="ib-rail-btn" data-rail-pane="circuit"
-              title="Circuit (Cmd/Ctrl+5)">
-        <span class="ib-rail-icon"><i class="fas fa-bolt"></i></span>
-        <span class="ib-rail-label">Circuit</span>
+              title="Schematic / step type (Cmd/Ctrl+5)">
+        <span class="ib-rail-icon"><i class="fas fa-diagram-project"></i></span>
+        <span class="ib-rail-label">Schematic</span>
       </button>
       <button type="button" class="ib-rail-btn" data-rail-pane="layers"
               title="Layers (Cmd/Ctrl+6)">
@@ -336,18 +340,113 @@ hide_nibsy: true
         </div>
       </section>
 
-      <!-- Circuit pane (stub) -->
+      <!-- Schematic / step-type pane (B3) — was the Circuit stub. The
+           pane key stays "circuit" so persisted UI state (which records
+           the active rail key in localStorage) keeps working. The
+           visible label + content are the step-type picker for the
+           currently-active step. -->
       <section class="ib-pane" data-pane="circuit">
         <header class="ib-pane-header">
-          <h6 class="ib-pane-title"><i class="fas fa-bolt me-2"></i>Circuit</h6>
+          <h6 class="ib-pane-title"><i class="fas fa-diagram-project me-2"></i>Schematic</h6>
         </header>
         <div class="ib-pane-body">
-          <div class="ib-pane-stub">
-            <div class="ib-pane-stub-icon"><i class="fas fa-bolt"></i></div>
-            <p>Circuit designer mode — separate handoff (issue #180).</p>
-            <p class="small text-muted">
-              Track progress at
-              <a href="https://github.com/kevinmcaleer/kevsrobots.com/issues/180" target="_blank" rel="noopener">issue #180</a>.
+          <div class="ib-pane-section">
+            <h6 class="ib-pane-section-title">Type — for this step</h6>
+            <div class="ib-step-type-radios" id="ib-step-type-radios" role="radiogroup"
+                 aria-label="Step type">
+              <label class="ib-step-type-radio">
+                <input type="radio" name="ib-step-type" value="photo" checked>
+                <span class="ib-step-type-icon"><i class="fas fa-image"></i></span>
+                <span class="ib-step-type-label">
+                  <strong>Photo</strong>
+                  <small class="text-muted d-block">Drawn-on background image (default).</small>
+                </span>
+              </label>
+              <label class="ib-step-type-radio">
+                <input type="radio" name="ib-step-type" value="schematic">
+                <span class="ib-step-type-icon"><i class="fas fa-diagram-project"></i></span>
+                <span class="ib-step-type-label">
+                  <strong>Schematic</strong>
+                  <small class="text-muted d-block">Embed the project schematic (E2).</small>
+                </span>
+              </label>
+              <label class="ib-step-type-radio">
+                <input type="radio" name="ib-step-type" value="text">
+                <span class="ib-step-type-icon"><i class="fas fa-pen-to-square"></i></span>
+                <span class="ib-step-type-label">
+                  <strong>Text</strong>
+                  <small class="text-muted d-block">Plain text, no canvas.</small>
+                </span>
+              </label>
+              <label class="ib-step-type-radio">
+                <input type="radio" name="ib-step-type" value="video">
+                <span class="ib-step-type-icon"><i class="fas fa-video"></i></span>
+                <span class="ib-step-type-label">
+                  <strong>Video</strong>
+                  <small class="text-muted d-block">YouTube / MP4 embed.</small>
+                </span>
+              </label>
+              <label class="ib-step-type-radio">
+                <input type="radio" name="ib-step-type" value="blank">
+                <span class="ib-step-type-icon"><i class="far fa-square"></i></span>
+                <span class="ib-step-type-label">
+                  <strong>Blank</strong>
+                  <small class="text-muted d-block">Empty canvas, annotations only.</small>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Per-type config — JS shows / hides the matching subsection
+               in sync with the radio selection. -->
+          <div class="ib-pane-section ib-step-type-config" data-config="photo">
+            <h6 class="ib-pane-section-title">Photo</h6>
+            <p class="ib-pane-hint text-muted small mb-0">
+              Upload or pick a background in the <strong>Photos</strong> pane.
+            </p>
+          </div>
+
+          <div class="ib-pane-section ib-step-type-config d-none" data-config="schematic">
+            <h6 class="ib-pane-section-title">Schematic</h6>
+            <div class="ib-step-schematic-card">
+              <div class="ib-step-schematic-icon"><i class="fas fa-diagram-project"></i></div>
+              <p class="mb-2"><strong>Embedded schematic</strong> — full editor (E2) coming soon.</p>
+              <p class="small text-muted mb-2">
+                The schematic linked to this project will appear here once the editor ships.
+              </p>
+              <button type="button" class="btn btn-sm btn-outline-secondary" disabled>
+                <i class="fas fa-pencil me-1"></i> open editor
+              </button>
+            </div>
+          </div>
+
+          <div class="ib-pane-section ib-step-type-config d-none" data-config="text">
+            <h6 class="ib-pane-section-title">Text</h6>
+            <textarea class="form-control form-control-sm ib-step-body-input"
+                      id="ib-step-body-input"
+                      rows="8"
+                      placeholder="Write the body of this text step…"></textarea>
+            <p class="ib-pane-hint text-muted small mt-2 mb-0">
+              Saved when you click outside the field. Markdown / plain text both work — the public viewer renders it as-is.
+            </p>
+          </div>
+
+          <div class="ib-pane-section ib-step-type-config d-none" data-config="video">
+            <h6 class="ib-pane-section-title">Video</h6>
+            <input type="url" class="form-control form-control-sm ib-step-video-input"
+                   id="ib-step-video-input"
+                   placeholder="YouTube URL or MP4 link…"
+                   maxlength="500">
+            <div class="ib-step-video-preview mt-2" id="ib-step-video-preview"></div>
+            <p class="ib-pane-hint text-muted small mt-2 mb-0">
+              YouTube watch links and short links are auto-extracted. Raw MP4 URLs play in a native video element.
+            </p>
+          </div>
+
+          <div class="ib-pane-section ib-step-type-config d-none" data-config="blank">
+            <h6 class="ib-pane-section-title">Blank</h6>
+            <p class="ib-pane-hint text-muted small mb-0">
+              Empty canvas — drop annotations only. All the drawing tools still work.
             </p>
           </div>
         </div>
@@ -381,6 +480,44 @@ hide_nibsy: true
         <canvas id="ib-canvas"></canvas>
         <div class="ib-canvas-empty" id="ib-canvas-empty">
           Drop a photo here, or pick a tool from the secondary pane.
+        </div>
+      </div>
+
+      <!-- B3: alternate canvas-area views — JS shows exactly one of
+           these or the Fabric canvas frame above based on the active
+           step's step_type. -->
+      <div class="ib-canvas-text d-none" id="ib-canvas-text">
+        <div class="ib-canvas-text-inner">
+          <div class="ib-canvas-text-empty" id="ib-canvas-text-empty">
+            <i class="fas fa-pen-to-square mb-2"></i>
+            <p class="mb-0">Write this step's body in the <strong>Schematic</strong> pane.</p>
+          </div>
+          <div class="ib-canvas-text-body" id="ib-canvas-text-body"></div>
+        </div>
+      </div>
+
+      <div class="ib-canvas-video d-none" id="ib-canvas-video">
+        <div class="ib-canvas-video-inner" id="ib-canvas-video-inner">
+          <div class="ib-canvas-video-empty">
+            <i class="fas fa-video mb-2"></i>
+            <p class="mb-0">Paste a YouTube or MP4 URL in the <strong>Schematic</strong> pane.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="ib-canvas-schematic d-none" id="ib-canvas-schematic">
+        <div class="ib-canvas-schematic-inner">
+          <div class="ib-canvas-schematic-icon">
+            <i class="fas fa-diagram-project"></i>
+          </div>
+          <h5 class="mb-2">Embedded schematic</h5>
+          <p class="text-muted mb-3">
+            View in the Schematic Editor (coming soon).<br>
+            The project schematic will render here once the editor ships.
+          </p>
+          <button type="button" class="btn btn-sm btn-outline-secondary" disabled>
+            <i class="fas fa-pencil me-1"></i> open editor
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Steps gain a `step_type` discriminator with five values; existing photo behaviour is the default and existing rows backfill to `"photo"`.
- The Schematic pane (rebadged from the old Circuit stub — preserves `data-rail-pane="circuit"` so saved UI state still works) becomes the per-step type picker. Canvas area swaps to a text card / video embed / schematic placeholder per type; Fabric canvas remains for photo + blank.
- Public slideshow viewer renders mixed-type instructions without crashing.
- 5 new backend tests; full suite 454/454.

## Test plan

- [ ] Create a new step (defaults to photo) — Fabric canvas + Photos pane work as before.
- [ ] Switch to text → textarea in Schematic pane; body persists on blur.
- [ ] Switch to video → URL input + small preview iframe; canvas area shows full embed.
- [ ] Switch to schematic → placeholder card in canvas + pane.
- [ ] Switch to blank → empty Fabric canvas (annotations only).
- [ ] Filmstrip badges per type (none for blank); active step's badge picks up primary colour.
- [ ] Autosave + step-undo entry pushed on every type switch.
- [ ] Flipping back to photo restores any previously-drawn overlays.
- [ ] view.html renders mixed-type slideshow with prev/next/dots/keyboard/swipe.
- [ ] Migration helper idempotent on Postgres (back-to-back runs succeed).

## Implementation notes

- **Existing-table migration** uses the idempotent ALTER pattern (`add_instruction_step_type_if_missing` in `db.py`) — four `ADD COLUMN IF NOT EXISTS` statements wired into the FastAPI lifespan alongside the existing helpers. **Production rebuild required.**
- **Step type preserves `canvas_json`** when flipping between types so toggling back from text/video/schematic to photo/blank restores the user's overlays. Documented in a code comment.
- **Text steps render as plaintext** (with `white-space: pre-wrap`) for B3; markdown rendering is a follow-up.
- **Export endpoints stay step-type-agnostic** — they render whatever PNG the frontend sends; documented at the top of the export section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)