### PR TITLE
feat(instructions): E2 — full schematic editor

### DIFF
--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -60,6 +60,7 @@ from .routers import (
     parts_talk,
     projects,
     remixes,
+    schematics,
     social_og,
     staff_picks,
     users,
@@ -195,6 +196,9 @@ def create_app() -> FastAPI:
     # Issue #178 Phase 0: build instructions (step-by-step outlines).
     # Phase 1 will layer a Fabric.js canvas on top of these rows.
     app.include_router(instructions.router)
+    # Issue #178 Phase E2: per-project schematic (one schematic per
+    # project for v1; opaque JSON blob stored in project_schematics).
+    app.include_router(schematics.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
     # Issue #123: parts catalog moderation (reports + community merges).

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -1137,3 +1137,46 @@ class Feedback(Base):
         Index("ix_feedback_status_created", "status", "created_at"),
         Index("ix_feedback_user_created", "user_id", "created_at"),
     )
+
+
+# --- Project schematic (issue #178 Phase E2) ----------------------------
+#
+# One schematic per project for v1. The schematic graph (symbol instances,
+# nets, labels) is stored as a single JSON document in ``schematic_data``
+# rather than a normalised set of tables — there are no server-side
+# queries on the graph (the editor is purely client-side) so the simpler
+# blob storage is sufficient. The shape of the JSON is the frontend's
+# source of truth — see ``web/assets/js/schematic-editor.js`` for the
+# schema.
+#
+# Brand-new table — ``create_all`` handles it on fresh deploys; no ALTER
+# helper needed because no existing table is being mutated.
+
+
+class ProjectSchematic(Base):
+    __tablename__ = "project_schematics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    name: Mapped[Optional[str]] = mapped_column(String(200))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    # JSON-serialised schematic graph. Stored as Text rather than JSONB so
+    # the column accepts an opaque blob without round-tripping through
+    # Postgres' JSON parser — the API just stores and returns whatever
+    # string the frontend POSTs / PUTs. Practical upper bound for v1 is
+    # ~2 MB (covered by ``test_schematics`` round-tripping a 1 MB payload).
+    schematic_data: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/stacks/projects-api/projects_api/routers/schematics.py
+++ b/stacks/projects-api/projects_api/routers/schematics.py
@@ -1,0 +1,167 @@
+"""Project schematic endpoints (issue #178, Phase E2).
+
+Each project has at most ONE schematic today — enforced by the unique
+constraint on ``project_schematics.project_id`` and the idempotent POST
+below. Mirrors the shape of ``routers/instructions.py`` (singular noun
+in the URL, idempotent POST, partial PUT, owner + T&Cs gating) so the
+two CRUD shapes stay learnable as a pair.
+
+URL surface:
+
+* ``GET    /api/projects/{id}/schematic`` — public, 404 if absent.
+* ``POST   /api/projects/{id}/schematic`` — owner + T&Cs.
+  Idempotent: if a row already exists, returns it with 200 (NOT 201).
+* ``PUT    /api/projects/{id}/schematic`` — owner + T&Cs, partial update.
+* ``DELETE /api/projects/{id}/schematic`` — owner + T&Cs.
+
+The schematic graph itself is an opaque JSON document in
+``schematic_data`` — the server doesn't parse it. The instruction-step
+linkage (``instruction_steps.schematic_id``) is set by the frontend via
+the existing instructions PUT route; no new endpoint is needed because
+for v1 (one schematic per project) the frontend just writes the
+project's single schematic id onto the step.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import require_terms_accepted
+from ..db import get_session
+from ..models import Project, ProjectSchematic
+from ..schemas import (
+    ProjectSchematicCreate,
+    ProjectSchematicResponse,
+    ProjectSchematicUpdate,
+)
+
+router = APIRouter(
+    prefix="/api/projects/{project_id}/schematic", tags=["schematics"]
+)
+
+
+async def _check_owner(session: AsyncSession, project_id: int, user: str) -> Project:
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+    if project.author_username != user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not the project owner")
+    return project
+
+
+async def _get_schematic(
+    session: AsyncSession, project_id: int
+) -> ProjectSchematic | None:
+    """Load the single schematic for a project (or None)."""
+    return (
+        await session.scalars(
+            select(ProjectSchematic).where(
+                ProjectSchematic.project_id == project_id
+            )
+        )
+    ).first()
+
+
+def _to_response(schematic: ProjectSchematic) -> ProjectSchematicResponse:
+    return ProjectSchematicResponse(
+        id=schematic.id,
+        project_id=schematic.project_id,
+        name=schematic.name,
+        description=schematic.description,
+        schematic_data=schematic.schematic_data,
+        created_at=schematic.created_at,
+        updated_at=schematic.updated_at,
+    )
+
+
+@router.get("", response_model=ProjectSchematicResponse)
+async def get_schematic(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSchematicResponse:
+    """Public read — surfaces user-authored content."""
+    schematic = await _get_schematic(session, project_id)
+    if schematic is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No schematic for this project",
+        )
+    return _to_response(schematic)
+
+
+@router.post("", response_model=ProjectSchematicResponse)
+async def create_schematic(
+    project_id: int,
+    body: ProjectSchematicCreate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSchematicResponse:
+    """Owner-only, idempotent.
+
+    If a schematic already exists for this project, the existing row is
+    returned with 200 (NOT 201). The frontend wires this up so that
+    flipping a step to ``step_type=schematic`` can call POST blindly
+    without first checking — the second-and-later POSTs are safe.
+    """
+    await _check_owner(session, project_id, user)
+    existing = await _get_schematic(session, project_id)
+    if existing is not None:
+        return _to_response(existing)
+    schematic = ProjectSchematic(
+        project_id=project_id,
+        name=body.name,
+        description=body.description,
+        schematic_data=body.schematic_data,
+    )
+    session.add(schematic)
+    await session.commit()
+    await session.refresh(schematic)
+    return _to_response(schematic)
+
+
+@router.put("", response_model=ProjectSchematicResponse)
+async def update_schematic(
+    project_id: int,
+    body: ProjectSchematicUpdate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSchematicResponse:
+    """Partial update of name / description / schematic_data.
+
+    Used by the schematic editor's debounced autosave (every ~800ms of
+    edit activity). The endpoint accepts arbitrary text in
+    ``schematic_data`` — payload size is effectively bounded by HTTP
+    body limits (the practical upper bound for v1 schematics is well
+    under 2 MB; see ``test_schematics`` for a 1 MB round-trip case)."""
+    await _check_owner(session, project_id, user)
+    schematic = await _get_schematic(session, project_id)
+    if schematic is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No schematic for this project",
+        )
+    payload = body.model_dump(exclude_unset=True)
+    for field, value in payload.items():
+        setattr(schematic, field, value)
+    await session.commit()
+    await session.refresh(schematic)
+    return _to_response(schematic)
+
+
+@router.delete("", status_code=204)
+async def delete_schematic(
+    project_id: int,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    await _check_owner(session, project_id, user)
+    schematic = await _get_schematic(session, project_id)
+    if schematic is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail="No schematic for this project",
+        )
+    await session.delete(schematic)
+    await session.commit()

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -386,6 +386,40 @@ class InstructionResponse(BaseModel):
     steps: list[InstructionStepResponse] = Field(default_factory=list)
 
 
+# --- Project schematic (issue #178 Phase E2) ----------------------------
+#
+# One schematic per project for v1. The graph (symbol instances + nets +
+# labels) is an opaque JSON blob in ``schematic_data`` — the server
+# stores and returns it verbatim, the frontend owns the shape. Mirrors
+# ``Instruction{Create,Update,Response}`` for surface consistency.
+
+
+class ProjectSchematicCreate(BaseModel):
+    """Empty body permitted — creates the row, frontend can update later."""
+
+    name: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+    schematic_data: Optional[str] = None
+
+
+class ProjectSchematicUpdate(BaseModel):
+    """Partial — fields omitted are left untouched."""
+
+    name: Optional[str] = Field(None, max_length=200)
+    description: Optional[str] = None
+    schematic_data: Optional[str] = None
+
+
+class ProjectSchematicResponse(BaseModel):
+    id: int
+    project_id: int
+    name: Optional[str] = None
+    description: Optional[str] = None
+    schematic_data: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
 # --- Build instructions export (issue #178, Phase 2b) --------------------
 #
 # Hybrid PDF pipeline: the browser renders each Fabric.js canvas to a

--- a/stacks/projects-api/tests/test_schematics.py
+++ b/stacks/projects-api/tests/test_schematics.py
@@ -1,0 +1,280 @@
+"""Project schematic CRUD tests (issue #178, Phase E2).
+
+Mirrors the fixture pattern in ``tests/test_instructions.py``: a per-test
+project is created up front, then we exercise the schematic endpoints
+against it. The terms-gate test deliberately strips the
+``conftest.client`` bypass to confirm the gate fires on writes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture
+async def project_id(client) -> int:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Schematic Test Project"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# --- Basic CRUD ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schematic_post_is_idempotent(client, project_id) -> None:
+    """A second POST returns the SAME row with 200, not 201."""
+    headers = make_auth_header()
+    first = await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "Main schematic", "description": "Pico + LED"},
+        headers=headers,
+    )
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body["name"] == "Main schematic"
+    assert first_body["description"] == "Pico + LED"
+    assert first_body["project_id"] == project_id
+    assert first_body["schematic_data"] is None
+
+    second = await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "Different on second POST"},
+        headers=headers,
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    # Idempotent: same row id, original name preserved (no overwrite).
+    assert second_body["id"] == first_body["id"]
+    assert second_body["name"] == "Main schematic"
+
+
+@pytest.mark.asyncio
+async def test_get_returns_404_when_no_schematic(client, project_id) -> None:
+    resp = await client.get(f"/api/projects/{project_id}/schematic")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_put_updates_fields_partially(client, project_id) -> None:
+    """PUT applies the fields in the payload, leaves omitted fields alone."""
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "Initial", "description": "Initial desc"},
+        headers=headers,
+    )
+
+    # Update only the name — description should stay.
+    resp = await client.put(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "Updated"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Updated"
+    assert body["description"] == "Initial desc"
+
+    # Now update schematic_data — name + description still preserved.
+    blob = json.dumps({"instances": [{"id": "i1", "symbolId": "rpi-pico"}]})
+    resp = await client.put(
+        f"/api/projects/{project_id}/schematic",
+        json={"schematic_data": blob},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Updated"
+    assert body["description"] == "Initial desc"
+    assert body["schematic_data"] == blob
+
+    # GET reflects the latest state.
+    get_resp = await client.get(f"/api/projects/{project_id}/schematic")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["schematic_data"] == blob
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_schematic(client, project_id) -> None:
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/schematic", json={}, headers=headers
+    )
+    resp = await client.delete(
+        f"/api/projects/{project_id}/schematic", headers=headers
+    )
+    assert resp.status_code == 204
+
+    get_resp = await client.get(f"/api/projects/{project_id}/schematic")
+    assert get_resp.status_code == 404
+
+
+# --- Public read --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anonymous_can_read_schematic(client, project_id) -> None:
+    """Public GETs work without any auth header."""
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "public read", "schematic_data": "{}"},
+        headers=headers,
+    )
+
+    # No auth header.
+    resp = await client.get(f"/api/projects/{project_id}/schematic")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "public read"
+    assert resp.json()["schematic_data"] == "{}"
+
+
+# --- Ownership ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_owner_post_returns_403(client, project_id) -> None:
+    other = make_auth_header(username="someoneelse")
+    resp = await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "hijack"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_put_returns_403(client, project_id) -> None:
+    owner = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "ok"},
+        headers=owner,
+    )
+    other = make_auth_header(username="someoneelse")
+    resp = await client.put(
+        f"/api/projects/{project_id}/schematic",
+        json={"name": "hijacked"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_delete_returns_403(client, project_id) -> None:
+    owner = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/schematic", json={}, headers=owner
+    )
+    other = make_auth_header(username="someoneelse")
+    resp = await client.delete(
+        f"/api/projects/{project_id}/schematic", headers=other
+    )
+    assert resp.status_code == 403
+
+
+# --- Large payload ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_large_schematic_data_round_trips(client, project_id) -> None:
+    """A ~1 MB schematic_data blob should round-trip via POST and GET.
+
+    Schematic graphs for typical Pico-class projects sit at a few tens
+    of KB; the 1 MB ceiling is the practical upper bound for v1 (e.g. a
+    massive shield with hundreds of pins + nets) and we want it well
+    inside what the API will accept."""
+    headers = make_auth_header()
+    # Build a deterministic payload roughly 1 MB in size. The blob itself
+    # is opaque to the server — what matters is that the column accepts
+    # it and the JSON encoder round-trips it intact.
+    blob = "x" * (1 * 1024 * 1024)
+    resp = await client.post(
+        f"/api/projects/{project_id}/schematic",
+        json={"schematic_data": blob},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["schematic_data"] == blob
+
+    # GET still returns it verbatim.
+    get_resp = await client.get(f"/api/projects/{project_id}/schematic")
+    assert get_resp.status_code == 200
+    assert len(get_resp.json()["schematic_data"]) == len(blob)
+
+
+# --- Terms gate ---------------------------------------------------------
+#
+# The default ``client`` fixture in ``conftest.py`` patches
+# ``require_terms_accepted`` to no-op so the bulk of the suite doesn't
+# need to first POST /api/users/me/accept-terms. This test opts back
+# into the real gate (same pattern as ``tests/test_instructions.py``)
+# and confirms a schematic-write hits 403 before acceptance.
+
+
+@pytest.mark.asyncio
+async def test_write_without_terms_acceptance_returns_403(client) -> None:
+    from projects_api import auth as auth_module
+
+    app = client._transport.app
+    for dep in (
+        auth_module.require_terms_accepted,
+        auth_module.require_terms_accepted_aged,
+    ):
+        app.dependency_overrides.pop(dep, None)
+
+    headers = make_auth_header("alice")
+
+    # Accept terms so the project itself can be created — POST /api/projects
+    # is also gated by ``require_terms_accepted``.
+    acc = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert acc.status_code == 200, acc.text
+    proj = await client.post(
+        "/api/projects",
+        json={"title": "Gated Schematic Project"},
+        headers=headers,
+    )
+    assert proj.status_code == 201, proj.text
+    pid = proj.json()["id"]
+
+    # Now bump the terms version so alice's 1.0 acceptance goes stale.
+    from projects_api import config as config_module
+    from projects_api.routers import users as users_router
+
+    def _fake_get_settings():
+        s = config_module.Settings()
+        return s.model_copy(update={"current_terms_version": "2.0"})
+
+    import pytest as _pytest
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr(config_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(auth_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(users_router, "get_settings", _fake_get_settings)
+
+    try:
+        resp = await client.post(
+            f"/api/projects/{pid}/schematic",
+            json={"name": "should be blocked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail")
+        assert isinstance(detail, dict)
+        assert detail.get("detail") == "terms_not_accepted"
+    finally:
+        monkeypatch.undo()

--- a/web/assets/css/schematic-editor.css
+++ b/web/assets/css/schematic-editor.css
@@ -1,0 +1,397 @@
+/*
+ * Schematic Editor — issue #178 Phase E2.
+ *
+ * Three-region layout:
+ *   - Title bar  (top, full-width)
+ *   - Tools pane (left, 240px)
+ *   - Canvas + connections table (centre column; canvas on top,
+ *     table beneath, both flex children of the same column)
+ *
+ * The page is desktop-first; small viewports fall back to a stacked
+ * single-column scroll via the media query at the bottom.
+ */
+
+/* Site chrome: hide the footer / social bar so the editor uses the
+   full viewport. Site header / nav stay so the user can navigate
+   out normally. */
+body.schematic-editor-page #footer,
+body.schematic-editor-page .socials-bar,
+body.schematic-editor-page footer {
+  display: none !important;
+}
+body.schematic-editor-page > .container-fluid {
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* ---------- Workspace shell ---------- */
+
+.se-workspace {
+  --se-titlebar-h: 48px;
+  --se-tools-w: 240px;
+  --se-table-h: 240px;
+  --se-ink: #222;
+  --se-brand-red: #c8312a;
+  --se-bg: #f7f8fa;
+  --se-panel: #ffffff;
+  --se-border: #e2e6ea;
+  --se-muted: #7a8087;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 56px); /* approx site nav height; close enough */
+  background: var(--se-bg);
+  color: var(--se-ink);
+  font-size: 0.92rem;
+}
+
+/* ---------- Title bar ---------- */
+
+.se-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  height: var(--se-titlebar-h);
+  padding: 0 1rem;
+  background: var(--se-panel);
+  border-bottom: 1px solid var(--se-border);
+  flex: 0 0 auto;
+}
+.se-titlebar-left, .se-titlebar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.se-titlebar-center {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  justify-content: center;
+}
+.se-project-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+.se-save-status {
+  font-size: 0.85rem;
+  color: var(--se-muted);
+}
+.se-titlebar-link {
+  color: var(--se-ink);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+.se-titlebar-link:hover { color: var(--se-brand-red); }
+.se-titlebar-btn {
+  border: 1px solid var(--se-border);
+  background: var(--se-panel);
+  color: var(--se-ink);
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+.se-titlebar-btn:hover {
+  border-color: var(--se-brand-red);
+  color: var(--se-brand-red);
+}
+
+/* ---------- Loading / not-owner / error states ---------- */
+
+.se-loading,
+.se-not-owner,
+.se-error {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  color: var(--se-muted);
+}
+.se-not-owner .se-icon,
+.se-error .se-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  color: var(--se-muted);
+}
+.se-error .se-icon { color: var(--se-brand-red); }
+
+/* ---------- Main shell: tools | (canvas / table) ---------- */
+
+.se-main {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: var(--se-tools-w) 1fr;
+  min-height: 0;
+}
+
+/* ---------- Tools pane ---------- */
+
+.se-tools {
+  background: var(--se-panel);
+  border-right: 1px solid var(--se-border);
+  overflow-y: auto;
+  padding: 0.75rem 0.75rem 1.5rem;
+}
+.se-tools-section { margin-bottom: 1rem; }
+.se-tools-section-title {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7rem;
+  color: var(--se-muted);
+  margin: 0.25rem 0 0.5rem;
+  font-weight: 600;
+}
+.se-tool-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.4rem;
+}
+.se-tool-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  background: #fbfbfc;
+  border: 1px solid var(--se-border);
+  border-radius: 6px;
+  padding: 0.5rem 0.25rem;
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: var(--se-ink);
+  transition: border-color 0.1s, background 0.1s;
+}
+.se-tool-btn i { font-size: 1rem; }
+.se-tool-btn:hover {
+  border-color: var(--se-brand-red);
+  background: #fff;
+}
+.se-tool-btn.is-active {
+  background: var(--se-brand-red);
+  color: #fff;
+  border-color: var(--se-brand-red);
+}
+
+/* ---------- Symbol list (place-symbol library) ---------- */
+
+.se-symbol-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid var(--se-border);
+  border-radius: 6px;
+  background: #fbfbfc;
+}
+.se-symbol-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--se-border);
+  font-size: 0.85rem;
+}
+.se-symbol-item:last-child { border-bottom: none; }
+.se-symbol-item:hover { background: #fff; }
+.se-symbol-item.is-pending {
+  background: rgba(200, 49, 42, 0.08);
+  border-left: 3px solid var(--se-brand-red);
+  padding-left: calc(0.5rem - 3px);
+}
+.se-symbol-thumb {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background: #fff;
+  border: 1px solid var(--se-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--se-muted);
+  font-size: 0.9rem;
+  flex: 0 0 auto;
+}
+.se-symbol-meta { display: flex; flex-direction: column; line-height: 1.2; }
+.se-symbol-name { font-weight: 500; }
+.se-symbol-sub { font-size: 0.72rem; }
+.se-tools-secondary-btn {
+  width: 100%;
+  background: transparent;
+  border: 1px dashed var(--se-border);
+  color: var(--se-muted);
+  border-radius: 6px;
+  padding: 0.4rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+.se-tools-secondary-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.se-tools-help { margin-top: 1.25rem; }
+.se-tools-hint {
+  font-size: 0.78rem;
+  color: var(--se-muted);
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* ---------- Canvas area ---------- */
+
+.se-canvas-area {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+.se-canvas-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  background: var(--se-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0.5rem;
+}
+.se-canvas-wrap canvas {
+  background: #fff;
+  border: 1px solid var(--se-border);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+}
+
+/* The Fabric.js wrapper div Fabric inserts around the canvas — we
+   want our positioning rules to apply to it instead of just the
+   inner element. Fabric assigns the canvas-container class to it. */
+.se-canvas-wrap .canvas-container {
+  margin: 0 auto;
+}
+
+/* ---------- Symbol HUD (rotate / flip / delete) ---------- */
+
+.se-symbol-hud {
+  position: absolute;
+  z-index: 5;
+  display: flex;
+  gap: 0.15rem;
+  padding: 0.2rem;
+  background: #3a3a3a;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  transform: translateX(-50%);
+}
+.se-hud-btn {
+  background: transparent;
+  border: none;
+  color: #fff;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+}
+.se-hud-btn:hover { background: rgba(255,255,255,0.12); }
+.se-hud-btn-danger:hover { background: var(--se-brand-red); }
+
+/* ---------- Connections table ---------- */
+
+.se-table-wrap {
+  flex: 0 0 var(--se-table-h);
+  background: var(--se-panel);
+  border-top: 1px solid var(--se-border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.se-table-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--se-border);
+  background: #fbfbfc;
+}
+.se-table-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+.se-table-count {
+  font-size: 0.85rem;
+  color: var(--se-muted);
+  margin-left: 0.35rem;
+  font-weight: 400;
+}
+.se-table-hint { margin: 0; }
+
+.se-table-scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.se-table { margin-bottom: 0; }
+.se-table thead th {
+  position: sticky;
+  top: 0;
+  background: #fbfbfc;
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--se-muted);
+  border-bottom: 1px solid var(--se-border);
+  z-index: 1;
+}
+.se-th-net,  .se-td-net  { width: 16%; }
+.se-th-from, .se-td-from { width: 22%; }
+.se-th-to,   .se-td-to   { width: 22%; }
+.se-th-desc, .se-td-desc { width: 40%; }
+.se-td-net, .se-td-from, .se-td-to { font-family: ui-monospace, SFMono-Regular, monospace; }
+.se-table-row { cursor: pointer; }
+.se-table-row:hover { background: #fafbfc; }
+.se-table-row.is-selected {
+  background: rgba(200, 49, 42, 0.07);
+  border-left: 3px solid var(--se-brand-red);
+}
+.se-table-row.is-selected td:first-child { padding-left: calc(0.5rem - 3px); }
+
+.se-desc-input {
+  font-size: 0.85rem;
+  border-color: transparent;
+  background: transparent;
+  padding: 0.15rem 0.4rem;
+}
+.se-desc-input:focus {
+  background: #fff;
+  border-color: var(--se-brand-red);
+}
+
+/* ---------- Mobile fallback ---------- */
+
+@media (max-width: 768px) {
+  .se-workspace { height: auto; min-height: calc(100vh - 56px); }
+  .se-main {
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+  }
+  .se-tools {
+    border-right: none;
+    border-bottom: 1px solid var(--se-border);
+    max-height: 240px;
+  }
+  .se-canvas-area { min-height: 60vh; }
+  .se-table-wrap { flex: 0 0 auto; max-height: 320px; }
+  .se-titlebar { flex-wrap: wrap; height: auto; padding: 0.4rem 0.6rem; }
+  .se-titlebar-center { flex: 1 1 100%; justify-content: flex-start; }
+}

--- a/web/assets/js/instruction-builder.js
+++ b/web/assets/js/instruction-builder.js
@@ -208,6 +208,10 @@
     dom.stepBodyInput = document.getElementById('ib-step-body-input');
     dom.stepVideoInput = document.getElementById('ib-step-video-input');
     dom.stepVideoPreview = document.getElementById('ib-step-video-preview');
+    // E2: full-schematic-editor "open" CTAs (one in the schematic-step
+    // pane card, one in the canvas-area placeholder).
+    dom.openSchematicEditorPane = document.getElementById('ib-open-schematic-editor-pane');
+    dom.openSchematicEditorCanvas = document.getElementById('ib-open-schematic-editor-canvas');
     dom.inspectorHud = document.getElementById('ib-inspector-hud');
     dom.hudHeader = document.getElementById('ib-hud-header');
     dom.hudBody = document.getElementById('ib-hud-body');
@@ -1167,6 +1171,36 @@
     if (stepType === 'video') renderCanvasVideo(step);
   }
 
+  // E2: cache the project's single schematic id once it's known. The
+  // first POST to /schematic is idempotent so flipping a step to
+  // ``step_type=schematic`` can call it without checking first.
+  var schematicIdCache = null;
+
+  async function ensureProjectSchematicId() {
+    if (schematicIdCache) return schematicIdCache;
+    try {
+      var resp = await apiFetchWithTermsRetry(
+        API + '/api/projects/' + state.projectId + '/schematic',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }
+      );
+      if (!resp.ok) return null;
+      var body = await resp.json();
+      schematicIdCache = body.id;
+      return schematicIdCache;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function schematicEditorUrl() {
+    return '/projects/schematic/edit.html?id=' +
+      encodeURIComponent(state.projectId || '');
+  }
+
   async function onStepTypeChange(newType) {
     if (STEP_TYPES.indexOf(newType) < 0) return;
     var step = activeStepObject();
@@ -1184,6 +1218,26 @@
       var updated = await putStep(stepId, { step_type: newType });
       // Update local cache.
       step.step_type = updated.step_type;
+
+      // E2: when the step becomes a schematic step, ensure the project
+      // has a schematic record and link this step to it. The POST is
+      // idempotent so re-calling it for each step is safe — the
+      // schematicIdCache means we hit the network at most once per
+      // session.
+      if (newType === 'schematic') {
+        var schematicId = await ensureProjectSchematicId();
+        if (schematicId && step.schematic_id !== schematicId) {
+          try {
+            var stepResp = await putStep(stepId, { schematic_id: schematicId });
+            step.schematic_id = stepResp.schematic_id;
+          } catch (_) {
+            // Linkage failure is non-fatal — the editor still opens via the
+            // ?id=projectId URL; the step just won't carry the schematic_id
+            // until the next type-switch.
+          }
+        }
+      }
+
       setSaveStatus('saved');
       syncStepTypePane();
       renderFilmstrip();
@@ -1302,6 +1356,26 @@
             .catch(function () { setSaveStatus('error', 'Video URL save failed'); });
         });
       });
+    }
+
+    // E2: full schematic editor "open" CTAs (pane card + canvas-area
+    // placeholder). Both navigate to the new full-screen editor; the
+    // link is computed at click-time because state.projectId isn't
+    // populated until init() runs.
+    function openSchematicEditor(ev) {
+      if (ev && typeof ev.preventDefault === 'function') ev.preventDefault();
+      // Ensure the schematic exists (idempotent) so the link lands on
+      // an editor that already has its row. The await is fire-and-
+      // forget — even if the POST is in-flight when we navigate, the
+      // editor itself will POST again on load.
+      ensureProjectSchematicId();
+      window.open(schematicEditorUrl(), '_blank', 'noopener');
+    }
+    if (dom.openSchematicEditorPane) {
+      dom.openSchematicEditorPane.addEventListener('click', openSchematicEditor);
+    }
+    if (dom.openSchematicEditorCanvas) {
+      dom.openSchematicEditorCanvas.addEventListener('click', openSchematicEditor);
     }
   }
 

--- a/web/assets/js/schematic-editor.js
+++ b/web/assets/js/schematic-editor.js
@@ -1,0 +1,1682 @@
+/**
+ * Schematic Editor — issue #178 Phase E2.
+ *
+ * Full-screen editor for project schematics. One schematic per project
+ * for v1; the graph (symbol instances + nets + labels) is held entirely
+ * client-side and serialised to a single JSON blob in
+ * ``project_schematics.schematic_data`` via the backend's
+ * /api/projects/{id}/schematic endpoint.
+ *
+ * Renderer: Fabric.js v6.4.0 (CDN UMD, exposes ``window.fabric``).
+ *
+ * Coordinate system: a fixed 1600 × 1200 logical scene scaled to fit the
+ * panel. The dot grid is rendered as a Fabric pattern (16px display
+ * pitch == 2.54mm conceptual pitch) so snap math is just
+ * ``Math.round(p / 16) * 16``.
+ *
+ * State persistence: the entire STATE.schematic document is PUT to
+ * /api/projects/{id}/schematic via a debounced (800ms) autosave; the
+ * server stores and returns it verbatim.
+ *
+ * Out of scope (will land in follow-up PRs):
+ *   - Symbol Designer (the library is hard-coded JS data here).
+ *   - ERC / pin-type checking.
+ *   - Net auto-routing — segments are computed via a single L-bend.
+ *   - Multiple schematics per project.
+ *   - Region cropping for embedding into instruction steps.
+ */
+(function () {
+  'use strict';
+
+  // ====================================================================
+  // 1. CONSTANTS
+  // ====================================================================
+
+  var API = 'https://projects.kevsrobots.com';
+  var SCENE_W = 1600;
+  var SCENE_H = 1200;
+  var GRID = 16;                  // display pitch (px) — represents 2.54mm
+  var AUTOSAVE_MS = 800;
+
+  // Brand colours
+  var INK = '#222222';            // default symbol + net colour
+  var BRAND_RED = '#c8312a';      // selected net highlight + selection border
+  var BG = '#ffffff';
+  var GRID_DOT = '#cfd3d8';       // colour of the background dot grid
+  var JUNCTION_DOT_R = 4;         // px
+
+  // Junction-merge tolerance — any two segment endpoints within this
+  // distance (px) count as "meeting at the same point" for junction-dot
+  // rendering and net-merge detection. With the snap forcing all
+  // endpoints to GRID multiples this should never be more than ~0px in
+  // practice, but a small tolerance protects against rounding noise from
+  // the orthogonal-routing computation.
+  var JUNCTION_TOLERANCE = 2;
+
+  // Selected net highlight stroke width. Slightly thicker than the
+  // default so the selection is obvious without re-laying-out.
+  var NET_STROKE = 2;
+  var NET_STROKE_SELECTED = 3.5;
+
+  // ====================================================================
+  // 2. SYMBOL LIBRARY (stub — Symbol Designer ships next)
+  // ====================================================================
+  //
+  // Pin offsets are in scene units (px). ``side`` controls which edge
+  // the pin attaches to. The hard-coded set covers a credible minimal
+  // circuit (Pico + R + C + LED + GND + V+) and one generic 14-pin IC
+  // for representing other ICs the user doesn't have a dedicated symbol
+  // for. The full library lives in the Symbol Designer (next PR).
+
+  var SYMBOL_LIBRARY = [
+    {
+      id: 'rpi-pico',
+      name: 'Raspberry Pi Pico',
+      refDesPrefix: 'U',
+      bodyWidth: 160,
+      bodyHeight: 320,
+      // Subset of the Pico's pinout — enough to demonstrate net drawing.
+      // Each entry maps a pin number to its symbol-relative position.
+      pins: [
+        // Left edge — GPIOs
+        { number: '1',  name: 'GP0',  side: 'left',  offset: 32 },
+        { number: '2',  name: 'GP1',  side: 'left',  offset: 64 },
+        { number: '3',  name: 'GND',  side: 'left',  offset: 96 },
+        { number: '4',  name: 'GP2',  side: 'left',  offset: 128 },
+        { number: '5',  name: 'GP3',  side: 'left',  offset: 160 },
+        { number: '6',  name: 'GP4',  side: 'left',  offset: 192 },
+        { number: '7',  name: 'GP5',  side: 'left',  offset: 224 },
+        { number: '8',  name: 'GND',  side: 'left',  offset: 256 },
+        { number: '9',  name: 'GP6',  side: 'left',  offset: 288 },
+        // Right edge — power + extras
+        { number: '36', name: '3V3',  side: 'right', offset: 32 },
+        { number: '37', name: '3V3_EN', side: 'right', offset: 64 },
+        { number: '38', name: 'GND',  side: 'right', offset: 96 },
+        { number: '39', name: 'VSYS', side: 'right', offset: 128 },
+        { number: '40', name: 'VBUS', side: 'right', offset: 160 },
+        { number: '34', name: 'GP28', side: 'right', offset: 192 },
+        { number: '33', name: 'GND',  side: 'right', offset: 224 },
+        { number: '32', name: 'GP27', side: 'right', offset: 256 },
+        { number: '31', name: 'GP26', side: 'right', offset: 288 },
+      ],
+    },
+    {
+      id: 'ic-14',
+      name: 'Generic 14-pin IC',
+      refDesPrefix: 'U',
+      bodyWidth: 128,
+      bodyHeight: 224,
+      pins: [
+        { number: '1',  name: '1',  side: 'left',  offset: 32 },
+        { number: '2',  name: '2',  side: 'left',  offset: 64 },
+        { number: '3',  name: '3',  side: 'left',  offset: 96 },
+        { number: '4',  name: '4',  side: 'left',  offset: 128 },
+        { number: '5',  name: '5',  side: 'left',  offset: 160 },
+        { number: '6',  name: '6',  side: 'left',  offset: 192 },
+        { number: '7',  name: 'GND', side: 'left', offset: 224 - 32 },
+        { number: '14', name: 'VCC', side: 'right', offset: 32 },
+        { number: '13', name: '13', side: 'right', offset: 64 },
+        { number: '12', name: '12', side: 'right', offset: 96 },
+        { number: '11', name: '11', side: 'right', offset: 128 },
+        { number: '10', name: '10', side: 'right', offset: 160 },
+        { number: '9',  name: '9',  side: 'right', offset: 192 },
+        { number: '8',  name: '8',  side: 'right', offset: 224 - 32 },
+      ],
+    },
+    {
+      id: 'resistor',
+      name: 'Resistor',
+      refDesPrefix: 'R',
+      bodyWidth: 64,
+      bodyHeight: 32,
+      pins: [
+        { number: '1', name: '1', side: 'left',  offset: 16 },
+        { number: '2', name: '2', side: 'right', offset: 16 },
+      ],
+    },
+    {
+      id: 'capacitor',
+      name: 'Capacitor',
+      refDesPrefix: 'C',
+      bodyWidth: 64,
+      bodyHeight: 32,
+      pins: [
+        { number: '1', name: '+', side: 'left',  offset: 16 },
+        { number: '2', name: '-', side: 'right', offset: 16 },
+      ],
+    },
+    {
+      id: 'led',
+      name: 'LED',
+      refDesPrefix: 'D',
+      bodyWidth: 64,
+      bodyHeight: 48,
+      pins: [
+        { number: '1', name: 'A', side: 'left',  offset: 24 },
+        { number: '2', name: 'K', side: 'right', offset: 24 },
+      ],
+    },
+    {
+      id: 'gnd',
+      name: 'GND',
+      refDesPrefix: 'GND',
+      bodyWidth: 48,
+      bodyHeight: 32,
+      // GND has one pin attached at the top — wires drop into the
+      // GND symbol from above.
+      pins: [
+        { number: '1', name: 'GND', side: 'top', offset: 24 },
+      ],
+    },
+    {
+      id: 'vplus',
+      name: 'V+ rail',
+      refDesPrefix: 'V',
+      bodyWidth: 48,
+      bodyHeight: 32,
+      pins: [
+        { number: '1', name: 'V+', side: 'bottom', offset: 24 },
+      ],
+    },
+  ];
+
+  function symbolDefById(id) {
+    for (var i = 0; i < SYMBOL_LIBRARY.length; i++) {
+      if (SYMBOL_LIBRARY[i].id === id) return SYMBOL_LIBRARY[i];
+    }
+    return null;
+  }
+
+  // ====================================================================
+  // 3. STATE
+  // ====================================================================
+
+  var STATE = {
+    projectId: null,
+    project: null,
+    me: null,
+    isOwner: false,
+    schematic: null,           // ProjectSchematicResponse — id + graph wrapper
+    graph: emptyGraph(),       // mutable in-memory copy of the JSON document
+    canvas: null,              // fabric.Canvas instance
+
+    activeTool: 'select',
+    pendingSymbolId: null,     // when the user picks a symbol; null in select mode
+    selectedInstanceId: null,
+    selectedNetId: null,
+
+    // While drawing a net: from-endpoint + preview Fabric object.
+    netDrawingFrom: null,      // { instanceId, pinNumber, x, y }
+    netPreviewObj: null,
+
+    refDesCounters: {},        // { U: 1, R: 1, ... } — auto-incrementing per prefix
+    netCounter: 0,             // for auto-naming Net-1, Net-2, …
+
+    saveStatus: 'saved',
+    autosaveTimer: null,
+  };
+
+  function emptyGraph() {
+    return {
+      id: 0,
+      name: '',
+      description: '',
+      instances: [],
+      nets: [],
+      labels: [],
+    };
+  }
+
+  var dom = {};
+
+  // ====================================================================
+  // 4. UTILITIES
+  // ====================================================================
+
+  function nextId(prefix) {
+    // Lightweight uid generator — graph-local, doesn't need to be unique
+    // across schematics, just within the current one.
+    return prefix + '-' + Math.random().toString(36).slice(2, 10);
+  }
+
+  function snap(v) {
+    return Math.round(v / GRID) * GRID;
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function apiFetch(url, opts) {
+    opts = opts || {};
+    if (window.ProjectAuth && typeof window.ProjectAuth.apiFetch === 'function') {
+      return window.ProjectAuth.apiFetch(url, opts);
+    }
+    opts.credentials = opts.credentials || 'include';
+    return fetch(url, opts);
+  }
+
+  async function apiFetchWithTermsRetry(url, opts) {
+    var resp = await apiFetch(url, opts);
+    if (resp.status === 403 && window.TermsGate &&
+        typeof window.TermsGate.handleResponse === 'function') {
+      try {
+        var retry = await window.TermsGate.handleResponse(resp);
+        if (retry) return apiFetch(url, opts);
+      } catch (_) { /* fall through with original 403 */ }
+    }
+    return resp;
+  }
+
+  function showOnly(el) {
+    [dom.loading, dom.notOwner, dom.error, dom.main].forEach(function (n) {
+      if (!n) return;
+      if (n === el) n.classList.remove('d-none');
+      else n.classList.add('d-none');
+    });
+  }
+
+  function setSaveStatus(status, label) {
+    STATE.saveStatus = status;
+    if (!dom.saveStatus) return;
+    var icon, text;
+    switch (status) {
+      case 'saving': icon = 'fa-circle-notch fa-spin'; text = 'Saving…'; break;
+      case 'error':  icon = 'fa-triangle-exclamation'; text = label || 'Save failed'; break;
+      case 'saved':
+      default:       icon = 'fa-check'; text = 'Saved'; break;
+    }
+    dom.saveStatus.innerHTML =
+      '<i class="fas ' + icon + ' me-1"></i>' + escapeHtml(text);
+  }
+
+  // ====================================================================
+  // 5. SYMBOL INSTANCE MATH
+  // ====================================================================
+  //
+  // A SymbolInstance has an origin point ``(x, y)`` (centre of the
+  // symbol body). Pin positions are computed relative to that origin
+  // accounting for the symbol's rotation + flips. ``pinScenePos`` is
+  // the single source of truth used by both the renderer and the
+  // net-drawing logic.
+
+  function symbolWidth(symbolDef, rotation) {
+    return (rotation === 90 || rotation === 270)
+      ? symbolDef.bodyHeight : symbolDef.bodyWidth;
+  }
+  function symbolHeight(symbolDef, rotation) {
+    return (rotation === 90 || rotation === 270)
+      ? symbolDef.bodyWidth : symbolDef.bodyHeight;
+  }
+
+  // Compute a pin's position in the symbol's *unrotated*, *unflipped*
+  // local frame (origin = top-left of bodyWidth × bodyHeight rect).
+  function pinLocalPos(symbolDef, pin) {
+    switch (pin.side) {
+      case 'left':   return { x: 0,                       y: pin.offset };
+      case 'right':  return { x: symbolDef.bodyWidth,     y: pin.offset };
+      case 'top':    return { x: pin.offset,              y: 0 };
+      case 'bottom': return { x: pin.offset,              y: symbolDef.bodyHeight };
+      default:       return { x: 0, y: 0 };
+    }
+  }
+
+  // Convert a local-frame point to the symbol's *instance* frame
+  // (origin = the symbol's instance.x / instance.y, i.e. its centre).
+  // Applies rotation (0/90/180/270) + horizontal/vertical flip.
+  function localToScene(instance, symbolDef, lx, ly) {
+    var cx = symbolDef.bodyWidth / 2;
+    var cy = symbolDef.bodyHeight / 2;
+    var dx = lx - cx;
+    var dy = ly - cy;
+    if (instance.flipH) dx = -dx;
+    if (instance.flipV) dy = -dy;
+    var rot = ((instance.rotation || 0) % 360 + 360) % 360;
+    var rx, ry;
+    switch (rot) {
+      case 0:   rx = dx;  ry = dy;  break;
+      case 90:  rx = -dy; ry = dx;  break;
+      case 180: rx = -dx; ry = -dy; break;
+      case 270: rx = dy;  ry = -dx; break;
+      default:  rx = dx;  ry = dy;
+    }
+    return { x: instance.x + rx, y: instance.y + ry };
+  }
+
+  function pinScenePos(instance, pin) {
+    var symbolDef = symbolDefById(instance.symbolId);
+    if (!symbolDef) return { x: instance.x, y: instance.y };
+    var local = pinLocalPos(symbolDef, pin);
+    return localToScene(instance, symbolDef, local.x, local.y);
+  }
+
+  function findInstance(id) {
+    for (var i = 0; i < STATE.graph.instances.length; i++) {
+      if (STATE.graph.instances[i].id === id) return STATE.graph.instances[i];
+    }
+    return null;
+  }
+
+  function findPin(instance, pinNumber) {
+    var symbolDef = symbolDefById(instance.symbolId);
+    if (!symbolDef) return null;
+    for (var i = 0; i < symbolDef.pins.length; i++) {
+      if (symbolDef.pins[i].number === pinNumber) return symbolDef.pins[i];
+    }
+    return null;
+  }
+
+  // ====================================================================
+  // 6. SYMBOL PLACEMENT + REF-DES ASSIGNMENT
+  // ====================================================================
+
+  function bumpRefDes(prefix) {
+    var n = (STATE.refDesCounters[prefix] || 0) + 1;
+    STATE.refDesCounters[prefix] = n;
+    return prefix + n;
+  }
+
+  // Recompute the refDes counters by scanning instances. Called when a
+  // saved graph is loaded so subsequent placements continue the
+  // sequence rather than colliding.
+  function rebuildRefDesCounters() {
+    STATE.refDesCounters = {};
+    STATE.graph.instances.forEach(function (inst) {
+      var m = (inst.refDes || '').match(/^([A-Za-z]+)(\d+)$/);
+      if (!m) return;
+      var prefix = m[1];
+      var n = parseInt(m[2], 10);
+      if (n > (STATE.refDesCounters[prefix] || 0)) {
+        STATE.refDesCounters[prefix] = n;
+      }
+    });
+  }
+
+  function rebuildNetCounter() {
+    var max = 0;
+    STATE.graph.nets.forEach(function (net) {
+      var m = (net.name || '').match(/^Net-(\d+)$/);
+      if (m) {
+        var n = parseInt(m[1], 10);
+        if (n > max) max = n;
+      }
+    });
+    STATE.netCounter = max;
+  }
+
+  function placeSymbolAt(symbolId, sceneX, sceneY) {
+    var symbolDef = symbolDefById(symbolId);
+    if (!symbolDef) return null;
+    var instance = {
+      id: nextId('inst'),
+      symbolId: symbolId,
+      refDes: bumpRefDes(symbolDef.refDesPrefix),
+      x: snap(sceneX),
+      y: snap(sceneY),
+      rotation: 0,
+      flipH: false,
+      flipV: false,
+    };
+    STATE.graph.instances.push(instance);
+    renderGraph();
+    scheduleAutosave();
+    return instance;
+  }
+
+  // ====================================================================
+  // 7. NET DRAWING
+  // ====================================================================
+  //
+  // Net topology:
+  //   - A Net groups endpoints (pin references) and an ordered list of
+  //     wire segments (each a 4-tuple: x1,y1,x2,y2).
+  //   - When the user clicks two pins, we compute an L-shaped polyline
+  //     between them (single 90° corner) and:
+  //       * if both pins are unconnected → create a new net,
+  //       * if one is on an existing net → join into that net,
+  //       * if both are on different nets → MERGE the two nets into
+  //         one. The merge call is documented in the wrap-up.
+
+  function endpointsMatch(a, b) {
+    return a.instanceId === b.instanceId && a.pinNumber === b.pinNumber;
+  }
+
+  function findNetByEndpoint(endpoint) {
+    for (var i = 0; i < STATE.graph.nets.length; i++) {
+      var net = STATE.graph.nets[i];
+      for (var j = 0; j < net.endpoints.length; j++) {
+        if (endpointsMatch(net.endpoints[j], endpoint)) return net;
+      }
+    }
+    return null;
+  }
+
+  // Auto-name nets touching named power pins (GND / VBUS / VCC / 3V3 / V+)
+  // — the auto-name dramatically improves the connections-table read.
+  function autoNetNameForPin(instance, pin) {
+    var name = (pin.name || '').toUpperCase();
+    if (name === 'GND') return 'GND';
+    if (name === 'VBUS' || name === 'VCC' || name === 'V+' ||
+        name === '3V3' || name === '5V')   return name;
+    var symbolDef = symbolDefById(instance.symbolId);
+    if (symbolDef && symbolDef.id === 'gnd') return 'GND';
+    if (symbolDef && symbolDef.id === 'vplus') return 'VBUS';
+    return null;
+  }
+
+  function newNet(name) {
+    if (!name) {
+      STATE.netCounter += 1;
+      name = 'Net-' + STATE.netCounter;
+    }
+    var net = {
+      id: nextId('net'),
+      name: name,
+      color: INK,
+      description: '',
+      endpoints: [],
+      segments: [],
+    };
+    STATE.graph.nets.push(net);
+    return net;
+  }
+
+  // Compute an L-shaped polyline between (x1,y1) and (x2,y2). One 90°
+  // corner; horizontal-then-vertical is chosen so the resulting wire
+  // visually exits the source pin along the symbol's pin axis (which
+  // is left/right for the bulk of our library) — the connection feels
+  // right for most layouts. A future router could choose corner
+  // direction dynamically.
+  function lShapedSegments(x1, y1, x2, y2) {
+    x1 = snap(x1); y1 = snap(y1);
+    x2 = snap(x2); y2 = snap(y2);
+    if (x1 === x2 && y1 === y2) return [];
+    if (x1 === x2 || y1 === y2) {
+      // Straight line — no corner.
+      return [{ x1: x1, y1: y1, x2: x2, y2: y2 }];
+    }
+    var cornerX = x2;
+    var cornerY = y1;
+    return [
+      { x1: x1, y1: y1, x2: cornerX, y2: cornerY },
+      { x1: cornerX, y1: cornerY, x2: x2, y2: y2 },
+    ];
+  }
+
+  function mergeNets(target, source) {
+    // Append source's endpoints (deduped) and segments into target,
+    // then drop source from STATE.graph.nets.
+    source.endpoints.forEach(function (ep) {
+      var dup = target.endpoints.some(function (t) { return endpointsMatch(t, ep); });
+      if (!dup) target.endpoints.push(ep);
+    });
+    source.segments.forEach(function (seg) { target.segments.push(seg); });
+    if (source.description && !target.description) {
+      target.description = source.description;
+    }
+    var idx = STATE.graph.nets.indexOf(source);
+    if (idx >= 0) STATE.graph.nets.splice(idx, 1);
+    return target;
+  }
+
+  // Connect two pin endpoints. Decides on a target net (creating /
+  // merging as needed), appends the L-shaped segments + endpoints, and
+  // re-renders. Returns the resulting net.
+  function commitNetSegment(fromEp, toEp) {
+    if (endpointsMatch(fromEp, toEp)) return null;
+
+    var fromInst = findInstance(fromEp.instanceId);
+    var toInst   = findInstance(toEp.instanceId);
+    if (!fromInst || !toInst) return null;
+    var fromPin = findPin(fromInst, fromEp.pinNumber);
+    var toPin   = findPin(toInst,   toEp.pinNumber);
+    if (!fromPin || !toPin) return null;
+
+    var fromXY = pinScenePos(fromInst, fromPin);
+    var toXY   = pinScenePos(toInst,   toPin);
+
+    var fromNet = findNetByEndpoint(fromEp);
+    var toNet   = findNetByEndpoint(toEp);
+    var target;
+    if (fromNet && toNet && fromNet !== toNet) {
+      // Merge into the larger net (favours the named-power net if either
+      // is named GND/VBUS/etc., otherwise just the longer one).
+      var preferred = preferTargetNet(fromNet, toNet);
+      var other     = (preferred === fromNet) ? toNet : fromNet;
+      target = mergeNets(preferred, other);
+    } else if (fromNet) {
+      target = fromNet;
+    } else if (toNet) {
+      target = toNet;
+    } else {
+      var auto = autoNetNameForPin(fromInst, fromPin) ||
+                 autoNetNameForPin(toInst,   toPin);
+      target = newNet(auto);
+    }
+
+    [fromEp, toEp].forEach(function (ep) {
+      var dup = target.endpoints.some(function (t) { return endpointsMatch(t, ep); });
+      if (!dup) target.endpoints.push(ep);
+    });
+    lShapedSegments(fromXY.x, fromXY.y, toXY.x, toXY.y).forEach(function (s) {
+      target.segments.push(s);
+    });
+
+    return target;
+  }
+
+  function preferTargetNet(a, b) {
+    var aPower = isPowerNetName(a.name);
+    var bPower = isPowerNetName(b.name);
+    if (aPower && !bPower) return a;
+    if (bPower && !aPower) return b;
+    // Prefer the one with more endpoints — losing a smaller name is
+    // less surprising than losing GND.
+    return (a.endpoints.length >= b.endpoints.length) ? a : b;
+  }
+  function isPowerNetName(name) {
+    return /^(GND|VBUS|VCC|3V3|5V|V\+)$/i.test(name || '');
+  }
+
+  // ====================================================================
+  // 8. JUNCTION DOTS
+  // ====================================================================
+  //
+  // A junction is a point where 3+ wire segment endpoints meet. We
+  // compute it by counting how often each (x, y) appears as a segment
+  // endpoint *across all nets*; any point with count >= 3 gets a dot.
+  // Points within JUNCTION_TOLERANCE px are treated as identical (snap
+  // makes this almost always exact, but the tolerance covers rounding).
+
+  function computeJunctions() {
+    var buckets = [];
+    function bump(x, y) {
+      for (var i = 0; i < buckets.length; i++) {
+        var b = buckets[i];
+        if (Math.abs(b.x - x) <= JUNCTION_TOLERANCE &&
+            Math.abs(b.y - y) <= JUNCTION_TOLERANCE) {
+          b.count += 1;
+          return;
+        }
+      }
+      buckets.push({ x: x, y: y, count: 1 });
+    }
+    STATE.graph.nets.forEach(function (net) {
+      net.segments.forEach(function (s) {
+        bump(s.x1, s.y1);
+        bump(s.x2, s.y2);
+      });
+    });
+    return buckets.filter(function (b) { return b.count >= 3; });
+  }
+
+  // ====================================================================
+  // 9. RENDERING — FABRIC OBJECTS
+  // ====================================================================
+
+  function buildGridPattern() {
+    // Render the dot grid as a small offscreen canvas and use it as the
+    // background pattern. Cheap, scales with zoom.
+    var off = document.createElement('canvas');
+    off.width = GRID;
+    off.height = GRID;
+    var ctx = off.getContext('2d');
+    ctx.fillStyle = BG;
+    ctx.fillRect(0, 0, GRID, GRID);
+    ctx.fillStyle = GRID_DOT;
+    ctx.beginPath();
+    ctx.arc(0, 0, 1.3, 0, Math.PI * 2);
+    ctx.fill();
+    return off;
+  }
+
+  function applyGridBackground() {
+    if (!STATE.canvas) return;
+    var pattern = new fabric.Pattern({
+      source: buildGridPattern(),
+      repeat: 'repeat',
+    });
+    STATE.canvas.set('backgroundColor', pattern);
+    STATE.canvas.requestRenderAll();
+  }
+
+  // Build a Fabric.Group representing one symbol instance. Pins,
+  // pin labels, body, refDes label and origin cross are all included.
+  function buildInstanceFabric(instance) {
+    var symbolDef = symbolDefById(instance.symbolId);
+    if (!symbolDef) return null;
+    var w = symbolDef.bodyWidth;
+    var h = symbolDef.bodyHeight;
+    var pieces = [];
+
+    // Body
+    var body = new fabric.Rect({
+      left: -w / 2,
+      top: -h / 2,
+      width: w,
+      height: h,
+      fill: '#ffffff',
+      stroke: INK,
+      strokeWidth: 1.5,
+      rx: 4,
+      ry: 4,
+      originX: 'left',
+      originY: 'top',
+    });
+    pieces.push(body);
+
+    // refDes + name label, anchored above the body.
+    var refLabel = new fabric.Text(
+      (instance.refDes || '') + ' · ' + symbolDef.name,
+      {
+        left: 0,
+        top: -h / 2 - 22,
+        fontSize: 12,
+        fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+        fill: INK,
+        originX: 'center',
+        originY: 'top',
+      }
+    );
+    pieces.push(refLabel);
+
+    // Pins: a short stick + a pin-name label.
+    symbolDef.pins.forEach(function (pin) {
+      var local = pinLocalPos(symbolDef, pin);
+      // Translate from "0..bodyWidth" coords to body-centred coords.
+      var px = local.x - w / 2;
+      var py = local.y - h / 2;
+      var stickLen = 8;
+      var sx2 = px, sy2 = py;
+      switch (pin.side) {
+        case 'left':   sx2 = px - stickLen; sy2 = py; break;
+        case 'right':  sx2 = px + stickLen; sy2 = py; break;
+        case 'top':    sx2 = px; sy2 = py - stickLen; break;
+        case 'bottom': sx2 = px; sy2 = py + stickLen; break;
+      }
+      var stick = new fabric.Line([px, py, sx2, sy2], {
+        stroke: INK,
+        strokeWidth: 1.5,
+      });
+      pieces.push(stick);
+
+      // Pin label — anchored just inside the body, away from the stick.
+      var lx = px, ly = py;
+      var anchorX = 'left', anchorY = 'center';
+      var pad = 4;
+      switch (pin.side) {
+        case 'left':   lx = px + pad;  ly = py - 6; anchorX = 'left';   anchorY = 'top'; break;
+        case 'right':  lx = px - pad;  ly = py - 6; anchorX = 'right';  anchorY = 'top'; break;
+        case 'top':    lx = px - 6;    ly = py + pad; anchorX = 'right'; anchorY = 'top'; break;
+        case 'bottom': lx = px - 6;    ly = py - pad; anchorX = 'right'; anchorY = 'bottom'; break;
+      }
+      pieces.push(new fabric.Text(pin.name || pin.number, {
+        left: lx,
+        top: ly,
+        fontSize: 9,
+        fill: INK,
+        fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+        originX: anchorX,
+        originY: anchorY,
+      }));
+    });
+
+    // Origin cross (small red "+")
+    pieces.push(new fabric.Line([-6, 0, 6, 0], { stroke: BRAND_RED, strokeWidth: 1 }));
+    pieces.push(new fabric.Line([0, -6, 0, 6], { stroke: BRAND_RED, strokeWidth: 1 }));
+
+    var group = new fabric.Group(pieces, {
+      left: instance.x,
+      top: instance.y,
+      originX: 'center',
+      originY: 'center',
+      angle: instance.rotation || 0,
+      flipX: !!instance.flipH,
+      flipY: !!instance.flipV,
+      lockScalingFlip: true,
+      hasControls: false,         // no scale/skew handles — symbols are fixed size
+      hasBorders: true,
+      borderColor: BRAND_RED,
+      borderScaleFactor: 1.2,
+      objectCaching: false,
+    });
+    group.data = { kind: 'instance', instanceId: instance.id };
+    return group;
+  }
+
+  function buildNetFabric(net, selected) {
+    // One Polyline per segment — cheaper than building a single
+    // multi-segment Path when we want individual segments to be
+    // hit-testable.
+    var objs = [];
+    net.segments.forEach(function (seg) {
+      var line = new fabric.Line([seg.x1, seg.y1, seg.x2, seg.y2], {
+        stroke: selected ? BRAND_RED : (net.color || INK),
+        strokeWidth: selected ? NET_STROKE_SELECTED : NET_STROKE,
+        selectable: true,
+        hasControls: false,
+        hasBorders: false,
+        hoverCursor: 'pointer',
+        perPixelTargetFind: true,
+        objectCaching: false,
+      });
+      line.data = { kind: 'net', netId: net.id };
+      objs.push(line);
+    });
+    return objs;
+  }
+
+  function buildJunctionFabric(j) {
+    return new fabric.Circle({
+      left: j.x,
+      top: j.y,
+      radius: JUNCTION_DOT_R,
+      fill: INK,
+      originX: 'center',
+      originY: 'center',
+      selectable: false,
+      evented: false,
+    });
+  }
+
+  function buildPinHotspot(instance, pin) {
+    // Invisible (but evented) hit target on each pin — only active in
+    // Net-drawing mode so it doesn't compete with the symbol Group for
+    // hover / click. Sized generously (12px square) so pin clicks are
+    // forgiving.
+    var pos = pinScenePos(instance, pin);
+    var hot = new fabric.Circle({
+      left: pos.x,
+      top: pos.y,
+      radius: 6,
+      fill: 'rgba(0,0,0,0.001)',
+      stroke: null,
+      originX: 'center',
+      originY: 'center',
+      selectable: false,
+      hasControls: false,
+      hasBorders: false,
+      hoverCursor: 'crosshair',
+      evented: true,
+    });
+    hot.data = {
+      kind: 'pin-hotspot',
+      instanceId: instance.id,
+      pinNumber: pin.number,
+      x: pos.x,
+      y: pos.y,
+    };
+    return hot;
+  }
+
+  // ====================================================================
+  // 10. RENDER LOOP
+  // ====================================================================
+  //
+  // ``renderGraph`` is the single rebuild entry point: it wipes the
+  // Fabric canvas and reconstructs every visible object from
+  // STATE.graph + selection. Coarse but simple — the canvas rarely
+  // holds more than ~50 symbols + ~100 segments in v1.
+
+  function renderGraph() {
+    if (!STATE.canvas) return;
+    STATE.canvas.discardActiveObject();
+    STATE.canvas.clear();
+    applyGridBackground();
+
+    // Nets first so symbols sit on top.
+    STATE.graph.nets.forEach(function (net) {
+      var selected = (net.id === STATE.selectedNetId);
+      buildNetFabric(net, selected).forEach(function (line) {
+        STATE.canvas.add(line);
+      });
+    });
+
+    // Symbols
+    STATE.graph.instances.forEach(function (inst) {
+      var g = buildInstanceFabric(inst);
+      if (g) STATE.canvas.add(g);
+    });
+
+    // Junctions
+    computeJunctions().forEach(function (j) {
+      STATE.canvas.add(buildJunctionFabric(j));
+    });
+
+    // Pin hotspots — only when the Net tool is active.
+    if (STATE.activeTool === 'net') {
+      STATE.graph.instances.forEach(function (inst) {
+        var symbolDef = symbolDefById(inst.symbolId);
+        if (!symbolDef) return;
+        symbolDef.pins.forEach(function (pin) {
+          STATE.canvas.add(buildPinHotspot(inst, pin));
+        });
+      });
+    }
+
+    // Re-attach net preview overlay if drawing.
+    if (STATE.netPreviewObj) {
+      STATE.canvas.add(STATE.netPreviewObj);
+    }
+
+    STATE.canvas.requestRenderAll();
+    renderConnectionsTable();
+    updateSymbolHud();
+  }
+
+  // ====================================================================
+  // 11. CONNECTIONS TABLE
+  // ====================================================================
+
+  function refLabel(endpoint) {
+    var inst = findInstance(endpoint.instanceId);
+    if (!inst) return '?';
+    var pin = findPin(inst, endpoint.pinNumber);
+    var pinName = pin ? (pin.name || pin.number) : endpoint.pinNumber;
+    return (inst.refDes || '?') + '.' + pinName;
+  }
+
+  // Endpoint-pair listing: one row per *unique* pair of endpoints
+  // within a net. For a 2-endpoint net that's 1 row. For a 5-endpoint
+  // net that's 10 rows — fine for typical Pico-class schematics. If
+  // this gets too noisy in practice we can switch to the simpler
+  // "one row per endpoint" listing documented in the wrap-up.
+  function deriveConnections() {
+    var rows = [];
+    STATE.graph.nets.forEach(function (net) {
+      var eps = net.endpoints;
+      if (eps.length === 0) return;
+      if (eps.length === 1) {
+        rows.push({
+          netId: net.id,
+          netName: net.name,
+          from: refLabel(eps[0]),
+          to: '—',
+          description: net.description || '',
+        });
+        return;
+      }
+      for (var i = 0; i < eps.length; i++) {
+        for (var j = i + 1; j < eps.length; j++) {
+          rows.push({
+            netId: net.id,
+            netName: net.name,
+            from: refLabel(eps[i]),
+            to:   refLabel(eps[j]),
+            description: net.description || '',
+          });
+        }
+      }
+    });
+    return rows;
+  }
+
+  function renderConnectionsTable() {
+    if (!dom.tableBody) return;
+    var rows = deriveConnections();
+    if (dom.tableCount) {
+      dom.tableCount.textContent = rows.length
+        ? '(' + rows.length + ')' : '';
+    }
+    if (rows.length === 0) {
+      dom.tableBody.innerHTML =
+        '<tr class="se-table-empty"><td colspan="4" class="text-muted text-center py-3">' +
+        'No connections yet &mdash; draw a wire between two pins to start.' +
+        '</td></tr>';
+      return;
+    }
+    var html = '';
+    rows.forEach(function (r, idx) {
+      var sel = (r.netId === STATE.selectedNetId) ? ' is-selected' : '';
+      html +=
+        '<tr class="se-table-row' + sel + '" data-net-id="' + escapeHtml(r.netId) + '">' +
+          '<td class="se-td-net">' + escapeHtml(r.netName) + '</td>' +
+          '<td class="se-td-from">' + escapeHtml(r.from) + '</td>' +
+          '<td class="se-td-to">' + escapeHtml(r.to) + '</td>' +
+          '<td class="se-td-desc">' +
+            '<input type="text" class="form-control form-control-sm se-desc-input" ' +
+                   'data-net-id="' + escapeHtml(r.netId) + '" ' +
+                   'value="' + escapeHtml(r.description) + '" ' +
+                   'placeholder="(none)" maxlength="500">' +
+          '</td>' +
+        '</tr>';
+    });
+    dom.tableBody.innerHTML = html;
+  }
+
+  function onTableRowClick(ev) {
+    var input = ev.target.closest('.se-desc-input');
+    if (input) return;       // let the input handle its own focus / clicks
+    var row = ev.target.closest('.se-table-row');
+    if (!row) return;
+    var netId = row.dataset.netId;
+    if (!netId) return;
+    selectNet(netId, { centreOnCanvas: true });
+  }
+
+  function onTableInputChange(ev) {
+    var input = ev.target.closest('.se-desc-input');
+    if (!input) return;
+    var netId = input.dataset.netId;
+    if (!netId) return;
+    var net = STATE.graph.nets.find(function (n) { return n.id === netId; });
+    if (!net) return;
+    if (net.description === input.value) return;
+    net.description = input.value;
+    scheduleAutosave();
+    // Don't re-render the whole table — that would steal focus mid-edit.
+    // The other rows reading the same net will pick up the new value on
+    // the next coarse re-render (next save / canvas update).
+  }
+
+  // ====================================================================
+  // 12. SELECTION + HIGHLIGHT
+  // ====================================================================
+
+  function selectNet(netId, opts) {
+    opts = opts || {};
+    STATE.selectedNetId = netId;
+    STATE.selectedInstanceId = null;
+    renderGraph();
+    // Scroll the connections table to the first matching row.
+    if (dom.tableBody) {
+      var row = dom.tableBody.querySelector('.se-table-row.is-selected');
+      if (row && row.scrollIntoView) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+    if (opts.centreOnCanvas) {
+      var net = STATE.graph.nets.find(function (n) { return n.id === netId; });
+      if (net && net.segments.length > 0) {
+        // No "pan-to-point" in our minimal canvas (fit-to-screen) —
+        // the visual highlight already provides the cue.
+      }
+    }
+  }
+
+  function clearSelection() {
+    STATE.selectedInstanceId = null;
+    STATE.selectedNetId = null;
+    renderGraph();
+  }
+
+  // ====================================================================
+  // 13. AUTOSAVE
+  // ====================================================================
+
+  function serialiseGraph() {
+    // The schematic id is server-side; everything else is the document.
+    return JSON.stringify({
+      instances: STATE.graph.instances,
+      nets: STATE.graph.nets,
+      labels: STATE.graph.labels,
+    });
+  }
+
+  function scheduleAutosave() {
+    if (STATE.autosaveTimer) clearTimeout(STATE.autosaveTimer);
+    setSaveStatus('saving');
+    STATE.autosaveTimer = setTimeout(function () {
+      STATE.autosaveTimer = null;
+      doAutosave();
+    }, AUTOSAVE_MS);
+  }
+
+  async function doAutosave() {
+    if (!STATE.schematic) return;
+    try {
+      var resp = await apiFetchWithTermsRetry(
+        API + '/api/projects/' + STATE.projectId + '/schematic',
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ schematic_data: serialiseGraph() }),
+        }
+      );
+      if (!resp.ok) throw new Error('PUT schematic HTTP ' + resp.status);
+      setSaveStatus('saved');
+    } catch (e) {
+      setSaveStatus('error', 'Save failed');
+    }
+  }
+
+  // ====================================================================
+  // 14. SYMBOL HUD (rotate / flip / delete above selection)
+  // ====================================================================
+
+  function updateSymbolHud() {
+    if (!dom.symbolHud) return;
+    if (!STATE.selectedInstanceId) {
+      dom.symbolHud.hidden = true;
+      return;
+    }
+    var inst = findInstance(STATE.selectedInstanceId);
+    if (!inst) { dom.symbolHud.hidden = true; return; }
+    var symbolDef = symbolDefById(inst.symbolId);
+    if (!symbolDef) { dom.symbolHud.hidden = true; return; }
+    dom.symbolHud.hidden = false;
+    // Position above the symbol. Fabric coords are scene coords; we
+    // convert to CSS pixel coords via the canvas viewport.
+    var zoom = STATE.canvas.getZoom();
+    var cssTop = (inst.y - symbolHeight(symbolDef, inst.rotation) / 2) * zoom;
+    var cssLeft = inst.x * zoom;
+    dom.symbolHud.style.left = cssLeft + 'px';
+    dom.symbolHud.style.top = (cssTop - 32) + 'px';
+  }
+
+  function rotateSelected(deltaDeg) {
+    var inst = findInstance(STATE.selectedInstanceId);
+    if (!inst) return;
+    inst.rotation = (((inst.rotation || 0) + deltaDeg) % 360 + 360) % 360;
+    rerouteNetsFor(inst.id);
+    renderGraph();
+    scheduleAutosave();
+  }
+
+  function flipSelected(axis) {
+    var inst = findInstance(STATE.selectedInstanceId);
+    if (!inst) return;
+    if (axis === 'h') inst.flipH = !inst.flipH;
+    if (axis === 'v') inst.flipV = !inst.flipV;
+    rerouteNetsFor(inst.id);
+    renderGraph();
+    scheduleAutosave();
+  }
+
+  function deleteSelected() {
+    if (STATE.selectedInstanceId) {
+      var id = STATE.selectedInstanceId;
+      STATE.graph.instances = STATE.graph.instances.filter(function (i) {
+        return i.id !== id;
+      });
+      // Strip net endpoints that referenced this instance. Nets that
+      // become endpoint-less are removed entirely.
+      STATE.graph.nets = STATE.graph.nets.map(function (n) {
+        n.endpoints = n.endpoints.filter(function (ep) {
+          return ep.instanceId !== id;
+        });
+        return n;
+      }).filter(function (n) {
+        return n.endpoints.length > 0 || n.segments.length > 0;
+      });
+      STATE.selectedInstanceId = null;
+    } else if (STATE.selectedNetId) {
+      STATE.graph.nets = STATE.graph.nets.filter(function (n) {
+        return n.id !== STATE.selectedNetId;
+      });
+      STATE.selectedNetId = null;
+    }
+    renderGraph();
+    scheduleAutosave();
+  }
+
+  // When a symbol moves or rotates, the pin scene-positions shift —
+  // the stored segments don't auto-follow. For v1 we rebuild each
+  // affected net's segments from scratch via the recorded endpoints,
+  // re-running the L-bend router for each pair. Imperfect (we lose any
+  // hand-edited bends the user might have made) but the v1 editor
+  // doesn't expose hand-editing, so the loss is hypothetical.
+  function rerouteNetsFor(instanceId) {
+    STATE.graph.nets.forEach(function (net) {
+      var touchesThis = net.endpoints.some(function (ep) {
+        return ep.instanceId === instanceId;
+      });
+      if (!touchesThis) return;
+      // Re-route as a fan from endpoints[0] to the others. Topology is
+      // preserved (same endpoints, same net id); only the segment
+      // geometry refreshes.
+      if (net.endpoints.length < 2) { net.segments = []; return; }
+      var newSegs = [];
+      var anchor = net.endpoints[0];
+      var anchorInst = findInstance(anchor.instanceId);
+      var anchorPin = anchorInst && findPin(anchorInst, anchor.pinNumber);
+      if (!anchorInst || !anchorPin) { net.segments = []; return; }
+      var anchorXY = pinScenePos(anchorInst, anchorPin);
+      for (var i = 1; i < net.endpoints.length; i++) {
+        var ep = net.endpoints[i];
+        var inst = findInstance(ep.instanceId);
+        var pin = inst && findPin(inst, ep.pinNumber);
+        if (!inst || !pin) continue;
+        var xy = pinScenePos(inst, pin);
+        lShapedSegments(anchorXY.x, anchorXY.y, xy.x, xy.y).forEach(function (s) {
+          newSegs.push(s);
+        });
+      }
+      net.segments = newSegs;
+    });
+  }
+
+  // ====================================================================
+  // 15. CANVAS EVENTS
+  // ====================================================================
+
+  function pointerScene(opt) {
+    var p = STATE.canvas.getPointer(opt.e);
+    return { x: p.x, y: p.y };
+  }
+
+  function onCanvasMouseDown(opt) {
+    var obj = opt.target;
+    var p = pointerScene(opt);
+
+    // ----- Place-symbol mode -----
+    if (STATE.activeTool === 'symbol' && STATE.pendingSymbolId) {
+      placeSymbolAt(STATE.pendingSymbolId, p.x, p.y);
+      return;
+    }
+    if (STATE.activeTool === 'gnd') {
+      placeSymbolAt('gnd', p.x, p.y);
+      setActiveTool('select');
+      return;
+    }
+    if (STATE.activeTool === 'vplus') {
+      placeSymbolAt('vplus', p.x, p.y);
+      setActiveTool('select');
+      return;
+    }
+
+    // ----- Net-drawing mode -----
+    if (STATE.activeTool === 'net') {
+      if (obj && obj.data && obj.data.kind === 'pin-hotspot') {
+        var ep = {
+          instanceId: obj.data.instanceId,
+          pinNumber: obj.data.pinNumber,
+        };
+        if (!STATE.netDrawingFrom) {
+          STATE.netDrawingFrom = {
+            instanceId: ep.instanceId,
+            pinNumber: ep.pinNumber,
+            x: obj.data.x,
+            y: obj.data.y,
+          };
+        } else {
+          // Commit the net.
+          var fromEp = {
+            instanceId: STATE.netDrawingFrom.instanceId,
+            pinNumber: STATE.netDrawingFrom.pinNumber,
+          };
+          var net = commitNetSegment(fromEp, ep);
+          STATE.netDrawingFrom = null;
+          if (STATE.netPreviewObj) {
+            STATE.canvas.remove(STATE.netPreviewObj);
+            STATE.netPreviewObj = null;
+          }
+          renderGraph();
+          if (net) selectNet(net.id);
+          scheduleAutosave();
+        }
+        return;
+      }
+      // Click empty space mid-draw: abort.
+      if (STATE.netDrawingFrom) {
+        STATE.netDrawingFrom = null;
+        if (STATE.netPreviewObj) {
+          STATE.canvas.remove(STATE.netPreviewObj);
+          STATE.netPreviewObj = null;
+          STATE.canvas.requestRenderAll();
+        }
+      }
+      return;
+    }
+
+    // ----- Selection (default) -----
+    if (obj && obj.data) {
+      if (obj.data.kind === 'instance') {
+        STATE.selectedInstanceId = obj.data.instanceId;
+        STATE.selectedNetId = null;
+      } else if (obj.data.kind === 'net') {
+        STATE.selectedNetId = obj.data.netId;
+        STATE.selectedInstanceId = null;
+      } else {
+        clearSelection();
+        return;
+      }
+      renderGraph();
+      return;
+    }
+    clearSelection();
+  }
+
+  function onCanvasMouseMove(opt) {
+    if (STATE.activeTool !== 'net' || !STATE.netDrawingFrom) return;
+    var p = pointerScene(opt);
+    var from = STATE.netDrawingFrom;
+    var segs = lShapedSegments(from.x, from.y, p.x, p.y);
+    if (STATE.netPreviewObj) {
+      STATE.canvas.remove(STATE.netPreviewObj);
+      STATE.netPreviewObj = null;
+    }
+    if (segs.length === 0) { STATE.canvas.requestRenderAll(); return; }
+    var pts = [{ x: segs[0].x1, y: segs[0].y1 }];
+    segs.forEach(function (s) { pts.push({ x: s.x2, y: s.y2 }); });
+    STATE.netPreviewObj = new fabric.Polyline(pts, {
+      stroke: BRAND_RED,
+      strokeWidth: NET_STROKE,
+      fill: '',
+      strokeDashArray: [4, 4],
+      selectable: false,
+      evented: false,
+    });
+    STATE.canvas.add(STATE.netPreviewObj);
+    STATE.canvas.requestRenderAll();
+  }
+
+  function onCanvasObjectMoving(opt) {
+    var obj = opt.target;
+    if (!obj || !obj.data || obj.data.kind !== 'instance') return;
+    var inst = findInstance(obj.data.instanceId);
+    if (!inst) return;
+    // Snap the moving group to the grid as it drags.
+    var snappedLeft = snap(obj.left);
+    var snappedTop = snap(obj.top);
+    obj.set({ left: snappedLeft, top: snappedTop });
+    inst.x = snappedLeft;
+    inst.y = snappedTop;
+    rerouteNetsFor(inst.id);
+    updateSymbolHud();
+  }
+
+  function onCanvasObjectModified(opt) {
+    var obj = opt.target;
+    if (!obj || !obj.data || obj.data.kind !== 'instance') return;
+    var inst = findInstance(obj.data.instanceId);
+    if (!inst) return;
+    inst.x = obj.left;
+    inst.y = obj.top;
+    rerouteNetsFor(inst.id);
+    renderGraph();
+    scheduleAutosave();
+  }
+
+  // ====================================================================
+  // 16. TOOLS PANE
+  // ====================================================================
+
+  function setActiveTool(tool) {
+    STATE.activeTool = tool;
+    // When entering net mode, clear any partial draw.
+    if (tool !== 'net' && STATE.netDrawingFrom) {
+      STATE.netDrawingFrom = null;
+      if (STATE.netPreviewObj) {
+        STATE.canvas.remove(STATE.netPreviewObj);
+        STATE.netPreviewObj = null;
+      }
+    }
+    // The Rotate tool is a one-shot — apply to the selection then revert.
+    if (tool === 'rotate') {
+      rotateSelected(90);
+      STATE.activeTool = 'select';
+      tool = 'select';
+    }
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.se-tool-btn'),
+      function (btn) {
+        btn.classList.toggle('is-active', btn.dataset.tool === tool);
+      }
+    );
+    if (tool !== 'symbol') {
+      STATE.pendingSymbolId = null;
+      Array.prototype.forEach.call(
+        document.querySelectorAll('.se-symbol-item'),
+        function (li) { li.classList.remove('is-pending'); }
+      );
+    }
+    renderGraph();
+  }
+
+  function renderSymbolList() {
+    if (!dom.symbolList) return;
+    var html = '';
+    SYMBOL_LIBRARY.forEach(function (sym) {
+      html +=
+        '<li class="se-symbol-item" data-symbol-id="' + escapeHtml(sym.id) + '" ' +
+            'role="option" tabindex="0">' +
+          '<span class="se-symbol-thumb"><i class="fas fa-microchip"></i></span>' +
+          '<span class="se-symbol-meta">' +
+            '<span class="se-symbol-name">' + escapeHtml(sym.name) + '</span>' +
+            '<span class="se-symbol-sub small text-muted">' +
+              escapeHtml(sym.refDesPrefix) + ' &middot; ' +
+              sym.pins.length + ' pins' +
+            '</span>' +
+          '</span>' +
+        '</li>';
+    });
+    dom.symbolList.innerHTML = html;
+  }
+
+  function onSymbolItemClick(ev) {
+    var li = ev.target.closest('.se-symbol-item');
+    if (!li) return;
+    var symId = li.dataset.symbolId;
+    if (!symId) return;
+    STATE.pendingSymbolId = symId;
+    setActiveTool('symbol');
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.se-symbol-item'),
+      function (other) { other.classList.toggle('is-pending', other === li); }
+    );
+  }
+
+  // ====================================================================
+  // 17. EXPORTS
+  // ====================================================================
+
+  function downloadBlob(blob, filename) {
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 200);
+  }
+
+  function exportCSV() {
+    var rows = deriveConnections();
+    var lines = ['Net,From,To,Description'];
+    rows.forEach(function (r) {
+      lines.push([
+        csvCell(r.netName),
+        csvCell(r.from),
+        csvCell(r.to),
+        csvCell(r.description),
+      ].join(','));
+    });
+    var blob = new Blob([lines.join('\n') + '\n'], { type: 'text/csv;charset=utf-8' });
+    downloadBlob(blob, 'schematic-connections.csv');
+  }
+  function csvCell(v) {
+    v = String(v == null ? '' : v);
+    if (/[",\n]/.test(v)) return '"' + v.replace(/"/g, '""') + '"';
+    return v;
+  }
+
+  function exportPNG() {
+    if (!STATE.canvas) return;
+    // Use Fabric's toDataURL with 2x supersampling for a crisp export.
+    var dataUrl = STATE.canvas.toDataURL({
+      format: 'png',
+      multiplier: 2,
+      enableRetinaScaling: false,
+    });
+    var a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = 'schematic.png';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
+
+  // ====================================================================
+  // 18. SYMBOL-HUD WIRING
+  // ====================================================================
+
+  function wireSymbolHud() {
+    if (!dom.symbolHud) return;
+    dom.symbolHud.addEventListener('click', function (ev) {
+      var btn = ev.target.closest('[data-hud-action]');
+      if (!btn) return;
+      switch (btn.dataset.hudAction) {
+        case 'rotate-ccw': rotateSelected(-90); break;
+        case 'rotate-cw':  rotateSelected(90);  break;
+        case 'flip-h':     flipSelected('h');   break;
+        case 'flip-v':     flipSelected('v');   break;
+        case 'delete':     deleteSelected();    break;
+      }
+    });
+  }
+
+  // ====================================================================
+  // 19. CANVAS INIT
+  // ====================================================================
+
+  function initCanvas() {
+    if (typeof fabric === 'undefined' || !fabric.Canvas) {
+      throw new Error('Fabric.js failed to load');
+    }
+    STATE.canvas = new fabric.Canvas(dom.canvasEl, {
+      width: SCENE_W,
+      height: SCENE_H,
+      backgroundColor: BG,
+      preserveObjectStacking: true,
+      selection: false,
+      // Make the canvas a defined size relative to the container.
+    });
+
+    var c = STATE.canvas;
+    c.on('mouse:down', onCanvasMouseDown);
+    c.on('mouse:move', onCanvasMouseMove);
+    c.on('object:moving',   onCanvasObjectMoving);
+    c.on('object:modified', onCanvasObjectModified);
+
+    syncCanvasDisplaySize();
+    window.addEventListener('resize', syncCanvasDisplaySize);
+
+    // Esc aborts a net-in-progress.
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        if (STATE.netDrawingFrom) {
+          STATE.netDrawingFrom = null;
+          if (STATE.netPreviewObj) {
+            STATE.canvas.remove(STATE.netPreviewObj);
+            STATE.netPreviewObj = null;
+            STATE.canvas.requestRenderAll();
+          }
+        } else {
+          clearSelection();
+        }
+      } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (document.activeElement && /input|textarea/i.test(document.activeElement.tagName)) {
+          return;
+        }
+        if (STATE.selectedInstanceId || STATE.selectedNetId) {
+          e.preventDefault();
+          deleteSelected();
+        }
+      }
+    });
+  }
+
+  function syncCanvasDisplaySize() {
+    if (!STATE.canvas || !dom.canvasWrap) return;
+    var rect = dom.canvasWrap.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    // Compute a uniform scale that fits SCENE_W × SCENE_H inside the
+    // wrap, with a small margin. The canvas internal dimensions stay
+    // SCENE_W × SCENE_H so all scene math stays simple.
+    var scale = Math.min(rect.width / SCENE_W, rect.height / SCENE_H);
+    STATE.canvas.setDimensions(
+      { width: SCENE_W * scale, height: SCENE_H * scale },
+      { cssOnly: true }
+    );
+    STATE.canvas.setZoom(scale);
+    updateSymbolHud();
+  }
+
+  // ====================================================================
+  // 20. BOOTSTRAP — fetch project, schematic, render
+  // ====================================================================
+
+  async function fetchMe() {
+    try {
+      var r = await apiFetch(API + '/api/auth/me');
+      if (!r.ok) return null;
+      return await r.json();
+    } catch (_) { return null; }
+  }
+  async function fetchProject() {
+    var r = await apiFetch(API + '/api/projects/' + STATE.projectId);
+    if (!r.ok) {
+      var err = new Error('Project HTTP ' + r.status);
+      err.status = r.status;
+      throw err;
+    }
+    return r.json();
+  }
+  async function fetchSchematic() {
+    var r = await apiFetch(API + '/api/projects/' + STATE.projectId + '/schematic');
+    if (r.status === 404) return null;
+    if (!r.ok) throw new Error('Schematic HTTP ' + r.status);
+    return r.json();
+  }
+  async function ensureSchematic() {
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + STATE.projectId + '/schematic',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      }
+    );
+    if (!resp.ok) throw new Error('Create schematic HTTP ' + resp.status);
+    return resp.json();
+  }
+
+  function loadGraphFromSchematic(schematic) {
+    var doc = emptyGraph();
+    if (schematic && schematic.schematic_data) {
+      try {
+        var parsed = JSON.parse(schematic.schematic_data);
+        if (parsed && typeof parsed === 'object') {
+          if (Array.isArray(parsed.instances)) doc.instances = parsed.instances;
+          if (Array.isArray(parsed.nets))      doc.nets = parsed.nets;
+          if (Array.isArray(parsed.labels))    doc.labels = parsed.labels;
+        }
+      } catch (_) {
+        // Corrupt blob — start fresh and let the next save overwrite it.
+      }
+    }
+    if (schematic) {
+      doc.id = schematic.id;
+      doc.name = schematic.name || '';
+      doc.description = schematic.description || '';
+    }
+    STATE.graph = doc;
+    rebuildRefDesCounters();
+    rebuildNetCounter();
+  }
+
+  function cacheDom() {
+    dom.workspace      = document.getElementById('se-workspace');
+    dom.titlebar       = document.getElementById('se-titlebar');
+    dom.backLink       = document.getElementById('se-back-link');
+    dom.projectTitle   = document.getElementById('se-project-title');
+    dom.saveStatus     = document.getElementById('se-save-status');
+    dom.exportCsvBtn   = document.getElementById('se-export-csv');
+    dom.exportPngBtn   = document.getElementById('se-export-png');
+    dom.loading        = document.getElementById('se-loading');
+    dom.notOwner       = document.getElementById('se-not-owner');
+    dom.error          = document.getElementById('se-error');
+    dom.errorDetail    = document.getElementById('se-error-detail');
+    dom.main           = document.getElementById('se-main');
+    dom.tools          = document.getElementById('se-tools');
+    dom.symbolList     = document.getElementById('se-symbol-list');
+    dom.openSymDesigner = document.getElementById('se-open-symbol-designer');
+    dom.canvasArea     = document.getElementById('se-canvas-area');
+    dom.canvasWrap     = document.getElementById('se-canvas-wrap');
+    dom.canvasEl       = document.getElementById('se-canvas');
+    dom.symbolHud      = document.getElementById('se-symbol-hud');
+    dom.tableWrap      = document.getElementById('se-table-wrap');
+    dom.tableCount     = document.getElementById('se-table-count');
+    dom.tableBody      = document.getElementById('se-table-body');
+  }
+
+  function wireUi() {
+    // Tool buttons
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.se-tool-btn'),
+      function (btn) {
+        btn.addEventListener('click', function () {
+          setActiveTool(btn.dataset.tool);
+        });
+      }
+    );
+
+    // Symbol list
+    if (dom.symbolList) {
+      dom.symbolList.addEventListener('click', onSymbolItemClick);
+    }
+
+    // Table interactions (delegated)
+    if (dom.tableBody) {
+      dom.tableBody.addEventListener('click', onTableRowClick);
+      dom.tableBody.addEventListener('change', onTableInputChange);
+    }
+
+    // Exports
+    if (dom.exportCsvBtn) dom.exportCsvBtn.addEventListener('click', exportCSV);
+    if (dom.exportPngBtn) dom.exportPngBtn.addEventListener('click', exportPNG);
+
+    wireSymbolHud();
+  }
+
+  async function init() {
+    cacheDom();
+    var params = new URLSearchParams(window.location.search);
+    STATE.projectId = params.get('id');
+    if (!STATE.projectId) {
+      if (dom.errorDetail) dom.errorDetail.textContent = 'Missing ?id=… project id in the URL.';
+      showOnly(dom.error);
+      return;
+    }
+    if (dom.backLink) dom.backLink.href =
+      '/projects/instructions/edit.html?id=' + encodeURIComponent(STATE.projectId);
+
+    try {
+      var me = await fetchMe();
+      STATE.me = me;
+      var project = await fetchProject();
+      STATE.project = project;
+      STATE.isOwner = !!(me && project && project.author_username === me.username);
+
+      if (dom.projectTitle) {
+        dom.projectTitle.textContent =
+          'Schematic · ' + (project.title || 'Untitled');
+      }
+
+      if (!STATE.isOwner) {
+        showOnly(dom.notOwner);
+        return;
+      }
+
+      // Create the row if it doesn't exist (idempotent POST on the
+      // backend). This is also where the B3 step-type-switch handler
+      // gets the schematic id from — having the row already in place
+      // means the step-link write is just an InstructionStep PUT.
+      var schematic = await fetchSchematic();
+      if (!schematic) {
+        schematic = await ensureSchematic();
+      }
+      STATE.schematic = schematic;
+      loadGraphFromSchematic(schematic);
+
+      wireUi();
+      initCanvas();
+      renderSymbolList();
+      setActiveTool('select');
+      renderGraph();
+      setSaveStatus('saved');
+
+      showOnly(dom.main);
+      // Re-fit after the layout settles.
+      setTimeout(syncCanvasDisplaySize, 50);
+    } catch (e) {
+      if (e && e.status === 404) {
+        if (dom.errorDetail) dom.errorDetail.textContent = 'Project not found.';
+      }
+      showOnly(dom.error);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/web/projects/instructions/edit.html
+++ b/web/projects/instructions/edit.html
@@ -417,11 +417,12 @@ hide_nibsy: true
             <h6 class="ib-pane-section-title">Schematic</h6>
             <div class="ib-step-schematic-card">
               <div class="ib-step-schematic-icon"><i class="fas fa-diagram-project"></i></div>
-              <p class="mb-2"><strong>Embedded schematic</strong> — full editor (E2) coming soon.</p>
+              <p class="mb-2"><strong>Embedded schematic</strong></p>
               <p class="small text-muted mb-2">
-                The schematic linked to this project will appear here once the editor ships.
+                The full schematic editor opens in a new tab. Edits propagate live to every step that embeds this schematic.
               </p>
-              <button type="button" class="btn btn-sm btn-outline-secondary" disabled>
+              <button type="button" class="btn btn-sm btn-outline-primary"
+                      id="ib-open-schematic-editor-pane">
                 <i class="fas fa-pencil me-1"></i> open editor
               </button>
             </div>
@@ -519,10 +520,11 @@ hide_nibsy: true
           </div>
           <h5 class="mb-2">Embedded schematic</h5>
           <p class="text-muted mb-3">
-            View in the Schematic Editor (coming soon).<br>
-            The project schematic will render here once the editor ships.
+            Edit the schematic in the full Schematic Editor.<br>
+            Changes here propagate live to every step that embeds it.
           </p>
-          <button type="button" class="btn btn-sm btn-outline-secondary" disabled>
+          <button type="button" class="btn btn-sm btn-outline-primary"
+                  id="ib-open-schematic-editor-canvas">
             <i class="fas fa-pencil me-1"></i> open editor
           </button>
         </div>

--- a/web/projects/schematic/edit.html
+++ b/web/projects/schematic/edit.html
@@ -1,0 +1,199 @@
+---
+title: Schematic Editor
+layout: default
+description: Edit the schematic for your project
+permalink: /projects/schematic/edit.html
+hide_nibsy: true
+---
+
+{% include nav_projects.html %}
+
+<link rel="stylesheet" href="/assets/css/schematic-editor.css?v={{ site.time | date: '%s' }}">
+
+<!-- Tag the body so site-level CSS rules (footer hide, container reset)
+     scope to this workspace only. -->
+<script>document.body.classList.add('schematic-editor-page');</script>
+
+<div class="se-workspace" id="se-workspace">
+
+  <!-- ===========================================================
+       Title bar — Back / centred title + save status / exports
+       =========================================================== -->
+  <div class="se-titlebar" id="se-titlebar">
+    <div class="se-titlebar-left">
+      <a id="se-back-link" href="/projects/instructions/edit.html" class="se-titlebar-link">
+        <i class="fas fa-arrow-left me-1"></i> Back to project editor
+      </a>
+    </div>
+    <div class="se-titlebar-center">
+      <span class="se-project-title" id="se-project-title">Loading&hellip;</span>
+      <span class="se-save-status" id="se-save-status" aria-live="polite"></span>
+    </div>
+    <div class="se-titlebar-right">
+      <button type="button" class="se-titlebar-btn" id="se-export-csv"
+              title="Download the connections table as CSV">
+        <i class="fas fa-file-csv me-1"></i> Export CSV
+      </button>
+      <button type="button" class="se-titlebar-btn" id="se-export-png"
+              title="Download the schematic as a PNG image">
+        <i class="fas fa-file-image me-1"></i> Export PNG
+      </button>
+    </div>
+  </div>
+
+  <!-- ===========================================================
+       Loading / not-owner / error states
+       =========================================================== -->
+  <div class="se-loading" id="se-loading">
+    <i class="fas fa-spinner fa-spin me-2"></i> Loading schematic editor&hellip;
+  </div>
+
+  <div class="se-not-owner d-none" id="se-not-owner">
+    <div class="se-icon"><i class="fas fa-lock"></i></div>
+    <h4><i class="fas fa-lock me-3"></i> You don't own this project</h4>
+    <p class="text-muted">Only the project author can edit the schematic.</p>
+    <a href="/projects/" class="btn btn-outline-primary mt-2">
+      <i class="fas fa-arrow-left me-1"></i> Back to projects
+    </a>
+  </div>
+
+  <div class="se-error d-none" id="se-error">
+    <div class="se-icon text-danger"><i class="fas fa-exclamation-triangle"></i></div>
+    <h4><i class="fas fa-exclamation-triangle me-3 text-danger"></i> Couldn't load this project</h4>
+    <p class="text-muted" id="se-error-detail">The project may not exist, or you may need to log in.</p>
+    <a href="/projects/" class="btn btn-outline-primary mt-2">
+      <i class="fas fa-arrow-left me-1"></i> Back to projects
+    </a>
+  </div>
+
+  <!-- ===========================================================
+       Main editor shell — hidden until loader resolves
+       =========================================================== -->
+  <div class="se-main d-none" id="se-main">
+
+    <!-- Tools pane (left, 240px) -->
+    <aside class="se-tools" id="se-tools" aria-label="Schematic tools">
+
+      <section class="se-tools-section">
+        <h6 class="se-tools-section-title">Tools</h6>
+        <div class="se-tool-grid">
+          <button type="button" class="se-tool-btn is-active" data-tool="select" title="Select / move">
+            <i class="fas fa-mouse-pointer"></i><span>Select</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="net" title="Draw net (wire)">
+            <i class="fas fa-bolt"></i><span>Net</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="symbol" title="Place symbol (pick one below)">
+            <i class="fas fa-microchip"></i><span>Symbol</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="label" title="Net label">
+            <i class="fas fa-tag"></i><span>Label</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="gnd" title="Place GND symbol">
+            <i class="fas fa-arrow-down"></i><span>GND</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="vplus" title="Place V+ rail">
+            <i class="fas fa-plug"></i><span>V+</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="rotate" title="Rotate selected symbol 90&deg;">
+            <i class="fas fa-rotate-right"></i><span>Rotate</span>
+          </button>
+          <button type="button" class="se-tool-btn" data-tool="move" title="Pan / move mode">
+            <i class="fas fa-arrows-up-down-left-right"></i><span>Move</span>
+          </button>
+        </div>
+      </section>
+
+      <section class="se-tools-section">
+        <h6 class="se-tools-section-title">Place symbol</h6>
+        <ul class="se-symbol-list" id="se-symbol-list" role="listbox" aria-label="Symbol library">
+          <!-- Populated by JS from SYMBOL_LIBRARY -->
+        </ul>
+        <button type="button" class="se-tools-secondary-btn" id="se-open-symbol-designer" disabled
+                title="Coming in the next release">
+          <i class="fas fa-plus me-1"></i> open Symbol Designer
+        </button>
+      </section>
+
+      <section class="se-tools-section se-tools-help">
+        <p class="se-tools-hint">
+          Click a symbol above, then click on the canvas to place it.<br>
+          With the <strong>Net</strong> tool, click a pin then click another pin to draw a wire.
+        </p>
+      </section>
+    </aside>
+
+    <!-- Canvas + connections table column -->
+    <main class="se-canvas-area" id="se-canvas-area" aria-label="Schematic canvas">
+      <div class="se-canvas-wrap" id="se-canvas-wrap">
+        <canvas id="se-canvas"></canvas>
+
+        <!-- Floating mini-HUD above selected symbols (rotate, flip, delete) -->
+        <div id="se-symbol-hud" class="se-symbol-hud" hidden role="toolbar"
+             aria-label="Selected symbol actions">
+          <button type="button" class="se-hud-btn" data-hud-action="rotate-ccw"
+                  title="Rotate -90&deg;">
+            <i class="fas fa-rotate-left"></i>
+          </button>
+          <button type="button" class="se-hud-btn" data-hud-action="rotate-cw"
+                  title="Rotate +90&deg;">
+            <i class="fas fa-rotate-right"></i>
+          </button>
+          <button type="button" class="se-hud-btn" data-hud-action="flip-h"
+                  title="Flip horizontally">
+            <i class="fas fa-arrows-left-right"></i>
+          </button>
+          <button type="button" class="se-hud-btn" data-hud-action="flip-v"
+                  title="Flip vertically">
+            <i class="fas fa-arrows-up-down"></i>
+          </button>
+          <button type="button" class="se-hud-btn se-hud-btn-danger"
+                  data-hud-action="delete" title="Delete">
+            <i class="fas fa-trash"></i>
+          </button>
+        </div>
+      </div>
+
+      <div class="se-table-wrap" id="se-table-wrap">
+        <header class="se-table-header">
+          <h6 class="se-table-title">
+            <i class="fas fa-table me-3"></i> Connections
+            <span class="se-table-count" id="se-table-count"></span>
+          </h6>
+          <span class="se-table-hint text-muted small">
+            Auto-derived from the net graph. <em>Description</em> is editable.
+          </span>
+        </header>
+        <div class="se-table-scroll">
+          <table class="table table-sm table-hover se-table" id="se-table">
+            <thead>
+              <tr>
+                <th class="se-th-net">Net</th>
+                <th class="se-th-from">From</th>
+                <th class="se-th-to">To</th>
+                <th class="se-th-desc">Description</th>
+              </tr>
+            </thead>
+            <tbody id="se-table-body">
+              <tr class="se-table-empty">
+                <td colspan="4" class="text-muted text-center py-3">
+                  No connections yet &mdash; draw a wire between two pins to start.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!--
+  Fabric.js v6 (UMD build). v6 exposes window.fabric for browser
+  consumers; pinned to 6.4.0 to match the instruction builder so the two
+  pages share the same engine.
+-->
+<script src="https://cdn.jsdelivr.net/npm/fabric@6.4.0/dist/index.min.js"></script>
+<script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/terms-gate.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/schematic-editor.js?v={{ site.time | date: '%s' }}"></script>


### PR DESCRIPTION
## Summary

- New full-screen schematic editor at `/projects/schematic/edit.html?id=<project_id>` with a Fabric.js canvas (2.54 mm dot-grid + snap), a stub symbol library (Pico, 14-pin IC, R, C, LED, GND, V+), 90°-only net routing, auto junction dots, brand-red selection highlight, and an inline-editable connections table.
- One-schematic-per-project backend: new `project_schematics` table + `/api/projects/{id}/schematic` CRUD (public GET, owner+T&Cs writes, idempotent POST, partial PUT). 10 new tests; full suite 464/464.
- B3 schematic-step "✎ open editor" buttons (pane card + canvas placeholder) are now enabled; switching a step to `schematic` type ensures the project's schematic record exists and writes its id into `instruction_steps.schematic_id` via the existing PUT route.
- Exports: CSV (`Net,From,To,Description`) + PNG (Fabric `toDataURL` multiplier 2). Autosave debounced 800ms.

## Test plan

- [ ] Switch a step to **Schematic** type in the instruction builder; "✎ open editor" launches the schematic editor in a new tab.
- [ ] Place a Pico + a Resistor; switch to Net tool; click pin → click pin draws an orthogonal wire that commits + appears in the table.
- [ ] Click a table row → canvas net highlights red. Click the canvas wire → table row highlights.
- [ ] Edit the **Description** cell → blur → "Saving…" → "Saved ✓".
- [ ] Export CSV downloads `schematic-connections.csv` with the description.
- [ ] Export PNG downloads `schematic.png`.
- [ ] Hard-reload → symbols and nets persist.
- [ ] Non-owner sees a "you don't own this project" placeholder.
- [ ] `pytest stacks/projects-api/tests/ -q` → 464 passing.

## Implementation notes (calls I made)

- **Net merge:** when a new wire bridges two existing nets, they merge. Preferred net (power-named or larger) keeps its identity; description survives if the absorbed net had one.
- **Junction tolerance** = 2 px; endpoints are grid-snapped so this just guards against floating-point noise from L-bend computation.
- **Connections table** uses endpoint-pair listing per spec (N endpoints → N×(N-1)/2 rows). If too dense in practice, swap to one-row-per-endpoint in `deriveConnections`.
- **Symbol move/rotate re-routes nets** via the L-bend router. Hand-edited bends would be lost — but v1 doesn't expose hand-editing.
- **GND / V+ tools** are one-shot placers (click tool → click canvas → drops the symbol → reverts to Select).

## Out of scope

Symbol designer (next PR), ERC validation, net auto-routing, multiple schematics per project, region cropping, PCB footprints, KiCad import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)