### PR TITLE
feat(instructions): Symbol Designer + E2 library merge + C1 ⌗ chips

### DIFF
--- a/stacks/projects-api/projects_api/main.py
+++ b/stacks/projects-api/projects_api/main.py
@@ -63,6 +63,7 @@ from .routers import (
     schematics,
     social_og,
     staff_picks,
+    symbols,
     users,
     videos,
 )
@@ -199,6 +200,11 @@ def create_app() -> FastAPI:
     # Issue #178 Phase E2: per-project schematic (one schematic per
     # project for v1; opaque JSON blob stored in project_schematics).
     app.include_router(schematics.router)
+    # Symbol Designer: per-project user-designed schematic symbols.
+    # Augments the hard-coded library in the schematic editor (E2) at
+    # runtime; one symbol can be linked to a BOM row via ``bom_item_id``
+    # so it surfaces as a ``⌗`` chip in C1's asset drawer.
+    app.include_router(symbols.router)
     app.include_router(journal.router)
     app.include_router(moderation.router)
     # Issue #123: parts catalog moderation (reports + community merges).

--- a/stacks/projects-api/projects_api/models.py
+++ b/stacks/projects-api/projects_api/models.py
@@ -1180,3 +1180,61 @@ class ProjectSchematic(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+
+class ProjectSymbol(Base):
+    """A user-designed schematic symbol scoped to a project.
+
+    Body shapes + pin layout are stored as a JSON document in
+    ``symbol_data``; the shape is the frontend's source of truth — see
+    ``web/assets/js/symbol-designer.js`` for the schema. The symbol
+    designer extends the hard-coded stub library in the schematic editor
+    (E2) at runtime with these per-project entries, and links one to a
+    ``project_bom_items`` row via ``bom_item_id`` so a custom symbol
+    surfaces as a ``⌗`` chip in that BOM row's asset drawer (C1).
+
+    Brand-new table — no migration helper needed (per CLAUDE.md
+    "Backend services" guidance, only existing-table alterations need
+    the idempotent ALTER helper pattern).
+    """
+
+    __tablename__ = "project_symbols"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    # Reference-designator prefix shown in the schematic editor (U, R,
+    # C, D, …). Defaults to ``U`` for generic ICs because that's the
+    # most-common case in maker projects.
+    ref_des_prefix: Mapped[str] = mapped_column(
+        String(8), nullable=False, server_default="U", default="U"
+    )
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    # Optional link to a BOM item (``project_bom_items.id``). When set,
+    # the symbol shows up as a ``⌗`` chip in that BOM row's asset drawer
+    # in the instruction builder (C1). SET NULL on delete so the symbol
+    # survives BOM churn — the chip just stops appearing.
+    bom_item_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("project_bom_items.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # JSON document with the shape ``{ bodyShapes: Shape[], pins:
+    # PinDef[] }`` — see ``web/assets/js/symbol-designer.js``. Stored
+    # opaquely; the server doesn't parse it. Practical upper bound for
+    # v1 is ~1 MB (covered by ``test_symbols`` round-tripping a 1 MB
+    # payload).
+    symbol_data: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/stacks/projects-api/projects_api/routers/symbols.py
+++ b/stacks/projects-api/projects_api/routers/symbols.py
@@ -1,0 +1,225 @@
+"""Project symbols (Symbol Designer) CRUD endpoints.
+
+Per-project user-designed schematic symbols that augment the hard-coded
+stub library in the schematic editor (E2). Mirrors ``routers/schematics``
+in surface conventions (owner + T&Cs gating on writes, public reads,
+partial-update PUT) but the noun is *plural* because a project can hold
+many symbols — one per electronic component the user wants to design.
+
+URL surface:
+
+* ``GET    /api/projects/{id}/symbols``         — public, list.
+* ``POST   /api/projects/{id}/symbols``         — owner + T&Cs, returns 201.
+* ``GET    /api/projects/{id}/symbols/{sid}``   — public, single.
+* ``PUT    /api/projects/{id}/symbols/{sid}``   — owner + T&Cs, partial.
+* ``DELETE /api/projects/{id}/symbols/{sid}``   — owner + T&Cs.
+* ``POST   /api/projects/{id}/symbols/{sid}/duplicate``
+                                                — owner + T&Cs, clones the row.
+
+The symbol body + pin layout itself is an opaque JSON document in
+``symbol_data`` — the server doesn't parse it. ``bom_item_id`` is
+validated (404 if it doesn't exist or belongs to a different project) so
+a stale link can't slip through; the same rule applies on PUT.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import require_terms_accepted
+from ..db import get_session
+from ..models import Project, ProjectBOMItem, ProjectSymbol
+from ..schemas import (
+    ProjectSymbolCreate,
+    ProjectSymbolResponse,
+    ProjectSymbolUpdate,
+)
+
+router = APIRouter(
+    prefix="/api/projects/{project_id}/symbols", tags=["symbols"]
+)
+
+
+async def _check_owner(session: AsyncSession, project_id: int, user: str) -> Project:
+    project = await session.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Project not found")
+    if project.author_username != user:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Not the project owner")
+    return project
+
+
+async def _get_symbol(
+    session: AsyncSession, project_id: int, symbol_id: int
+) -> ProjectSymbol | None:
+    """Load a symbol, scoped to the URL's project for safety.
+
+    Returning None on either a missing row or a project-id mismatch
+    means the caller can issue a single 404 without leaking which case
+    fired."""
+    sym = await session.get(ProjectSymbol, symbol_id)
+    if sym is None or sym.project_id != project_id:
+        return None
+    return sym
+
+
+async def _validate_bom_item(
+    session: AsyncSession, project_id: int, bom_item_id: int | None
+) -> None:
+    """Reject ``bom_item_id`` values that don't correspond to a BOM row
+    in this project. Pass ``None`` through unchanged (it means "no link").
+    Raises 422 on a bad id — chosen over 400 because the value is a
+    request-body field and 422 is FastAPI's convention for body
+    validation failures."""
+    if bom_item_id is None:
+        return
+    item = await session.get(ProjectBOMItem, bom_item_id)
+    if item is None or item.project_id != project_id:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="bom_item_id does not correspond to a BOM row on this project",
+        )
+
+
+def _to_response(symbol: ProjectSymbol) -> ProjectSymbolResponse:
+    return ProjectSymbolResponse(
+        id=symbol.id,
+        project_id=symbol.project_id,
+        name=symbol.name,
+        ref_des_prefix=symbol.ref_des_prefix or "U",
+        description=symbol.description,
+        bom_item_id=symbol.bom_item_id,
+        symbol_data=symbol.symbol_data,
+        created_at=symbol.created_at,
+        updated_at=symbol.updated_at,
+    )
+
+
+@router.get("", response_model=list[ProjectSymbolResponse])
+async def list_symbols(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> list[ProjectSymbolResponse]:
+    """Public read — surfaces user-authored content for project viewers
+    (a remixer can see the library that ships with the project before
+    deciding to fork)."""
+    rows = (
+        await session.scalars(
+            select(ProjectSymbol)
+            .where(ProjectSymbol.project_id == project_id)
+            .order_by(ProjectSymbol.id.asc())
+        )
+    ).all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=ProjectSymbolResponse, status_code=201)
+async def create_symbol(
+    project_id: int,
+    body: ProjectSymbolCreate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSymbolResponse:
+    await _check_owner(session, project_id, user)
+    await _validate_bom_item(session, project_id, body.bom_item_id)
+    symbol = ProjectSymbol(
+        project_id=project_id,
+        name=body.name,
+        ref_des_prefix=body.ref_des_prefix or "U",
+        description=body.description,
+        bom_item_id=body.bom_item_id,
+        symbol_data=body.symbol_data,
+    )
+    session.add(symbol)
+    await session.commit()
+    await session.refresh(symbol)
+    return _to_response(symbol)
+
+
+@router.get("/{symbol_id}", response_model=ProjectSymbolResponse)
+async def get_symbol(
+    project_id: int,
+    symbol_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSymbolResponse:
+    symbol = await _get_symbol(session, project_id, symbol_id)
+    if symbol is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Symbol not found")
+    return _to_response(symbol)
+
+
+@router.put("/{symbol_id}", response_model=ProjectSymbolResponse)
+async def update_symbol(
+    project_id: int,
+    symbol_id: int,
+    body: ProjectSymbolUpdate,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSymbolResponse:
+    """Partial update — fields omitted from the payload are untouched.
+
+    Used by the symbol designer's debounced autosave (every ~500ms of
+    edit activity). Body shape is opaque on the server; see the
+    docstring of ``models.ProjectSymbol`` for the schema."""
+    await _check_owner(session, project_id, user)
+    symbol = await _get_symbol(session, project_id, symbol_id)
+    if symbol is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Symbol not found")
+    payload = body.model_dump(exclude_unset=True)
+    if "bom_item_id" in payload:
+        await _validate_bom_item(session, project_id, payload["bom_item_id"])
+    for field, value in payload.items():
+        setattr(symbol, field, value)
+    await session.commit()
+    await session.refresh(symbol)
+    return _to_response(symbol)
+
+
+@router.delete("/{symbol_id}", status_code=204)
+async def delete_symbol(
+    project_id: int,
+    symbol_id: int,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    await _check_owner(session, project_id, user)
+    symbol = await _get_symbol(session, project_id, symbol_id)
+    if symbol is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Symbol not found")
+    await session.delete(symbol)
+    await session.commit()
+
+
+@router.post(
+    "/{symbol_id}/duplicate",
+    response_model=ProjectSymbolResponse,
+    status_code=201,
+)
+async def duplicate_symbol(
+    project_id: int,
+    symbol_id: int,
+    user: str = Depends(require_terms_accepted),
+    session: AsyncSession = Depends(get_session),
+) -> ProjectSymbolResponse:
+    """Convenience clone — fields copied 1:1 with ``(copy)`` appended to
+    the name. The new row gets a fresh id + created_at; the BOM link is
+    copied through (a duplicate likely wants the same association — the
+    user can clear it from the designer if not)."""
+    await _check_owner(session, project_id, user)
+    source = await _get_symbol(session, project_id, symbol_id)
+    if source is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Symbol not found")
+    copy = ProjectSymbol(
+        project_id=project_id,
+        name=(source.name or "Untitled") + " (copy)",
+        ref_des_prefix=source.ref_des_prefix or "U",
+        description=source.description,
+        bom_item_id=source.bom_item_id,
+        symbol_data=source.symbol_data,
+    )
+    session.add(copy)
+    await session.commit()
+    await session.refresh(copy)
+    return _to_response(copy)

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -420,6 +420,52 @@ class ProjectSchematicResponse(BaseModel):
     updated_at: datetime
 
 
+# --- Project symbols (Symbol Designer) -----------------------------------
+#
+# Per-project user-designed schematic symbols. The body-shape and pin
+# layout live in the opaque ``symbol_data`` JSON blob — the server stores
+# and returns it verbatim; the shape is owned by the frontend (see
+# ``web/assets/js/symbol-designer.js``). One symbol can be linked to a
+# BOM row via ``bom_item_id`` so it surfaces as a ``⌗`` chip in that
+# row's asset drawer in the instruction builder.
+
+
+class ProjectSymbolCreate(BaseModel):
+    """Required: ``name``. Everything else optional with defaults."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+    ref_des_prefix: Optional[str] = Field(None, max_length=8)
+    description: Optional[str] = None
+    bom_item_id: Optional[int] = None
+    symbol_data: Optional[str] = None
+
+
+class ProjectSymbolUpdate(BaseModel):
+    """Partial — fields omitted are left untouched.
+
+    ``bom_item_id`` can be set to ``null`` explicitly to clear the link;
+    fields excluded from the request body are not touched (standard
+    ``exclude_unset`` semantics on the route)."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    ref_des_prefix: Optional[str] = Field(None, max_length=8)
+    description: Optional[str] = None
+    bom_item_id: Optional[int] = None
+    symbol_data: Optional[str] = None
+
+
+class ProjectSymbolResponse(BaseModel):
+    id: int
+    project_id: int
+    name: str
+    ref_des_prefix: str
+    description: Optional[str] = None
+    bom_item_id: Optional[int] = None
+    symbol_data: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
 # --- Build instructions export (issue #178, Phase 2b) --------------------
 #
 # Hybrid PDF pipeline: the browser renders each Fabric.js canvas to a

--- a/stacks/projects-api/tests/test_symbols.py
+++ b/stacks/projects-api/tests/test_symbols.py
@@ -1,0 +1,377 @@
+"""Project symbol CRUD tests (Symbol Designer).
+
+Mirrors the fixture pattern in ``tests/test_schematics.py``: a per-test
+project is created up front, then we exercise the symbol endpoints
+against it. The terms-gate test deliberately strips the
+``conftest.client`` bypass to confirm the gate fires on writes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import make_auth_header
+
+
+@pytest.fixture
+async def project_id(client) -> int:
+    headers = make_auth_header()
+    resp = await client.post(
+        "/api/projects",
+        json={"title": "Symbol Test Project"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _bom_item_id(client, project_id: int, name: str = "Pico") -> int:
+    """Create a BOM row on ``project_id`` and return its id."""
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/bom",
+        json={"name": name, "quantity": 1},
+        headers=headers,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+# --- Basic CRUD ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_creates_symbol_then_list_returns_it(client, project_id) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "MyLED", "ref_des_prefix": "D", "description": "5mm red"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    created = resp.json()
+    assert created["name"] == "MyLED"
+    assert created["ref_des_prefix"] == "D"
+    assert created["description"] == "5mm red"
+    assert created["project_id"] == project_id
+    assert created["bom_item_id"] is None
+    assert created["symbol_data"] is None
+
+    listing = await client.get(f"/api/projects/{project_id}/symbols")
+    assert listing.status_code == 200
+    items = listing.json()
+    assert isinstance(items, list)
+    assert len(items) == 1
+    assert items[0]["id"] == created["id"]
+
+
+@pytest.mark.asyncio
+async def test_post_without_name_returns_422(client, project_id) -> None:
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"ref_des_prefix": "U"},  # missing required `name`
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_partial_update(client, project_id) -> None:
+    """PUT applies the fields in the payload, leaves omitted fields alone."""
+    headers = make_auth_header()
+    bom_id = await _bom_item_id(client, project_id)
+    created = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "Initial", "description": "Initial desc"},
+        headers=headers,
+    )
+    assert created.status_code == 201
+    sid = created.json()["id"]
+
+    # Update only the name.
+    resp = await client.put(
+        f"/api/projects/{project_id}/symbols/{sid}",
+        json={"name": "Renamed"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Renamed"
+    assert body["description"] == "Initial desc"
+
+    # Now update description + symbol_data + bom_item_id.
+    blob = json.dumps({
+        "bodyShapes": [{"id": "s1", "kind": "rect", "x": -32, "y": -16, "w": 64, "h": 32}],
+        "pins": [{"id": "p1", "number": "1", "name": "A", "type": "I/O",
+                  "side": "left", "x": -32, "y": 0}],
+    })
+    resp = await client.put(
+        f"/api/projects/{project_id}/symbols/{sid}",
+        json={
+            "description": "Now linked",
+            "symbol_data": blob,
+            "bom_item_id": bom_id,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Renamed"
+    assert body["description"] == "Now linked"
+    assert body["symbol_data"] == blob
+    assert body["bom_item_id"] == bom_id
+
+    # GET single reflects the latest state.
+    one = await client.get(f"/api/projects/{project_id}/symbols/{sid}")
+    assert one.status_code == 200
+    assert one.json()["symbol_data"] == blob
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_symbol(client, project_id) -> None:
+    headers = make_auth_header()
+    created = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "Doomed"},
+        headers=headers,
+    )
+    sid = created.json()["id"]
+
+    resp = await client.delete(
+        f"/api/projects/{project_id}/symbols/{sid}", headers=headers
+    )
+    assert resp.status_code == 204
+
+    one = await client.get(f"/api/projects/{project_id}/symbols/{sid}")
+    assert one.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_duplicate_creates_clone_with_copy_suffix(client, project_id) -> None:
+    headers = make_auth_header()
+    bom_id = await _bom_item_id(client, project_id)
+    blob = json.dumps({"bodyShapes": [], "pins": [{"id": "p1"}]})
+    created = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={
+            "name": "Original",
+            "ref_des_prefix": "R",
+            "description": "first",
+            "bom_item_id": bom_id,
+            "symbol_data": blob,
+        },
+        headers=headers,
+    )
+    sid = created.json()["id"]
+
+    dup = await client.post(
+        f"/api/projects/{project_id}/symbols/{sid}/duplicate",
+        headers=headers,
+    )
+    assert dup.status_code == 201, dup.text
+    body = dup.json()
+    assert body["id"] != sid
+    assert body["name"] == "Original (copy)"
+    assert body["ref_des_prefix"] == "R"
+    assert body["description"] == "first"
+    assert body["bom_item_id"] == bom_id
+    assert body["symbol_data"] == blob
+
+    # List should now have two rows.
+    listing = await client.get(f"/api/projects/{project_id}/symbols")
+    assert len(listing.json()) == 2
+
+
+# --- Public read --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anonymous_can_list_symbols(client, project_id) -> None:
+    """Public GETs work without any auth header."""
+    headers = make_auth_header()
+    await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "PublicReadCheck"},
+        headers=headers,
+    )
+    # No auth header.
+    resp = await client.get(f"/api/projects/{project_id}/symbols")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    assert resp.json()[0]["name"] == "PublicReadCheck"
+
+
+# --- Ownership ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_owner_post_returns_403(client, project_id) -> None:
+    other = make_auth_header(username="someoneelse")
+    resp = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "hijack"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_put_returns_403(client, project_id) -> None:
+    owner = make_auth_header()
+    created = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "ok"},
+        headers=owner,
+    )
+    sid = created.json()["id"]
+
+    other = make_auth_header(username="someoneelse")
+    resp = await client.put(
+        f"/api/projects/{project_id}/symbols/{sid}",
+        json={"name": "hijacked"},
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_non_owner_delete_returns_403(client, project_id) -> None:
+    owner = make_auth_header()
+    created = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "ok"},
+        headers=owner,
+    )
+    sid = created.json()["id"]
+
+    other = make_auth_header(username="someoneelse")
+    resp = await client.delete(
+        f"/api/projects/{project_id}/symbols/{sid}",
+        headers=other,
+    )
+    assert resp.status_code == 403
+
+
+# --- BOM-link validation ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_with_nonexistent_bom_id_returns_422(client, project_id) -> None:
+    """Linking to a non-existent BOM item id → 422 (FastAPI body-validation
+    convention; documented in the route docstring)."""
+    headers = make_auth_header()
+    resp = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "BadLink", "bom_item_id": 999_999},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_with_nonexistent_bom_id_returns_422(client, project_id) -> None:
+    headers = make_auth_header()
+    created = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "Ok"},
+        headers=headers,
+    )
+    sid = created.json()["id"]
+
+    resp = await client.put(
+        f"/api/projects/{project_id}/symbols/{sid}",
+        json={"bom_item_id": 999_999},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+# --- Large payload ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_large_symbol_data_round_trips(client, project_id) -> None:
+    """A ~1 MB symbol_data blob should round-trip via POST + GET.
+
+    Typical custom-symbol JSON is well under a few KB; the 1 MB ceiling
+    matches the schematic-data test and ensures even pathologically
+    large body-shape sets are accepted by the column."""
+    headers = make_auth_header()
+    blob = "x" * (1 * 1024 * 1024)
+    resp = await client.post(
+        f"/api/projects/{project_id}/symbols",
+        json={"name": "Huge", "symbol_data": blob},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    sid = resp.json()["id"]
+    assert resp.json()["symbol_data"] == blob
+
+    one = await client.get(f"/api/projects/{project_id}/symbols/{sid}")
+    assert one.status_code == 200
+    assert len(one.json()["symbol_data"]) == len(blob)
+
+
+# --- Terms gate ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_without_terms_acceptance_returns_403(client) -> None:
+    """Confirms the T&Cs gate fires on symbol writes."""
+    from projects_api import auth as auth_module
+
+    app = client._transport.app
+    for dep in (
+        auth_module.require_terms_accepted,
+        auth_module.require_terms_accepted_aged,
+    ):
+        app.dependency_overrides.pop(dep, None)
+
+    headers = make_auth_header("alice")
+
+    # Accept terms so the project can be created (POST /api/projects is
+    # also gated by require_terms_accepted).
+    acc = await client.post(
+        "/api/users/me/accept-terms",
+        json={"version": "1.0"},
+        headers=headers,
+    )
+    assert acc.status_code == 200, acc.text
+    proj = await client.post(
+        "/api/projects",
+        json={"title": "Gated Symbol Project"},
+        headers=headers,
+    )
+    assert proj.status_code == 201, proj.text
+    pid = proj.json()["id"]
+
+    # Bump the terms version so alice's 1.0 acceptance goes stale.
+    from projects_api import config as config_module
+    from projects_api.routers import users as users_router
+
+    def _fake_get_settings():
+        s = config_module.Settings()
+        return s.model_copy(update={"current_terms_version": "2.0"})
+
+    import pytest as _pytest
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr(config_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(auth_module, "get_settings", _fake_get_settings)
+    monkeypatch.setattr(users_router, "get_settings", _fake_get_settings)
+
+    try:
+        resp = await client.post(
+            f"/api/projects/{pid}/symbols",
+            json={"name": "should be blocked"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail")
+        assert isinstance(detail, dict)
+        assert detail.get("detail") == "terms_not_accepted"
+    finally:
+        monkeypatch.undo()

--- a/web/assets/css/instruction-builder.css
+++ b/web/assets/css/instruction-builder.css
@@ -1789,8 +1789,36 @@ body.instruction-builder-page > .container-fluid {
   background: #f1f3f5;
   color: #212529;
 }
-.ib-bom-row-menu { cursor: default; opacity: 0.65; }
+.ib-bom-row-menu { opacity: 0.75; }
 .ib-bom-row-menu:hover { opacity: 1; }
+
+/* The menu is now a Bootstrap dropdown with `✎ design symbol` etc. */
+.ib-bom-row-menu-wrap {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+.ib-bom-row-menu-list {
+  font-size: 0.82rem;
+  min-width: 200px;
+  padding: 4px 0;
+}
+.ib-bom-row-menu-list .dropdown-item {
+  padding: 5px 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ib-bom-row-menu-list .ib-bom-menu-glyph {
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  font-weight: 600;
+}
+.ib-bom-row-menu-list .ib-bom-menu-disabled {
+  color: #adb5bd !important;
+  cursor: not-allowed;
+}
 
 /* Drawer */
 .ib-bom-row-drawer {
@@ -1825,6 +1853,25 @@ body.instruction-builder-page > .container-fluid {
 }
 .ib-bom-asset:hover { border-color: #adb5bd; }
 .ib-bom-asset:active { cursor: grabbing; transform: scale(0.97); }
+
+/* Symbol-kind chip (from the Symbol Designer). Distinguished visually
+   from photo chips with the brand-red accent + ⌗ glyph so it's clear
+   the chip drops as a schematic symbol rather than an image. */
+.ib-bom-asset-symbol {
+  border-color: rgba(200, 49, 42, 0.3);
+  background: rgba(200, 49, 42, 0.03);
+}
+.ib-bom-asset-symbol:hover { border-color: #c8312a; }
+.ib-bom-asset-symbol-thumb {
+  background: #fff;
+  color: #c8312a;
+}
+.ib-bom-symbol-glyph {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
 .ib-bom-asset-thumb {
   width: 100%;
   aspect-ratio: 1 / 1;

--- a/web/assets/css/schematic-editor.css
+++ b/web/assets/css/schematic-editor.css
@@ -222,6 +222,29 @@ body.schematic-editor-page > .container-fluid {
 .se-symbol-meta { display: flex; flex-direction: column; line-height: 1.2; }
 .se-symbol-name { font-weight: 500; }
 .se-symbol-sub { font-size: 0.72rem; }
+
+/* "Custom" badge — appended to a symbol-item name when the entry
+   came from /api/projects/{id}/symbols (i.e. designed in the Symbol
+   Designer). Distinguishes user-designed symbols from the built-in
+   stub library at a glance. */
+.se-symbol-item.is-custom .se-symbol-thumb {
+  background: rgba(200, 49, 42, 0.08);
+  color: var(--se-brand-red);
+  border-color: rgba(200, 49, 42, 0.25);
+}
+.se-symbol-custom-badge {
+  display: inline-block;
+  background: var(--se-brand-red);
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
 .se-tools-secondary-btn {
   width: 100%;
   background: transparent;

--- a/web/assets/css/symbol-designer.css
+++ b/web/assets/css/symbol-designer.css
@@ -1,0 +1,493 @@
+/*
+ * Symbol Designer — per-project schematic-symbol editor.
+ *
+ * Three-region layout:
+ *   - Title bar  (top, full-width)
+ *   - Library list (left, 240px)
+ *   - Canvas column (centre — toolbox on top, dot-grid canvas beneath)
+ *   - Properties panel (right, 260px)
+ *
+ * Mirrors the visual idiom of the schematic editor (same brand red,
+ * same neutral panels) so the two workspaces feel like part of one
+ * tool family.
+ */
+
+/* ---------- Site chrome ---------- */
+
+body.symbol-designer-page #footer,
+body.symbol-designer-page .socials-bar,
+body.symbol-designer-page footer {
+  display: none !important;
+}
+body.symbol-designer-page > .container-fluid {
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* ---------- Workspace shell ---------- */
+
+.sd-workspace {
+  --sd-titlebar-h: 48px;
+  --sd-toolbox-h: 48px;
+  --sd-library-w: 240px;
+  --sd-props-w: 260px;
+  --sd-ink: #222;
+  --sd-brand-red: #c8312a;
+  --sd-bg: #f7f8fa;
+  --sd-panel: #ffffff;
+  --sd-border: #e2e6ea;
+  --sd-muted: #7a8087;
+  --sd-pin-rail: #cfd3d8;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 56px);
+  background: var(--sd-bg);
+  color: var(--sd-ink);
+  font-size: 0.92rem;
+}
+
+/* ---------- Title bar ---------- */
+
+.sd-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  height: var(--sd-titlebar-h);
+  padding: 0 1rem;
+  background: var(--sd-panel);
+  border-bottom: 1px solid var(--sd-border);
+  flex: 0 0 auto;
+}
+.sd-titlebar-left, .sd-titlebar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.sd-titlebar-center {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  justify-content: center;
+}
+.sd-project-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+.sd-save-status {
+  font-size: 0.85rem;
+  color: var(--sd-muted);
+}
+.sd-titlebar-link {
+  color: var(--sd-ink);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+.sd-titlebar-link:hover { color: var(--sd-brand-red); }
+.sd-titlebar-btn {
+  border: 1px solid var(--sd-border);
+  background: var(--sd-panel);
+  color: var(--sd-ink);
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.88rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+.sd-titlebar-btn:hover {
+  border-color: var(--sd-brand-red);
+  color: var(--sd-brand-red);
+  text-decoration: none;
+}
+
+/* ---------- Loading / not-owner / error states ---------- */
+
+.sd-loading,
+.sd-not-owner,
+.sd-error {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  color: var(--sd-muted);
+}
+.sd-not-owner .sd-icon,
+.sd-error .sd-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  color: var(--sd-muted);
+}
+.sd-error .sd-icon { color: var(--sd-brand-red); }
+
+/* ---------- Main shell: library | canvas col | props ---------- */
+
+.sd-main {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: var(--sd-library-w) 1fr var(--sd-props-w);
+  min-height: 0;
+}
+
+/* ---------- Library list ---------- */
+
+.sd-library {
+  background: var(--sd-panel);
+  border-right: 1px solid var(--sd-border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.sd-library-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--sd-border);
+}
+.sd-library-title {
+  font-size: 0.85rem;
+  margin: 0;
+  font-weight: 600;
+}
+.sd-library-new-btn {
+  background: var(--sd-brand-red);
+  border: none;
+  color: #fff;
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.sd-library-new-btn:hover { background: #a52720; }
+.sd-library-search {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--sd-border);
+}
+.sd-library-list {
+  list-style: none;
+  padding: 0.25rem 0;
+  margin: 0;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+.sd-library-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.86rem;
+  border-left: 3px solid transparent;
+}
+.sd-library-item:hover { background: #fbfbfc; }
+.sd-library-item.is-active {
+  background: rgba(200, 49, 42, 0.08);
+  border-left-color: var(--sd-brand-red);
+  font-weight: 500;
+}
+.sd-library-item-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: #fff;
+  border: 1px solid var(--sd-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--sd-muted);
+  font-size: 0.78rem;
+  flex: 0 0 auto;
+}
+.sd-library-item-name {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sd-library-item-sub {
+  font-size: 0.7rem;
+  color: var(--sd-muted);
+  flex: 0 0 auto;
+}
+.sd-library-empty {
+  padding: 1rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--sd-muted);
+  text-align: center;
+}
+.sd-library-footer {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  border-top: 1px solid var(--sd-border);
+}
+.sd-library-action-btn {
+  flex: 1 1 0;
+  background: #fbfbfc;
+  border: 1px solid var(--sd-border);
+  color: var(--sd-ink);
+  font-size: 0.78rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.sd-library-action-btn:hover:not(:disabled) {
+  border-color: var(--sd-brand-red);
+  color: var(--sd-brand-red);
+}
+.sd-library-action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.sd-library-action-danger:hover:not(:disabled) {
+  background: var(--sd-brand-red);
+  color: #fff;
+  border-color: var(--sd-brand-red);
+}
+
+/* ---------- Canvas column ---------- */
+
+.sd-canvas-col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Toolbox */
+.sd-toolbox {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.4rem 0.75rem;
+  height: var(--sd-toolbox-h);
+  background: var(--sd-panel);
+  border-bottom: 1px solid var(--sd-border);
+  overflow-x: auto;
+  flex: 0 0 auto;
+}
+.sd-tool-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: #fbfbfc;
+  border: 1px solid var(--sd-border);
+  color: var(--sd-ink);
+  padding: 0.3rem 0.55rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.sd-tool-btn i { font-size: 0.9rem; }
+.sd-tool-btn:hover {
+  border-color: var(--sd-brand-red);
+  background: #fff;
+}
+.sd-tool-btn.is-active {
+  background: var(--sd-brand-red);
+  color: #fff;
+  border-color: var(--sd-brand-red);
+}
+.sd-toolbox-sep {
+  display: inline-block;
+  width: 1px;
+  height: 24px;
+  background: var(--sd-border);
+  margin: 0 0.25rem;
+}
+
+/* Canvas wrap */
+.sd-canvas-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  background: var(--sd-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0.5rem;
+}
+.sd-canvas-wrap canvas {
+  background: #fff;
+  border: 1px solid var(--sd-border);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+}
+.sd-canvas-wrap .canvas-container { margin: 0 auto; }
+
+/* Pin side rails — a faint colored strip on each edge of the canvas
+   so the user can see exactly where the Pin tool will accept a click.
+   Drawn directly on the canvas by JS as part of the body background; no
+   CSS pseudo-element here (Fabric owns the canvas pixels). */
+
+.sd-canvas-empty {
+  position: absolute;
+  inset: 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(247, 248, 250, 0.92);
+  color: var(--sd-muted);
+  text-align: center;
+  padding: 2rem;
+  z-index: 4;
+  pointer-events: none;
+}
+.sd-canvas-empty.is-visible { display: flex; }
+
+/* Lightweight toast for "coming soon" tool stubs etc. */
+.sd-toast {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #3a3a3a;
+  color: #fff;
+  padding: 0.5rem 0.9rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+.sd-toast.is-visible { opacity: 1; }
+
+/* ---------- Properties panel ---------- */
+
+.sd-props {
+  background: var(--sd-panel);
+  border-left: 1px solid var(--sd-border);
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+.sd-props-section {
+  margin-bottom: 1.25rem;
+}
+.sd-props-section-title {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7rem;
+  color: var(--sd-muted);
+  margin: 0 0 0.6rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--sd-border);
+  padding-bottom: 0.35rem;
+}
+.sd-props-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.7rem;
+}
+.sd-props-field label {
+  font-size: 0.78rem;
+  color: var(--sd-muted);
+  font-weight: 500;
+  margin: 0;
+}
+.sd-props-readonly {
+  font-size: 0.88rem;
+  padding: 0.25rem 0.5rem;
+  background: #fbfbfc;
+  border: 1px solid var(--sd-border);
+  border-radius: 4px;
+}
+.sd-props-hint {
+  font-size: 0.72rem;
+  color: var(--sd-muted);
+  display: block;
+  margin-top: 0.2rem;
+}
+.sd-props-hint code {
+  background: transparent;
+  font-family: inherit;
+  font-weight: 600;
+}
+
+/* Pin-type / pin-side radio grids */
+.sd-props-radio-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.25rem;
+}
+.sd-props-radio-grid-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+.sd-props-radio-grid label {
+  position: relative;
+  cursor: pointer;
+  border: 1px solid var(--sd-border);
+  border-radius: 4px;
+  padding: 0.25rem 0;
+  text-align: center;
+  background: #fbfbfc;
+  font-size: 0.72rem;
+  color: var(--sd-ink);
+}
+.sd-props-radio-grid input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  cursor: pointer;
+}
+.sd-props-radio-grid input[type="radio"]:checked + span {
+  color: #fff;
+}
+.sd-props-radio-grid label:has(input:checked) {
+  background: var(--sd-brand-red);
+  border-color: var(--sd-brand-red);
+}
+
+/* Shape-properties grid (rect / line) */
+.sd-props-grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.35rem;
+}
+.sd-props-inline {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem !important;
+  color: var(--sd-muted);
+}
+.sd-props-inline .form-control { padding: 0.15rem 0.3rem; font-size: 0.78rem; }
+.sd-props-delete-btn {
+  width: 100%;
+  background: transparent;
+  border: 1px solid var(--sd-border);
+  color: var(--sd-brand-red);
+  padding: 0.3rem;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  margin-top: 0.25rem;
+}
+.sd-props-delete-btn:hover {
+  background: var(--sd-brand-red);
+  color: #fff;
+  border-color: var(--sd-brand-red);
+}
+
+/* ---------- Responsive: stack panels on narrow viewports ---------- */
+
+@media (max-width: 980px) {
+  .sd-main {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+  }
+  .sd-library, .sd-props {
+    max-height: 220px;
+    border-right: none;
+    border-left: none;
+    border-bottom: 1px solid var(--sd-border);
+  }
+}

--- a/web/assets/js/instruction-builder.js
+++ b/web/assets/js/instruction-builder.js
@@ -104,6 +104,12 @@
     bomItemsLoaded: false,    // true once a successful fetch has populated bomItems
     bomPartAssets: {},        // part_id -> Asset[] (derived from /api/parts/{slug})
     bomPartAssetsPending: {}, // part_id -> Promise (de-dupe in-flight fetches)
+    // Symbol Designer integration: user-designed symbols (one row per
+    // /api/projects/{id}/symbols entry). When a symbol's bom_item_id
+    // matches a BOM row, the symbol surfaces as a `⌗` chip in that
+    // row's asset drawer. Loaded once alongside the BOM list.
+    projectSymbols: [],
+    projectSymbolsLoaded: false,
   };
 
   // Camera capture modal — built lazily on first open.
@@ -2082,8 +2088,124 @@
         // in the schema, this can branch on `assetId` and place an
         // asset-typed Fabric object instead of a generic image.
         await dropPhotosOnCanvas([{ id: null, src: payload.src }], e);
+      } else if (payload.kind === 'symbol' && payload.symbolId) {
+        // Symbol Designer integration: rasterise the symbol_data off-
+        // screen and drop the resulting PNG dataURL onto the canvas.
+        // The drop behaves exactly like any other asset image from
+        // there — selectable, resizable, deletable.
+        var symSrc = await rasteriseSymbolToDataUrl(payload.symbolId);
+        if (symSrc) {
+          await dropPhotosOnCanvas([{ id: null, src: symSrc }], e);
+        }
       }
     });
+  }
+
+  // Off-screen Fabric canvas → PNG dataURL. Mirrors the visual idiom of
+  // the schematic editor's symbol rendering (body rect + sticks +
+  // labels) but doesn't import the editor module — duplicating a
+  // ~50-line render is cheaper than coupling the two pages. Same idea
+  // the slideshow viewer uses for its render-to-png snapshots.
+  async function rasteriseSymbolToDataUrl(symbolId) {
+    var row = (state.projectSymbols || []).find(function (s) {
+      return s && s.id === symbolId;
+    });
+    if (!row || !row.symbol_data) return null;
+    var doc;
+    try { doc = JSON.parse(row.symbol_data); } catch (_) { return null; }
+    if (!doc || typeof doc !== 'object') return null;
+    var shapes = Array.isArray(doc.bodyShapes) ? doc.bodyShapes : [];
+    var pins = Array.isArray(doc.pins) ? doc.pins : [];
+    // Bounding box (centred coords) — with generous padding so labels
+    // and pin sticks don't get clipped.
+    var xs = [], ys = [];
+    pins.forEach(function (p) { xs.push(p.x || 0); ys.push(p.y || 0); });
+    shapes.forEach(function (s) {
+      if (s.kind === 'rect') {
+        xs.push(s.x); xs.push(s.x + s.w);
+        ys.push(s.y); ys.push(s.y + s.h);
+      } else if (s.kind === 'line') {
+        xs.push(s.x1); xs.push(s.x2);
+        ys.push(s.y1); ys.push(s.y2);
+      }
+    });
+    if (xs.length === 0) { xs = [-32, 32]; ys = [-24, 24]; }
+    var pad = 32;
+    var minX = Math.min.apply(null, xs) - pad;
+    var minY = Math.min.apply(null, ys) - pad;
+    var maxX = Math.max.apply(null, xs) + pad;
+    var maxY = Math.max.apply(null, ys) + pad;
+    var W = Math.max(maxX - minX, 64);
+    var H = Math.max(maxY - minY, 64);
+    var off = document.createElement('canvas');
+    off.width = W;
+    off.height = H;
+    var ctx = off.getContext('2d');
+    ctx.clearRect(0, 0, W, H);
+    // Body rect — bounding box of shapes (so the symbol reads as a
+    // single "chip"). Light stroke, white fill.
+    ctx.strokeStyle = '#222';
+    ctx.lineWidth = 1.5;
+    ctx.fillStyle = '#ffffff';
+    // Body backdrop — uses the *unpadded* bounding box so the white
+    // fill sits behind shapes but not behind labels / pin sticks (those
+    // extend into the padded margin around the body).
+    var sMinX = Math.min.apply(null, xs);
+    var sMinY = Math.min.apply(null, ys);
+    var sMaxX = Math.max.apply(null, xs);
+    var sMaxY = Math.max.apply(null, ys);
+    ctx.fillRect(sMinX - minX, sMinY - minY,
+                 sMaxX - sMinX, sMaxY - sMinY);
+    ctx.strokeRect(sMinX - minX, sMinY - minY,
+                   sMaxX - sMinX, sMaxY - sMinY);
+    // Body shapes
+    shapes.forEach(function (s) {
+      if (s.kind === 'rect') {
+        ctx.strokeRect(s.x - minX, s.y - minY, s.w, s.h);
+      } else if (s.kind === 'line') {
+        ctx.beginPath();
+        ctx.moveTo(s.x1 - minX, s.y1 - minY);
+        ctx.lineTo(s.x2 - minX, s.y2 - minY);
+        ctx.stroke();
+      }
+    });
+    // Pins: short stick + label.
+    ctx.font = '11px system-ui, -apple-system, "Segoe UI", sans-serif';
+    ctx.fillStyle = '#222';
+    pins.forEach(function (p) {
+      var px = p.x - minX, py = p.y - minY;
+      var stickLen = 12;
+      var ex = px, ey = py;
+      switch (p.side) {
+        case 'left':   ex = px + stickLen; break;
+        case 'right':  ex = px - stickLen; break;
+        case 'top':    ey = py + stickLen; break;
+        case 'bottom': ey = py - stickLen; break;
+      }
+      ctx.beginPath();
+      ctx.moveTo(px, py);
+      ctx.lineTo(ex, ey);
+      ctx.stroke();
+      // Dot
+      ctx.beginPath();
+      ctx.arc(px, py, 3.5, 0, Math.PI * 2);
+      ctx.fillStyle = '#ffffff';
+      ctx.fill();
+      ctx.stroke();
+      // Label
+      var label = (p.number || '') + (p.name ? ' ' + p.name : '');
+      if (label.trim()) {
+        ctx.fillStyle = '#222';
+        ctx.textBaseline = 'middle';
+        switch (p.side) {
+          case 'left':   ctx.textAlign = 'left';   ctx.fillText(label, ex + 3, ey); break;
+          case 'right':  ctx.textAlign = 'right';  ctx.fillText(label, ex - 3, ey); break;
+          case 'top':    ctx.textAlign = 'center'; ctx.fillText(label, ex, ey + 8); break;
+          case 'bottom': ctx.textAlign = 'center'; ctx.fillText(label, ex, ey - 8); break;
+        }
+      }
+    });
+    return off.toDataURL('image/png');
   }
 
   // Convert a canvas-frame mouse drop position into Fabric internal
@@ -2185,11 +2307,42 @@
             ensurePartAssets(item.part_id, item.part_slug);
           }
         });
+        // Symbol Designer integration: pull the project's symbols once
+        // so any with bom_item_id can surface as ⌗ chips in their
+        // matching BOM row's asset drawer.
+        loadProjectSymbols();
       })
       .catch(function (err) {
         state.bomItemsLoading = false;
         state.bomItemsError = err && err.message ? err.message : 'Failed to load BOM';
         renderBomPane();
+      });
+  }
+
+  // Fetch the project's user-designed symbols (one row per Symbol
+  // Designer entry). On success any matching BOM row's drawer picks up
+  // a ⌗ chip via assetsForBomItem(); on failure the chips just don't
+  // appear (the BOM pane itself still works).
+  function loadProjectSymbols() {
+    if (!state.projectId) return;
+    if (state.projectSymbolsLoaded) {
+      renderBomPane();
+      return;
+    }
+    apiFetch(API + '/api/projects/' + state.projectId + '/symbols')
+      .then(function (resp) {
+        if (!resp.ok) throw new Error('Symbols HTTP ' + resp.status);
+        return resp.json();
+      })
+      .then(function (rows) {
+        state.projectSymbols = Array.isArray(rows) ? rows : [];
+        state.projectSymbolsLoaded = true;
+        renderBomPane();
+      })
+      .catch(function () {
+        // Silent — no chips, but the BOM pane is unaffected.
+        state.projectSymbols = [];
+        state.projectSymbolsLoaded = true;
       });
   }
 
@@ -2240,13 +2393,43 @@
 
   function assetsForBomItem(item) {
     if (!item) return [];
-    // Future-proofing: if the schema ever ships an inline assets[] field
-    // on a BOM row, prefer it.
-    if (Array.isArray(item.assets)) return item.assets;
-    if (item.part_id && state.bomPartAssets[item.part_id]) {
-      return state.bomPartAssets[item.part_id];
+    // Combine inline + part-derived assets with any Symbol Designer
+    // chips for this BOM row. Symbol chips are prepended so they read
+    // first in the drawer — they're the most-specific "this part is
+    // wired in this way" affordance.
+    var baseAssets;
+    if (Array.isArray(item.assets)) {
+      baseAssets = item.assets;
+    } else if (item.part_id && state.bomPartAssets[item.part_id]) {
+      baseAssets = state.bomPartAssets[item.part_id];
+    } else {
+      baseAssets = [];
     }
-    return [];
+    var symbolChips = symbolChipsForBomItem(item);
+    if (symbolChips.length === 0) return baseAssets;
+    return symbolChips.concat(baseAssets);
+  }
+
+  // Find project symbols whose bom_item_id matches this BOM row's id,
+  // and convert each into an Asset-shaped object the drawer renderer
+  // already knows how to lay out. The ``kind: 'symbol'`` flag is the
+  // distinguishing field — chip rendering and the drag payload both
+  // branch on it.
+  function symbolChipsForBomItem(item) {
+    if (!item || !item.id || !Array.isArray(state.projectSymbols)) return [];
+    var out = [];
+    state.projectSymbols.forEach(function (sym) {
+      if (sym && sym.bom_item_id === item.id) {
+        out.push({
+          id: 'symbol-' + sym.id,
+          symbolId: sym.id,
+          label: sym.name || ('Symbol #' + sym.id),
+          kind: 'symbol',
+          chip: '⌗',  // ⌗
+        });
+      }
+    });
+    return out;
   }
 
   function bomExpandedSet() {
@@ -2338,6 +2521,13 @@
       ? 'Loading assets…'
       : (count + ' asset' + (count === 1 ? '' : 's') + ' attached');
 
+    // Build the deep-link URL for "design symbol" before encoding into
+    // the dropdown markup. ``new=true`` so the symbol designer creates
+    // a fresh row pre-linked to this BOM item via ``bom_item_id``.
+    var designSymbolUrl = '/projects/symbol/edit.html?project_id=' +
+      encodeURIComponent(state.projectId) +
+      '&new=true&bom_item_id=' + encodeURIComponent(rowId);
+
     return '' +
       '<div class="ib-bom-row' + (isExpanded ? ' is-expanded' : '') + '"' +
       ' data-bom-row-id="' + escapeHtml(String(rowId)) + '"' +
@@ -2350,10 +2540,30 @@
           escapeHtml(name) + '</span>' +
           '<span class="ib-bom-asset-chip" title="' + escapeHtml(chipTitle) + '">' +
           chipText + '</span>' +
-          '<button type="button" class="ib-bom-row-menu" aria-label="More actions" tabindex="-1"' +
-          ' title="More actions (coming soon)">' +
-            '<i class="fas fa-ellipsis-vertical"></i>' +
-          '</button>' +
+          // Bootstrap dropdown for the ⋮ menu — was an inert button in
+          // the C1 merge; gaining "design symbol" links + a placeholder
+          // for future actions.
+          '<div class="dropdown ib-bom-row-menu-wrap">' +
+            '<button type="button" class="ib-bom-row-menu" aria-label="More actions"' +
+            ' tabindex="-1" data-bs-toggle="dropdown" data-bs-auto-close="true"' +
+            ' aria-expanded="false" title="More actions">' +
+              '<i class="fas fa-ellipsis-vertical"></i>' +
+            '</button>' +
+            '<ul class="dropdown-menu dropdown-menu-end ib-bom-row-menu-list">' +
+              '<li>' +
+                '<a class="dropdown-item ib-bom-menu-design-symbol" href="' +
+                escapeHtml(designSymbolUrl) + '">' +
+                  '<span class="ib-bom-menu-glyph">&#x270E;</span> design symbol&hellip;' +
+                '</a>' +
+              '</li>' +
+              '<li>' +
+                '<span class="dropdown-item disabled ib-bom-menu-disabled"' +
+                ' aria-disabled="true" title="Use the project editor\'s BOM section">' +
+                  '<i class="fas fa-trash me-2"></i>remove from BOM' +
+                '</span>' +
+              '</li>' +
+            '</ul>' +
+          '</div>' +
           '<button type="button" class="ib-bom-row-toggle" aria-label="' +
           (isExpanded ? 'Collapse' : 'Expand') + '" tabindex="-1">' +
             '<i class="fas fa-chevron-' + (isExpanded ? 'up' : 'down') + '"></i>' +
@@ -2378,14 +2588,34 @@
         (item.part_slug
           ? escapeHtml('/parts/view.html?slug=' + encodeURIComponent(item.part_slug))
           : '#') +
-        '" target="_blank" rel="noopener">Parts Catalog</a>. ' +
-        '<span class="text-muted">Schematic symbols (⌗) come from the Symbol designer (coming soon).</span>' +
+        '" target="_blank" rel="noopener">Parts Catalog</a>, or ' +
+        '<a href="' +
+        escapeHtml('/projects/symbol/edit.html?project_id=' +
+          encodeURIComponent(state.projectId) + '&new=true&bom_item_id=' +
+          encodeURIComponent(item.id)) +
+        '">design a <code>&#x2317;</code> symbol</a> for it.' +
         '</div>';
     }
     return '<div class="ib-bom-assets">' + assets.map(function (a) {
-      var safeSrc = escapeHtml(a.src || '');
       var safeLabel = escapeHtml(a.label || 'Asset');
       var safeKind = escapeHtml(a.kind || 'photo');
+      // Symbol-kind chips show a `⌗` glyph instead of an image thumb
+      // and carry a different drag payload (no src; the canvas drop
+      // handler rasterises the symbol_data at drop time).
+      if (a.kind === 'symbol') {
+        var safeSymId = escapeHtml(String(a.symbolId || ''));
+        return '<div class="ib-bom-asset ib-bom-asset-symbol" draggable="true"' +
+          ' data-asset-kind="symbol"' +
+          ' data-asset-label="' + safeLabel + '"' +
+          ' data-symbol-id="' + safeSymId + '"' +
+          ' title="' + safeLabel + ' — drag onto canvas to place a schematic symbol">' +
+            '<div class="ib-bom-asset-thumb ib-bom-asset-symbol-thumb">' +
+              '<span class="ib-bom-symbol-glyph">&#x2317;</span>' +
+            '</div>' +
+            '<div class="ib-bom-asset-label">' + safeLabel + '</div>' +
+          '</div>';
+      }
+      var safeSrc = escapeHtml(a.src || '');
       return '<div class="ib-bom-asset" draggable="true"' +
         ' data-asset-src="' + safeSrc + '"' +
         ' data-asset-label="' + safeLabel + '"' +
@@ -2407,13 +2637,14 @@
     var toggleBtn = rowEl.querySelector('.ib-bom-row-toggle');
     var menuBtn = rowEl.querySelector('.ib-bom-row-menu');
 
-    // Click on head (anywhere except the buttons) toggles drawer.
+    // Click on head (anywhere except the buttons / dropdown) toggles drawer.
     if (head) {
       head.addEventListener('click', function (e) {
         var t = e.target;
-        // Ignore clicks on the menu / toggle buttons — they have their
-        // own handlers (toggle re-uses the same path).
-        if (t && (t.closest('.ib-bom-row-menu') || t.closest('.ib-bom-row-toggle'))) return;
+        // Ignore clicks on the menu / toggle buttons / dropdown items —
+        // they each have their own handlers.
+        if (t && (t.closest('.ib-bom-row-menu-wrap') ||
+                  t.closest('.ib-bom-row-toggle'))) return;
         toggleBomRowExpanded(rowId);
       });
       head.addEventListener('keydown', function (e) {
@@ -2430,12 +2661,18 @@
       });
     }
     if (menuBtn) {
-      menuBtn.addEventListener('click', function (e) {
-        // Inert placeholder — future home for `✎ design symbol` etc.
-        // Block bubbling so the row doesn't toggle on click.
-        e.stopPropagation();
-      });
+      // Bootstrap handles open/close via data-bs-toggle. We just stop
+      // propagation so the row doesn't toggle on the same click.
+      menuBtn.addEventListener('click', function (e) { e.stopPropagation(); });
     }
+    // Keep dropdown-item clicks from bubbling into the row (which would
+    // toggle the drawer mid-navigation).
+    Array.prototype.forEach.call(
+      rowEl.querySelectorAll('.ib-bom-row-menu-list .dropdown-item'),
+      function (a) {
+        a.addEventListener('click', function (e) { e.stopPropagation(); });
+      }
+    );
 
     // Drag the row itself → default asset (first in list, photo today).
     rowEl.addEventListener('dragstart', function (e) {
@@ -2475,9 +2712,29 @@
           // Stop the wrapping row's dragstart from also firing (it would
           // overwrite the chip's payload with the row default).
           e.stopPropagation();
-          var src = chip.getAttribute('data-asset-src') || '';
           var label = chip.getAttribute('data-asset-label') || 'Asset';
           var kind = chip.getAttribute('data-asset-kind') || 'photo';
+          // Symbol-kind chips: payload carries a symbolId rather than a
+          // src; the canvas drop handler rasterises the symbol_data
+          // off-screen into a PNG and places it like any other asset.
+          // This is the "rasterised symbol on a photo step" path the
+          // design handoff README references.
+          if (kind === 'symbol') {
+            var symbolId = parseInt(chip.getAttribute('data-symbol-id'), 10);
+            if (!symbolId) { e.preventDefault(); return; }
+            try {
+              e.dataTransfer.effectAllowed = 'copy';
+              e.dataTransfer.setData('application/json', JSON.stringify({
+                kind: 'symbol',
+                symbolId: symbolId,
+                label: label,
+                bomRowId: rowId,
+              }));
+              e.dataTransfer.setData('text/plain', label);
+            } catch (_) {}
+            return;
+          }
+          var src = chip.getAttribute('data-asset-src') || '';
           if (!src) { e.preventDefault(); return; }
           try {
             e.dataTransfer.effectAllowed = 'copy';

--- a/web/assets/js/schematic-editor.js
+++ b/web/assets/js/schematic-editor.js
@@ -187,6 +187,82 @@
     return null;
   }
 
+  // Convert a Symbol Designer document (``{ bodyShapes, pins }`` in
+  // symbol-space coords centred on (0,0)) into the editor's stub-library
+  // shape (``{ bodyWidth, bodyHeight, pins: [{ side, offset, ... }] }``).
+  // The pin x/y coords from the designer come in centred-at-origin
+  // space; the editor's ``pinLocalPos`` expects pins to live on the
+  // body's edge with an ``offset`` from the top-left corner along the
+  // relevant axis. The bounding box is computed from the union of pin
+  // coords + body shapes so each user-designed symbol stays compact.
+  function symbolDefFromCustom(row) {
+    if (!row || !row.symbol_data) return null;
+    var doc;
+    try { doc = JSON.parse(row.symbol_data); }
+    catch (_) { return null; }
+    if (!doc || typeof doc !== 'object') return null;
+    var pins = Array.isArray(doc.pins) ? doc.pins : [];
+    var shapes = Array.isArray(doc.bodyShapes) ? doc.bodyShapes : [];
+
+    // Bounding box from pins + shapes (centred coords).
+    var xs = [], ys = [];
+    pins.forEach(function (p) { xs.push(p.x || 0); ys.push(p.y || 0); });
+    shapes.forEach(function (s) {
+      if (s.kind === 'rect') {
+        xs.push(s.x); xs.push(s.x + s.w);
+        ys.push(s.y); ys.push(s.y + s.h);
+      } else if (s.kind === 'line') {
+        xs.push(s.x1); xs.push(s.x2);
+        ys.push(s.y1); ys.push(s.y2);
+      }
+    });
+    if (xs.length === 0) { xs = [-32, 32]; ys = [-24, 24]; }
+    var minX = Math.min.apply(null, xs);
+    var maxX = Math.max.apply(null, xs);
+    var minY = Math.min.apply(null, ys);
+    var maxY = Math.max.apply(null, ys);
+
+    // Pad slightly so pins stick out of the body rather than sitting on
+    // its corners — feels like a real symbol.
+    var pad = 8;
+    minX -= pad; minY -= pad; maxX += pad; maxY += pad;
+    var bodyWidth = Math.max(maxX - minX, 32);
+    var bodyHeight = Math.max(maxY - minY, 32);
+
+    // Convert each pin's centred coord into a (side, offset) the editor
+    // can render. ``offset`` is measured from the top-left of the body
+    // box, along the axis that runs parallel to that side.
+    var convertedPins = pins.map(function (p, i) {
+      var offset = (p.side === 'left' || p.side === 'right')
+        ? (p.y - minY)
+        : (p.x - minX);
+      return {
+        number: p.number || String(i + 1),
+        name: p.name || (p.number || String(i + 1)),
+        side: p.side || 'left',
+        offset: Math.max(0, Math.round(offset)),
+        type: p.type || 'I/O',
+      };
+    });
+
+    return {
+      id: 'custom-' + row.id,
+      name: row.name || ('Custom #' + row.id),
+      refDesPrefix: row.ref_des_prefix || 'U',
+      bodyWidth: bodyWidth,
+      bodyHeight: bodyHeight,
+      pins: convertedPins,
+      isCustom: true,
+      customId: row.id,
+      // Optional body shapes the designer drew — kept so the renderer
+      // could overlay them later. For v1 the editor uses the bounding
+      // box only (mirrors the stub library look).
+      _bodyShapes: shapes,
+      _minX: minX,
+      _minY: minY,
+    };
+  }
+
   // ====================================================================
   // 3. STATE
   // ====================================================================
@@ -1333,12 +1409,21 @@
     if (!dom.symbolList) return;
     var html = '';
     SYMBOL_LIBRARY.forEach(function (sym) {
+      var customBadge = sym.isCustom
+        ? '<span class="se-symbol-custom-badge" title="Designed in the Symbol Designer">Custom</span>'
+        : '';
       html +=
-        '<li class="se-symbol-item" data-symbol-id="' + escapeHtml(sym.id) + '" ' +
+        '<li class="se-symbol-item' + (sym.isCustom ? ' is-custom' : '') +
+            '" data-symbol-id="' + escapeHtml(sym.id) + '" ' +
             'role="option" tabindex="0">' +
-          '<span class="se-symbol-thumb"><i class="fas fa-microchip"></i></span>' +
+          '<span class="se-symbol-thumb">' +
+            (sym.isCustom
+              ? '<i class="fas fa-shapes"></i>'
+              : '<i class="fas fa-microchip"></i>') +
+          '</span>' +
           '<span class="se-symbol-meta">' +
-            '<span class="se-symbol-name">' + escapeHtml(sym.name) + '</span>' +
+            '<span class="se-symbol-name">' + escapeHtml(sym.name) +
+              customBadge + '</span>' +
             '<span class="se-symbol-sub small text-muted">' +
               escapeHtml(sym.refDesPrefix) + ' &middot; ' +
               sym.pins.length + ' pins' +
@@ -1347,6 +1432,31 @@
         '</li>';
     });
     dom.symbolList.innerHTML = html;
+  }
+
+  // ------------------------------------------------------------------
+  // Symbol Designer integration
+  // ------------------------------------------------------------------
+  //
+  // The schematic editor ships with the SYMBOL_LIBRARY array at the top
+  // of this file (Pico + R + C + LED + GND + V+ + generic IC). The
+  // Symbol Designer page (/projects/symbol/edit.html) grows that
+  // library project-by-project: each row in /api/projects/{id}/symbols
+  // is converted into a stub-shaped def via symbolDefFromCustom() and
+  // appended here. Failures are silent (the editor still works with
+  // just the built-in symbols).
+
+  async function loadCustomSymbolsIntoLibrary() {
+    try {
+      var r = await apiFetch(API + '/api/projects/' + STATE.projectId + '/symbols');
+      if (!r.ok) return;
+      var rows = await r.json();
+      if (!Array.isArray(rows)) return;
+      rows.forEach(function (row) {
+        var def = symbolDefFromCustom(row);
+        if (def) SYMBOL_LIBRARY.push(def);
+      });
+    } catch (_) { /* silent — built-in library still works */ }
   }
 
   function onSymbolItemClick(ev) {
@@ -1656,12 +1766,28 @@
       STATE.schematic = schematic;
       loadGraphFromSchematic(schematic);
 
+      // Symbol Designer integration: pull the project's user-designed
+      // symbols and append them to SYMBOL_LIBRARY so they show up in
+      // the tools-pane symbol list alongside the built-in stubs.
+      await loadCustomSymbolsIntoLibrary();
+
       wireUi();
       initCanvas();
       renderSymbolList();
       setActiveTool('select');
       renderGraph();
       setSaveStatus('saved');
+
+      // Enable the "+ open Symbol Designer" button now that the page
+      // ships (was disabled in the E2 merge).
+      if (dom.openSymDesigner) {
+        dom.openSymDesigner.disabled = false;
+        dom.openSymDesigner.removeAttribute('title');
+        dom.openSymDesigner.addEventListener('click', function () {
+          window.location.href = '/projects/symbol/edit.html?project_id=' +
+            encodeURIComponent(STATE.projectId) + '&new=true';
+        });
+      }
 
       showOnly(dom.main);
       // Re-fit after the layout settles.

--- a/web/assets/js/symbol-designer.js
+++ b/web/assets/js/symbol-designer.js
@@ -1,0 +1,1544 @@
+/**
+ * Symbol Designer — per-project schematic-symbol editor.
+ *
+ * Companion to the schematic editor (E2). The editor ships with a small
+ * hard-coded ``SYMBOL_LIBRARY`` (Pico, R, C, LED, GND, V+, generic
+ * 14-pin IC) and this page grows that library project-by-project: any
+ * symbol designed here gets POSTed to
+ * ``/api/projects/{id}/symbols`` and is then merged into the editor's
+ * library list at runtime (see ``schematic-editor.js`` for the merge
+ * call).
+ *
+ * Layout (see edit.html):
+ *
+ *   ┌─────────┬─────────────────────────────┬──────────────┐
+ *   │ Library │   Toolbox + Canvas          │ Properties   │
+ *   │ list    │   (16 px dot-grid)          │ panel        │
+ *   │ (240)   │   origin cross at (0,0)     │ (260)        │
+ *   └─────────┴─────────────────────────────┴──────────────┘
+ *
+ * Renderer: Fabric.js v6.4.0 (same engine as the schematic editor and
+ * the instruction builder; CDN UMD, exposes ``window.fabric``).
+ *
+ * Coordinate system: a fixed SCENE_W × SCENE_H logical canvas with the
+ * origin (0, 0) at the centre. Pin x/y and body shape coords are stored
+ * relative to that origin; rendering offsets them by SCENE_W/2,
+ * SCENE_H/2 so the origin cross sits in the middle of the canvas.
+ *
+ * State persistence: the active symbol's ``{ bodyShapes, pins }`` JSON
+ * document is PUT to ``/api/projects/{id}/symbols/{sid}`` via a
+ * debounced (500 ms) autosave. Symbol-level fields (name, refDes,
+ * description, bom_item_id) go through the same PUT.
+ *
+ * Tools (toolbox; left-to-right):
+ *   - Select (active by default)
+ *   - Pin       — implemented (click on a side rail places a pin)
+ *   - Net       — stubbed (toast); body-only design for v1
+ *   - Name      — stubbed (toast); symbol-level name lives in the
+ *                 properties panel for v1
+ *   - Label     — stubbed (toast)
+ *   - Line      — implemented (click two endpoints)
+ *   - Rect      — implemented (click and drag)
+ *   - Circle    — stubbed (toast)
+ *   - Text      — stubbed (toast)
+ *   - Rotate +/-90°, Flip H/V — implemented (apply to whole symbol)
+ *
+ * Stubbed tools document the v1 trim — re-enabling them is a follow-up.
+ *
+ * Public surface: an IIFE that auto-invokes on DOMContentLoaded. No
+ * external entry point — the page wires everything up via ``init()``.
+ */
+(function () {
+  'use strict';
+
+  // ====================================================================
+  // 1. CONSTANTS
+  // ====================================================================
+
+  var API = 'https://projects.kevsrobots.com';
+
+  // Logical scene size — small enough to feel like a "symbol editor"
+  // canvas (not a schematic page) but generous enough for big ICs.
+  var SCENE_W = 640;
+  var SCENE_H = 480;
+
+  // 16 px pitch dot grid, same as the schematic editor so the two
+  // workspaces share a visual + snap idiom.
+  var GRID = 16;
+  var AUTOSAVE_MS = 500;
+
+  // Brand colours
+  var INK = '#222222';
+  var BRAND_RED = '#c8312a';
+  var BG = '#ffffff';
+  var GRID_DOT = '#cfd3d8';
+  var PIN_RAIL = 'rgba(200, 49, 42, 0.06)';   // very faint red strip
+
+  // Side-rail width — clicks within this distance of the canvas edge
+  // are interpreted as "place a pin on that side".
+  var RAIL_W = 48;
+
+  // Default pin defaults for newly placed pins.
+  var DEFAULT_PIN_TYPE = 'I/O';
+
+  // The set of tools that are implemented in v1. Anything else
+  // produces a "coming soon" toast.
+  var IMPLEMENTED_TOOLS = {
+    select: true,
+    pin: true,
+    line: true,
+    rect: true,
+    // Side-effect toolbox buttons (apply to selection, then revert).
+    'rotate-ccw': true,
+    'rotate-cw': true,
+    'flip-h': true,
+    'flip-v': true,
+  };
+
+  // ====================================================================
+  // 2. STATE
+  // ====================================================================
+
+  var STATE = {
+    projectId: null,
+    project: null,
+    me: null,
+    isOwner: false,
+    symbols: [],             // [ProjectSymbolResponse]
+    bomItems: [],            // [BOMItemResponse] — for the linked-BOM dropdown
+    activeSymbolId: null,
+    activeSymbol: null,      // { bodyShapes: [], pins: [] } — parsed JSON
+    activeTool: 'select',
+    selectedShapeId: null,
+    selectedPinId: null,
+    librarySearch: '',
+    saveStatus: 'saved',
+    autosaveTimer: null,
+    canvas: null,            // fabric.Canvas
+    // Transient: drag-to-draw state for the rect tool.
+    rectDrawing: null,       // { x0, y0, previewObj }
+    // Transient: click-A → click-B state for the line tool.
+    linePending: null,       // { x, y, previewObj }
+    // Initial query string flags.
+    initNew: false,
+    initBomItemId: null,
+    initSymbolId: null,
+  };
+
+  function emptySymbolDoc() {
+    return { bodyShapes: [], pins: [] };
+  }
+
+  var dom = {};
+
+  // ====================================================================
+  // 3. UTILITIES
+  // ====================================================================
+
+  function snap(v) {
+    return Math.round(v / GRID) * GRID;
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function nextId(prefix) {
+    return prefix + '-' + Math.random().toString(36).slice(2, 10);
+  }
+
+  function apiFetch(url, opts) {
+    opts = opts || {};
+    if (window.ProjectAuth && typeof window.ProjectAuth.apiFetch === 'function') {
+      return window.ProjectAuth.apiFetch(url, opts);
+    }
+    opts.credentials = opts.credentials || 'include';
+    return fetch(url, opts);
+  }
+
+  async function apiFetchWithTermsRetry(url, opts) {
+    var resp = await apiFetch(url, opts);
+    if (resp.status === 403 && window.TermsGate &&
+        typeof window.TermsGate.handleResponse === 'function') {
+      try {
+        var retry = await window.TermsGate.handleResponse(resp);
+        if (retry) return apiFetch(url, opts);
+      } catch (_) { /* fall through */ }
+    }
+    return resp;
+  }
+
+  function showOnly(el) {
+    [dom.loading, dom.notOwner, dom.error, dom.main].forEach(function (n) {
+      if (!n) return;
+      if (n === el) n.classList.remove('d-none');
+      else n.classList.add('d-none');
+    });
+  }
+
+  function setSaveStatus(status, label) {
+    STATE.saveStatus = status;
+    if (!dom.saveStatus) return;
+    var icon, text;
+    switch (status) {
+      case 'saving': icon = 'fa-circle-notch fa-spin'; text = 'Saving…'; break;
+      case 'error':  icon = 'fa-triangle-exclamation'; text = label || 'Save failed'; break;
+      case 'saved':
+      default:       icon = 'fa-check'; text = 'Saved'; break;
+    }
+    dom.saveStatus.innerHTML =
+      '<i class="fas ' + icon + ' me-1"></i>' + escapeHtml(text);
+  }
+
+  function showToast(msg) {
+    if (!dom.toast) return;
+    dom.toast.textContent = msg;
+    dom.toast.classList.add('is-visible');
+    if (showToast._t) clearTimeout(showToast._t);
+    showToast._t = setTimeout(function () {
+      dom.toast.classList.remove('is-visible');
+    }, 1800);
+  }
+
+  // ====================================================================
+  // 4. COORDINATE TRANSFORMS
+  // ====================================================================
+  //
+  // Symbol-space coords are centred on (0, 0) (the origin cross). Fabric
+  // canvas coords are 0..SCENE_W / 0..SCENE_H. ``s2c`` / ``c2s``
+  // translate between the two.
+
+  function s2c(x, y) {
+    return { x: x + SCENE_W / 2, y: y + SCENE_H / 2 };
+  }
+  function c2s(x, y) {
+    return { x: x - SCENE_W / 2, y: y - SCENE_H / 2 };
+  }
+
+  // Snap a Fabric-canvas point to symbol-space grid (round-trip via
+  // c2s → snap → s2c so the result stays exactly aligned to the dots).
+  function snapCanvasXY(cx, cy) {
+    var s = c2s(cx, cy);
+    var ss = { x: snap(s.x), y: snap(s.y) };
+    return s2c(ss.x, ss.y);
+  }
+
+  // Classify a snapped *symbol-space* point as belonging to one of the
+  // four side rails (top/right/bottom/left) or to the body interior.
+  // Used by the Pin tool — rail clicks place pins on that side.
+  function classifyPinSide(sx, sy) {
+    var halfW = SCENE_W / 2;
+    var halfH = SCENE_H / 2;
+    var dLeft   = sx + halfW;             // distance from left edge
+    var dRight  = halfW - sx;             // from right edge
+    var dTop    = sy + halfH;
+    var dBottom = halfH - sy;
+    var min = Math.min(dLeft, dRight, dTop, dBottom);
+    if (min > RAIL_W) return null;        // interior — body shape, not a pin
+    if (min === dLeft)   return 'left';
+    if (min === dRight)  return 'right';
+    if (min === dTop)    return 'top';
+    return 'bottom';
+  }
+
+  // Snap a free pin x/y onto the corresponding side's rail axis. Pins
+  // on left/right live at the canvas edge (x = ±halfW), pins on
+  // top/bottom at y = ±halfH; the perpendicular coord stays snapped.
+  function snapPinToSide(sx, sy, side) {
+    var halfW = SCENE_W / 2;
+    var halfH = SCENE_H / 2;
+    sx = snap(sx); sy = snap(sy);
+    switch (side) {
+      case 'left':   return { x: -halfW + GRID, y: sy };
+      case 'right':  return { x:  halfW - GRID, y: sy };
+      case 'top':    return { x: sx, y: -halfH + GRID };
+      case 'bottom': return { x: sx, y:  halfH - GRID };
+    }
+    return { x: sx, y: sy };
+  }
+
+  // ====================================================================
+  // 5. GRID PATTERN + SIDE RAILS
+  // ====================================================================
+
+  function buildGridPattern() {
+    var off = document.createElement('canvas');
+    off.width = GRID;
+    off.height = GRID;
+    var ctx = off.getContext('2d');
+    ctx.fillStyle = BG;
+    ctx.fillRect(0, 0, GRID, GRID);
+    ctx.fillStyle = GRID_DOT;
+    ctx.beginPath();
+    ctx.arc(0, 0, 1.3, 0, Math.PI * 2);
+    ctx.fill();
+    return off;
+  }
+
+  function applyGridBackground() {
+    if (!STATE.canvas) return;
+    var pattern = new fabric.Pattern({
+      source: buildGridPattern(),
+      repeat: 'repeat',
+    });
+    STATE.canvas.set('backgroundColor', pattern);
+  }
+
+  // Faint coloured strips on the four canvas edges — visual cue that
+  // those are pin rails. Drawn as plain rects so they participate in
+  // the same clear()/render() loop as everything else.
+  function buildSideRails() {
+    var rails = [];
+    var mkRect = function (x, y, w, h) {
+      return new fabric.Rect({
+        left: x, top: y, width: w, height: h,
+        fill: PIN_RAIL,
+        stroke: null,
+        selectable: false,
+        evented: false,
+      });
+    };
+    rails.push(mkRect(0, 0, RAIL_W, SCENE_H));               // left
+    rails.push(mkRect(SCENE_W - RAIL_W, 0, RAIL_W, SCENE_H)); // right
+    rails.push(mkRect(0, 0, SCENE_W, RAIL_W));               // top
+    rails.push(mkRect(0, SCENE_H - RAIL_W, SCENE_W, RAIL_W)); // bottom
+    return rails;
+  }
+
+  function buildOriginCross() {
+    var c = s2c(0, 0);
+    return [
+      new fabric.Line([c.x - 8, c.y, c.x + 8, c.y], {
+        stroke: BRAND_RED, strokeWidth: 1, selectable: false, evented: false,
+      }),
+      new fabric.Line([c.x, c.y - 8, c.x, c.y + 8], {
+        stroke: BRAND_RED, strokeWidth: 1, selectable: false, evented: false,
+      }),
+    ];
+  }
+
+  // ====================================================================
+  // 6. SHAPE / PIN MUTATION
+  // ====================================================================
+
+  function findShape(id) {
+    if (!STATE.activeSymbol) return null;
+    for (var i = 0; i < STATE.activeSymbol.bodyShapes.length; i++) {
+      if (STATE.activeSymbol.bodyShapes[i].id === id) return STATE.activeSymbol.bodyShapes[i];
+    }
+    return null;
+  }
+
+  function findPin(id) {
+    if (!STATE.activeSymbol) return null;
+    for (var i = 0; i < STATE.activeSymbol.pins.length; i++) {
+      if (STATE.activeSymbol.pins[i].id === id) return STATE.activeSymbol.pins[i];
+    }
+    return null;
+  }
+
+  function autoPinNumber() {
+    if (!STATE.activeSymbol) return '1';
+    var max = 0;
+    STATE.activeSymbol.pins.forEach(function (p) {
+      var n = parseInt(p.number, 10);
+      if (!isNaN(n) && n > max) max = n;
+    });
+    return String(max + 1);
+  }
+
+  function addPin(sx, sy, side) {
+    if (!STATE.activeSymbol) return;
+    var snapped = snapPinToSide(sx, sy, side);
+    var pin = {
+      id: nextId('p'),
+      number: autoPinNumber(),
+      name: '',
+      type: DEFAULT_PIN_TYPE,
+      side: side,
+      x: snapped.x,
+      y: snapped.y,
+    };
+    STATE.activeSymbol.pins.push(pin);
+    STATE.selectedPinId = pin.id;
+    STATE.selectedShapeId = null;
+    renderCanvas();
+    renderPropertiesPanel();
+    scheduleAutosave();
+  }
+
+  function addRectShape(x0, y0, x1, y1) {
+    if (!STATE.activeSymbol) return;
+    var sx = Math.min(x0, x1);
+    var sy = Math.min(y0, y1);
+    var w = Math.abs(x1 - x0);
+    var h = Math.abs(y1 - y0);
+    if (w < GRID || h < GRID) return;       // ignore zero-width drags
+    var shape = {
+      id: nextId('s'),
+      kind: 'rect',
+      x: sx,
+      y: sy,
+      w: w,
+      h: h,
+      stroke: INK,
+      fill: null,
+    };
+    STATE.activeSymbol.bodyShapes.push(shape);
+    STATE.selectedShapeId = shape.id;
+    STATE.selectedPinId = null;
+    renderCanvas();
+    renderPropertiesPanel();
+    scheduleAutosave();
+  }
+
+  function addLineShape(x1, y1, x2, y2) {
+    if (!STATE.activeSymbol) return;
+    if (x1 === x2 && y1 === y2) return;
+    var shape = {
+      id: nextId('s'),
+      kind: 'line',
+      x1: x1, y1: y1,
+      x2: x2, y2: y2,
+      stroke: INK,
+    };
+    STATE.activeSymbol.bodyShapes.push(shape);
+    STATE.selectedShapeId = shape.id;
+    STATE.selectedPinId = null;
+    renderCanvas();
+    renderPropertiesPanel();
+    scheduleAutosave();
+  }
+
+  function deleteSelected() {
+    if (!STATE.activeSymbol) return;
+    var mutated = false;
+    if (STATE.selectedPinId) {
+      STATE.activeSymbol.pins = STATE.activeSymbol.pins.filter(function (p) {
+        return p.id !== STATE.selectedPinId;
+      });
+      STATE.selectedPinId = null;
+      mutated = true;
+    }
+    if (STATE.selectedShapeId) {
+      STATE.activeSymbol.bodyShapes = STATE.activeSymbol.bodyShapes.filter(function (s) {
+        return s.id !== STATE.selectedShapeId;
+      });
+      STATE.selectedShapeId = null;
+      mutated = true;
+    }
+    if (mutated) {
+      renderCanvas();
+      renderPropertiesPanel();
+      scheduleAutosave();
+    }
+  }
+
+  // ====================================================================
+  // 7. WHOLE-SYMBOL TRANSFORMS
+  // ====================================================================
+  //
+  // Rotate / flip act on the whole symbol when nothing is selected,
+  // and on the selected pin/shape otherwise. For v1 we only implement
+  // the whole-symbol path (the selection paths are tagged TODO; the
+  // common workflow is "design a symbol, rotate / flip it on the
+  // schematic page" — the schematic editor already supports per-
+  // instance rotate / flip on its instances).
+
+  function rotateAll(deg) {
+    if (!STATE.activeSymbol) return;
+    var rad = deg * Math.PI / 180;
+    var cos = Math.cos(rad);
+    var sin = Math.sin(rad);
+    var rot = function (x, y) {
+      return { x: snap(x * cos - y * sin), y: snap(x * sin + y * cos) };
+    };
+    STATE.activeSymbol.pins.forEach(function (p) {
+      var r = rot(p.x, p.y);
+      p.x = r.x; p.y = r.y;
+      // Side flips through the rotation cycle (left → top → right →
+      // bottom → left for +90°; the opposite for -90°).
+      p.side = rotateSide(p.side, deg);
+    });
+    STATE.activeSymbol.bodyShapes.forEach(function (s) {
+      if (s.kind === 'rect') {
+        var corners = [
+          rot(s.x, s.y),
+          rot(s.x + s.w, s.y + s.h),
+        ];
+        var nx = Math.min(corners[0].x, corners[1].x);
+        var ny = Math.min(corners[0].y, corners[1].y);
+        s.x = nx;
+        s.y = ny;
+        s.w = Math.abs(corners[1].x - corners[0].x);
+        s.h = Math.abs(corners[1].y - corners[0].y);
+      } else if (s.kind === 'line') {
+        var a = rot(s.x1, s.y1);
+        var b = rot(s.x2, s.y2);
+        s.x1 = a.x; s.y1 = a.y;
+        s.x2 = b.x; s.y2 = b.y;
+      }
+    });
+    renderCanvas();
+    scheduleAutosave();
+  }
+
+  function rotateSide(side, deg) {
+    var order = ['left', 'top', 'right', 'bottom'];
+    var idx = order.indexOf(side);
+    if (idx < 0) return side;
+    var steps = (deg / 90) % 4;
+    return order[((idx + steps) % 4 + 4) % 4];
+  }
+
+  function flipAll(axis) {
+    if (!STATE.activeSymbol) return;
+    STATE.activeSymbol.pins.forEach(function (p) {
+      if (axis === 'h') { p.x = -p.x; if (p.side === 'left') p.side = 'right'; else if (p.side === 'right') p.side = 'left'; }
+      else              { p.y = -p.y; if (p.side === 'top') p.side = 'bottom'; else if (p.side === 'bottom') p.side = 'top'; }
+    });
+    STATE.activeSymbol.bodyShapes.forEach(function (s) {
+      if (s.kind === 'rect') {
+        if (axis === 'h') s.x = -s.x - s.w;
+        else              s.y = -s.y - s.h;
+      } else if (s.kind === 'line') {
+        if (axis === 'h') { s.x1 = -s.x1; s.x2 = -s.x2; }
+        else              { s.y1 = -s.y1; s.y2 = -s.y2; }
+      }
+    });
+    renderCanvas();
+    scheduleAutosave();
+  }
+
+  // ====================================================================
+  // 8. CANVAS RENDER
+  // ====================================================================
+
+  function renderCanvas() {
+    if (!STATE.canvas) return;
+    STATE.canvas.discardActiveObject();
+    STATE.canvas.clear();
+    applyGridBackground();
+
+    // Side rails first (visual hint for the Pin tool).
+    buildSideRails().forEach(function (r) { STATE.canvas.add(r); });
+
+    if (!STATE.activeSymbol) {
+      // No symbol — just origin + rails so the empty state reads "this
+      // is a canvas but you haven't picked anything yet".
+      buildOriginCross().forEach(function (l) { STATE.canvas.add(l); });
+      if (dom.emptyState) dom.emptyState.classList.add('is-visible');
+      STATE.canvas.requestRenderAll();
+      return;
+    }
+    if (dom.emptyState) dom.emptyState.classList.remove('is-visible');
+
+    // Body shapes
+    STATE.activeSymbol.bodyShapes.forEach(function (s) {
+      var sel = (s.id === STATE.selectedShapeId);
+      if (s.kind === 'rect') {
+        var p = s2c(s.x, s.y);
+        var rect = new fabric.Rect({
+          left: p.x,
+          top: p.y,
+          width: s.w,
+          height: s.h,
+          fill: s.fill || 'rgba(255,255,255,0.01)',
+          stroke: sel ? BRAND_RED : (s.stroke || INK),
+          strokeWidth: sel ? 2.5 : 1.5,
+          selectable: false,
+          evented: true,
+          hoverCursor: 'pointer',
+          objectCaching: false,
+        });
+        rect.data = { kind: 'shape', id: s.id };
+        STATE.canvas.add(rect);
+      } else if (s.kind === 'line') {
+        var a = s2c(s.x1, s.y1);
+        var b = s2c(s.x2, s.y2);
+        var line = new fabric.Line([a.x, a.y, b.x, b.y], {
+          stroke: sel ? BRAND_RED : (s.stroke || INK),
+          strokeWidth: sel ? 2.5 : 1.5,
+          selectable: false,
+          evented: true,
+          hoverCursor: 'pointer',
+          perPixelTargetFind: true,
+          objectCaching: false,
+        });
+        line.data = { kind: 'shape', id: s.id };
+        STATE.canvas.add(line);
+      }
+    });
+
+    // Pins
+    STATE.activeSymbol.pins.forEach(function (pin) {
+      drawPin(pin);
+    });
+
+    // Origin cross last so it sits on top of body shapes.
+    buildOriginCross().forEach(function (l) { STATE.canvas.add(l); });
+
+    // Rect-draw preview (transient)
+    if (STATE.rectDrawing && STATE.rectDrawing.previewObj) {
+      STATE.canvas.add(STATE.rectDrawing.previewObj);
+    }
+    if (STATE.linePending && STATE.linePending.previewObj) {
+      STATE.canvas.add(STATE.linePending.previewObj);
+    }
+
+    STATE.canvas.requestRenderAll();
+  }
+
+  function drawPin(pin) {
+    var pos = s2c(pin.x, pin.y);
+    var stickLen = 12;
+    var ex = pos.x, ey = pos.y;
+    var labelDx = 0, labelDy = 0;
+    var labelAnchorX = 'left';
+    var labelAnchorY = 'center';
+    switch (pin.side) {
+      case 'left':
+        ex = pos.x + stickLen;
+        labelDx = stickLen + 4;
+        labelAnchorX = 'left';
+        break;
+      case 'right':
+        ex = pos.x - stickLen;
+        labelDx = -(stickLen + 4);
+        labelAnchorX = 'right';
+        break;
+      case 'top':
+        ey = pos.y + stickLen;
+        labelDy = stickLen + 4;
+        labelAnchorY = 'top';
+        break;
+      case 'bottom':
+        ey = pos.y - stickLen;
+        labelDy = -(stickLen + 4);
+        labelAnchorY = 'bottom';
+        break;
+    }
+    var sel = (pin.id === STATE.selectedPinId);
+    // Stick
+    var stick = new fabric.Line([pos.x, pos.y, ex, ey], {
+      stroke: sel ? BRAND_RED : INK,
+      strokeWidth: sel ? 2 : 1.5,
+      selectable: false,
+      evented: false,
+    });
+    STATE.canvas.add(stick);
+    // Endpoint dot — the click target.
+    var dot = new fabric.Circle({
+      left: pos.x,
+      top: pos.y,
+      radius: 5,
+      fill: sel ? BRAND_RED : '#fff',
+      stroke: sel ? BRAND_RED : INK,
+      strokeWidth: 1.2,
+      originX: 'center',
+      originY: 'center',
+      selectable: false,
+      evented: true,
+      hoverCursor: 'pointer',
+    });
+    dot.data = { kind: 'pin', id: pin.id };
+    STATE.canvas.add(dot);
+    // Label
+    var label = (pin.number || '') + (pin.name ? ' ' + pin.name : '');
+    if (label.trim()) {
+      var txt = new fabric.Text(label, {
+        left: ex + labelDx,
+        top: ey + labelDy,
+        fontSize: 11,
+        fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+        fill: INK,
+        originX: labelAnchorX,
+        originY: labelAnchorY,
+        selectable: false,
+        evented: false,
+      });
+      STATE.canvas.add(txt);
+    }
+  }
+
+  // ====================================================================
+  // 9. CANVAS EVENTS
+  // ====================================================================
+
+  function pointerScene(opt) {
+    return STATE.canvas.getPointer(opt.e);
+  }
+
+  function onCanvasMouseDown(opt) {
+    var obj = opt.target;
+    var p = pointerScene(opt);
+    var snapped = snapCanvasXY(p.x, p.y);
+    var sxy = c2s(snapped.x, snapped.y);
+
+    if (!STATE.activeSymbol) return;
+
+    switch (STATE.activeTool) {
+      case 'pin': {
+        var side = classifyPinSide(sxy.x, sxy.y);
+        if (!side) {
+          showToast('Click closer to an edge to place a pin.');
+          return;
+        }
+        addPin(sxy.x, sxy.y, side);
+        return;
+      }
+      case 'rect': {
+        STATE.rectDrawing = {
+          x0: sxy.x,
+          y0: sxy.y,
+          previewObj: null,
+        };
+        return;
+      }
+      case 'line': {
+        if (!STATE.linePending) {
+          STATE.linePending = { x: sxy.x, y: sxy.y, previewObj: null };
+        } else {
+          addLineShape(STATE.linePending.x, STATE.linePending.y, sxy.x, sxy.y);
+          STATE.linePending = null;
+          renderCanvas();
+        }
+        return;
+      }
+      case 'select':
+      default: {
+        if (obj && obj.data) {
+          if (obj.data.kind === 'pin') {
+            STATE.selectedPinId = obj.data.id;
+            STATE.selectedShapeId = null;
+          } else if (obj.data.kind === 'shape') {
+            STATE.selectedShapeId = obj.data.id;
+            STATE.selectedPinId = null;
+          }
+          renderCanvas();
+          renderPropertiesPanel();
+          return;
+        }
+        // Empty-canvas click clears the selection.
+        STATE.selectedPinId = null;
+        STATE.selectedShapeId = null;
+        renderCanvas();
+        renderPropertiesPanel();
+        return;
+      }
+    }
+  }
+
+  function onCanvasMouseMove(opt) {
+    if (!STATE.activeSymbol) return;
+    if (STATE.activeTool === 'rect' && STATE.rectDrawing) {
+      var p = pointerScene(opt);
+      var snapped = snapCanvasXY(p.x, p.y);
+      var sxy = c2s(snapped.x, snapped.y);
+      var s = STATE.rectDrawing;
+      var x = Math.min(s.x0, sxy.x);
+      var y = Math.min(s.y0, sxy.y);
+      var w = Math.abs(sxy.x - s.x0);
+      var h = Math.abs(sxy.y - s.y0);
+      var tl = s2c(x, y);
+      if (s.previewObj) {
+        STATE.canvas.remove(s.previewObj);
+        s.previewObj = null;
+      }
+      s.previewObj = new fabric.Rect({
+        left: tl.x,
+        top: tl.y,
+        width: w,
+        height: h,
+        fill: 'rgba(200, 49, 42, 0.05)',
+        stroke: BRAND_RED,
+        strokeWidth: 1.2,
+        strokeDashArray: [4, 4],
+        selectable: false,
+        evented: false,
+      });
+      STATE.canvas.add(s.previewObj);
+      STATE.canvas.requestRenderAll();
+    } else if (STATE.activeTool === 'line' && STATE.linePending) {
+      var p2 = pointerScene(opt);
+      var snapped2 = snapCanvasXY(p2.x, p2.y);
+      var lp = STATE.linePending;
+      var a = s2c(lp.x, lp.y);
+      if (lp.previewObj) {
+        STATE.canvas.remove(lp.previewObj);
+        lp.previewObj = null;
+      }
+      lp.previewObj = new fabric.Line([a.x, a.y, snapped2.x, snapped2.y], {
+        stroke: BRAND_RED,
+        strokeWidth: 1.2,
+        strokeDashArray: [4, 4],
+        selectable: false,
+        evented: false,
+      });
+      STATE.canvas.add(lp.previewObj);
+      STATE.canvas.requestRenderAll();
+    }
+  }
+
+  function onCanvasMouseUp(opt) {
+    if (STATE.activeTool === 'rect' && STATE.rectDrawing) {
+      var p = pointerScene(opt);
+      var snapped = snapCanvasXY(p.x, p.y);
+      var sxy = c2s(snapped.x, snapped.y);
+      var s = STATE.rectDrawing;
+      STATE.rectDrawing = null;
+      addRectShape(s.x0, s.y0, sxy.x, sxy.y);
+    }
+  }
+
+  // ====================================================================
+  // 10. PROPERTIES PANEL
+  // ====================================================================
+
+  function renderPropertiesPanel() {
+    var hasSymbol = !!STATE.activeSymbol;
+    var pin = STATE.selectedPinId ? findPin(STATE.selectedPinId) : null;
+    var shape = STATE.selectedShapeId ? findShape(STATE.selectedShapeId) : null;
+
+    // Symbol-level section
+    if (dom.symbolSection) {
+      dom.symbolSection.classList.toggle('d-none', !hasSymbol);
+    }
+    if (hasSymbol) {
+      var sym = getActiveSymbolRow();
+      if (dom.propName && document.activeElement !== dom.propName) {
+        dom.propName.value = sym ? (sym.name || '') : '';
+      }
+      if (dom.propRefDes && document.activeElement !== dom.propRefDes) {
+        dom.propRefDes.value = sym ? (sym.ref_des_prefix || 'U') : 'U';
+      }
+      if (dom.propDesc && document.activeElement !== dom.propDesc) {
+        dom.propDesc.value = sym ? (sym.description || '') : '';
+      }
+      if (dom.propPinCount) {
+        dom.propPinCount.textContent = String((STATE.activeSymbol.pins || []).length);
+      }
+      if (dom.propBom && document.activeElement !== dom.propBom) {
+        dom.propBom.value = sym && sym.bom_item_id != null ? String(sym.bom_item_id) : '';
+      }
+    }
+
+    // Pin section
+    if (dom.pinSection) {
+      dom.pinSection.classList.toggle('d-none', !pin);
+    }
+    if (pin) {
+      if (dom.pinNumber && document.activeElement !== dom.pinNumber) {
+        dom.pinNumber.value = pin.number || '';
+      }
+      if (dom.pinName && document.activeElement !== dom.pinName) {
+        dom.pinName.value = pin.name || '';
+      }
+      Array.prototype.forEach.call(
+        dom.pinTypeRadios,
+        function (r) { r.checked = (r.value === (pin.type || DEFAULT_PIN_TYPE)); }
+      );
+      Array.prototype.forEach.call(
+        dom.pinSideRadios,
+        function (r) { r.checked = (r.value === pin.side); }
+      );
+    }
+
+    // Shape section
+    if (dom.shapeSection) {
+      dom.shapeSection.classList.toggle('d-none', !shape);
+    }
+    if (shape) {
+      // Show only the field group that matches this shape's kind.
+      Array.prototype.forEach.call(
+        dom.shapeSection.querySelectorAll('[data-shape-kind]'),
+        function (el) {
+          el.classList.toggle('d-none', el.dataset.shapeKind !== shape.kind);
+        }
+      );
+      if (shape.kind === 'rect') {
+        if (dom.shapeRectX) dom.shapeRectX.value = shape.x;
+        if (dom.shapeRectY) dom.shapeRectY.value = shape.y;
+        if (dom.shapeRectW) dom.shapeRectW.value = shape.w;
+        if (dom.shapeRectH) dom.shapeRectH.value = shape.h;
+      } else if (shape.kind === 'line') {
+        if (dom.shapeLineX1) dom.shapeLineX1.value = shape.x1;
+        if (dom.shapeLineY1) dom.shapeLineY1.value = shape.y1;
+        if (dom.shapeLineX2) dom.shapeLineX2.value = shape.x2;
+        if (dom.shapeLineY2) dom.shapeLineY2.value = shape.y2;
+      }
+    }
+  }
+
+  function getActiveSymbolRow() {
+    if (STATE.activeSymbolId == null) return null;
+    for (var i = 0; i < STATE.symbols.length; i++) {
+      if (STATE.symbols[i].id === STATE.activeSymbolId) return STATE.symbols[i];
+    }
+    return null;
+  }
+
+  function setActiveSymbolField(field, value) {
+    var row = getActiveSymbolRow();
+    if (!row) return;
+    row[field] = value;
+    scheduleAutosave();
+  }
+
+  // ====================================================================
+  // 11. LIBRARY LIST
+  // ====================================================================
+
+  function renderLibraryList() {
+    if (!dom.libraryList) return;
+    var q = (STATE.librarySearch || '').toLowerCase().trim();
+    var visible = STATE.symbols.filter(function (s) {
+      if (!q) return true;
+      return String(s.name || '').toLowerCase().indexOf(q) >= 0;
+    });
+    if (visible.length === 0) {
+      dom.libraryList.innerHTML =
+        '<li class="sd-library-empty">' +
+        (STATE.symbols.length === 0
+          ? 'No symbols yet. Click <strong>+ New</strong> to design one.'
+          : 'No symbols match this search.') +
+        '</li>';
+    } else {
+      var html = visible.map(function (s) {
+        var isActive = (s.id === STATE.activeSymbolId);
+        var pinCount = countSymbolPins(s);
+        return '' +
+          '<li class="sd-library-item' + (isActive ? ' is-active' : '') + '"' +
+          ' data-symbol-id="' + s.id + '" role="option" tabindex="0">' +
+            '<span class="sd-library-item-icon">' +
+              '<i class="fas fa-microchip"></i>' +
+            '</span>' +
+            '<span class="sd-library-item-name" title="' + escapeHtml(s.name) + '">' +
+              escapeHtml(s.name) +
+            '</span>' +
+            '<span class="sd-library-item-sub">' +
+              escapeHtml(s.ref_des_prefix || 'U') + ' · ' + pinCount + 'p' +
+            '</span>' +
+          '</li>';
+      }).join('');
+      dom.libraryList.innerHTML = html;
+    }
+    // Footer button enable state.
+    var hasActive = !!getActiveSymbolRow();
+    if (dom.libraryDuplicate) dom.libraryDuplicate.disabled = !hasActive;
+    if (dom.libraryDelete) dom.libraryDelete.disabled = !hasActive;
+  }
+
+  function countSymbolPins(s) {
+    if (!s || !s.symbol_data) return 0;
+    try {
+      var doc = JSON.parse(s.symbol_data);
+      if (doc && Array.isArray(doc.pins)) return doc.pins.length;
+    } catch (_) {}
+    return 0;
+  }
+
+  // ====================================================================
+  // 12. BOM-LINK DROPDOWN
+  // ====================================================================
+
+  function renderBomDropdown() {
+    if (!dom.propBom) return;
+    var current = '';
+    var row = getActiveSymbolRow();
+    if (row && row.bom_item_id != null) current = String(row.bom_item_id);
+    var opts = '<option value="">(none)</option>';
+    STATE.bomItems.forEach(function (b) {
+      opts += '<option value="' + b.id + '"' +
+        (String(b.id) === current ? ' selected' : '') + '>' +
+        escapeHtml(b.name) + ' (×' + (b.quantity || 1) + ')' +
+        '</option>';
+    });
+    dom.propBom.innerHTML = opts;
+  }
+
+  // ====================================================================
+  // 13. AUTOSAVE
+  // ====================================================================
+
+  function scheduleAutosave() {
+    if (STATE.activeSymbolId == null) return;
+    if (STATE.autosaveTimer) clearTimeout(STATE.autosaveTimer);
+    setSaveStatus('saving');
+    STATE.autosaveTimer = setTimeout(function () {
+      STATE.autosaveTimer = null;
+      doAutosave();
+    }, AUTOSAVE_MS);
+  }
+
+  async function doAutosave() {
+    var row = getActiveSymbolRow();
+    if (!row) return;
+    var payload = {
+      name: row.name,
+      ref_des_prefix: row.ref_des_prefix || 'U',
+      description: row.description || null,
+      bom_item_id: row.bom_item_id == null ? null : row.bom_item_id,
+      symbol_data: JSON.stringify(STATE.activeSymbol || emptySymbolDoc()),
+    };
+    try {
+      var resp = await apiFetchWithTermsRetry(
+        API + '/api/projects/' + STATE.projectId + '/symbols/' + row.id,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }
+      );
+      if (!resp.ok) throw new Error('PUT symbol HTTP ' + resp.status);
+      var updated = await resp.json();
+      // Sync the in-memory row with the server's response (updated_at etc.).
+      for (var k in updated) {
+        if (Object.prototype.hasOwnProperty.call(updated, k)) {
+          row[k] = updated[k];
+        }
+      }
+      setSaveStatus('saved');
+    } catch (e) {
+      setSaveStatus('error', 'Save failed');
+    }
+  }
+
+  // ====================================================================
+  // 14. ACTIVATE A SYMBOL
+  // ====================================================================
+
+  function activateSymbol(symbolId) {
+    var row = null;
+    for (var i = 0; i < STATE.symbols.length; i++) {
+      if (STATE.symbols[i].id === symbolId) { row = STATE.symbols[i]; break; }
+    }
+    if (!row) return;
+    STATE.activeSymbolId = symbolId;
+    STATE.activeSymbol = parseSymbolData(row.symbol_data);
+    STATE.selectedPinId = null;
+    STATE.selectedShapeId = null;
+    setActiveTool('select');
+    renderLibraryList();
+    renderCanvas();
+    renderPropertiesPanel();
+  }
+
+  function parseSymbolData(s) {
+    if (!s) return emptySymbolDoc();
+    try {
+      var parsed = JSON.parse(s);
+      if (parsed && typeof parsed === 'object') {
+        return {
+          bodyShapes: Array.isArray(parsed.bodyShapes) ? parsed.bodyShapes : [],
+          pins: Array.isArray(parsed.pins) ? parsed.pins : [],
+        };
+      }
+    } catch (_) { /* fall through to empty */ }
+    return emptySymbolDoc();
+  }
+
+  // ====================================================================
+  // 15. CRUD (frontend → backend)
+  // ====================================================================
+
+  async function createSymbol(opts) {
+    opts = opts || {};
+    var body = {
+      name: opts.name || 'New symbol',
+      ref_des_prefix: opts.ref_des_prefix || 'U',
+      description: opts.description || null,
+      bom_item_id: opts.bom_item_id == null ? null : opts.bom_item_id,
+      symbol_data: JSON.stringify(opts.symbol_data || emptySymbolDoc()),
+    };
+    setSaveStatus('saving');
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + STATE.projectId + '/symbols',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }
+    );
+    if (!resp.ok) {
+      setSaveStatus('error', 'Create failed');
+      throw new Error('POST symbol HTTP ' + resp.status);
+    }
+    var created = await resp.json();
+    STATE.symbols.push(created);
+    activateSymbol(created.id);
+    renderLibraryList();
+    renderBomDropdown();
+    setSaveStatus('saved');
+    return created;
+  }
+
+  async function duplicateActive() {
+    var row = getActiveSymbolRow();
+    if (!row) return;
+    setSaveStatus('saving');
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + STATE.projectId + '/symbols/' + row.id + '/duplicate',
+      { method: 'POST' }
+    );
+    if (!resp.ok) {
+      setSaveStatus('error', 'Duplicate failed');
+      return;
+    }
+    var dup = await resp.json();
+    STATE.symbols.push(dup);
+    activateSymbol(dup.id);
+    renderLibraryList();
+    setSaveStatus('saved');
+  }
+
+  async function deleteActive() {
+    var row = getActiveSymbolRow();
+    if (!row) return;
+    if (!window.confirm('Delete "' + (row.name || 'this symbol') + '"? This cannot be undone.')) {
+      return;
+    }
+    setSaveStatus('saving');
+    var resp = await apiFetchWithTermsRetry(
+      API + '/api/projects/' + STATE.projectId + '/symbols/' + row.id,
+      { method: 'DELETE' }
+    );
+    if (!resp.ok) {
+      setSaveStatus('error', 'Delete failed');
+      return;
+    }
+    STATE.symbols = STATE.symbols.filter(function (s) { return s.id !== row.id; });
+    STATE.activeSymbolId = null;
+    STATE.activeSymbol = null;
+    renderLibraryList();
+    renderCanvas();
+    renderPropertiesPanel();
+    setSaveStatus('saved');
+  }
+
+  // ====================================================================
+  // 16. TOOL SWITCHING
+  // ====================================================================
+
+  function setActiveTool(tool) {
+    // Side-effect buttons — apply then revert to select.
+    if (tool === 'rotate-ccw') { rotateAll(-90); tool = 'select'; }
+    else if (tool === 'rotate-cw') { rotateAll(90); tool = 'select'; }
+    else if (tool === 'flip-h') { flipAll('h'); tool = 'select'; }
+    else if (tool === 'flip-v') { flipAll('v'); tool = 'select'; }
+
+    if (!IMPLEMENTED_TOOLS[tool]) {
+      // Stubbed tools — show a toast and stay on the current tool. The
+      // README handoff lists which ones are v1-trimmed; the toast points
+      // the user at the implemented alternatives.
+      showToast('"' + tool + '" tool is coming soon. Try Pin / Rect / Line for now.');
+      // Don't change the active tool — leave the previous one selected.
+      paintActiveToolButton();
+      return;
+    }
+    STATE.activeTool = tool;
+    // Clear transient drawing state when leaving rect/line.
+    if (tool !== 'rect' && STATE.rectDrawing) {
+      if (STATE.rectDrawing.previewObj) {
+        STATE.canvas.remove(STATE.rectDrawing.previewObj);
+      }
+      STATE.rectDrawing = null;
+    }
+    if (tool !== 'line' && STATE.linePending) {
+      if (STATE.linePending.previewObj) {
+        STATE.canvas.remove(STATE.linePending.previewObj);
+      }
+      STATE.linePending = null;
+    }
+    paintActiveToolButton();
+    renderCanvas();
+  }
+
+  function paintActiveToolButton() {
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.sd-tool-btn'),
+      function (btn) {
+        btn.classList.toggle('is-active', btn.dataset.tool === STATE.activeTool);
+      }
+    );
+  }
+
+  // ====================================================================
+  // 17. CANVAS INIT
+  // ====================================================================
+
+  function initCanvas() {
+    if (typeof fabric === 'undefined' || !fabric.Canvas) {
+      throw new Error('Fabric.js failed to load');
+    }
+    STATE.canvas = new fabric.Canvas(dom.canvasEl, {
+      width: SCENE_W,
+      height: SCENE_H,
+      backgroundColor: BG,
+      preserveObjectStacking: true,
+      selection: false,
+    });
+    var c = STATE.canvas;
+    c.on('mouse:down', onCanvasMouseDown);
+    c.on('mouse:move', onCanvasMouseMove);
+    c.on('mouse:up',   onCanvasMouseUp);
+
+    syncCanvasDisplaySize();
+    window.addEventListener('resize', syncCanvasDisplaySize);
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        if (STATE.rectDrawing) {
+          if (STATE.rectDrawing.previewObj) STATE.canvas.remove(STATE.rectDrawing.previewObj);
+          STATE.rectDrawing = null;
+          renderCanvas();
+        } else if (STATE.linePending) {
+          if (STATE.linePending.previewObj) STATE.canvas.remove(STATE.linePending.previewObj);
+          STATE.linePending = null;
+          renderCanvas();
+        } else {
+          STATE.selectedPinId = null;
+          STATE.selectedShapeId = null;
+          renderCanvas();
+          renderPropertiesPanel();
+        }
+      } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (document.activeElement &&
+            /input|textarea|select/i.test(document.activeElement.tagName)) {
+          return;
+        }
+        if (STATE.selectedPinId || STATE.selectedShapeId) {
+          e.preventDefault();
+          deleteSelected();
+        }
+      }
+    });
+  }
+
+  function syncCanvasDisplaySize() {
+    if (!STATE.canvas || !dom.canvasWrap) return;
+    var rect = dom.canvasWrap.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    var scale = Math.min(rect.width / SCENE_W, rect.height / SCENE_H, 1.6);
+    if (scale < 0.1) scale = 0.1;
+    STATE.canvas.setDimensions(
+      { width: SCENE_W * scale, height: SCENE_H * scale },
+      { cssOnly: true }
+    );
+    STATE.canvas.setZoom(scale);
+  }
+
+  // ====================================================================
+  // 18. EVENT WIRING
+  // ====================================================================
+
+  function cacheDom() {
+    dom.workspace      = document.getElementById('sd-workspace');
+    dom.titlebar       = document.getElementById('sd-titlebar');
+    dom.backLink       = document.getElementById('sd-back-link');
+    dom.openSchematic  = document.getElementById('sd-open-schematic');
+    dom.projectTitle   = document.getElementById('sd-project-title');
+    dom.saveStatus     = document.getElementById('sd-save-status');
+    dom.loading        = document.getElementById('sd-loading');
+    dom.notOwner       = document.getElementById('sd-not-owner');
+    dom.error          = document.getElementById('sd-error');
+    dom.errorDetail    = document.getElementById('sd-error-detail');
+    dom.main           = document.getElementById('sd-main');
+
+    dom.libraryList    = document.getElementById('sd-library-list');
+    dom.libraryNew     = document.getElementById('sd-library-new');
+    dom.libraryDuplicate = document.getElementById('sd-library-duplicate');
+    dom.libraryDelete  = document.getElementById('sd-library-delete');
+    dom.librarySearch  = document.getElementById('sd-library-search');
+
+    dom.canvasCol      = document.getElementById('sd-canvas-col');
+    dom.canvasWrap     = document.getElementById('sd-canvas-wrap');
+    dom.canvasEl       = document.getElementById('sd-canvas');
+    dom.emptyState     = document.getElementById('sd-canvas-empty');
+    dom.toast          = document.getElementById('sd-toast');
+
+    dom.symbolSection  = document.getElementById('sd-props-symbol-section');
+    dom.propName       = document.getElementById('sd-prop-name');
+    dom.propRefDes     = document.getElementById('sd-prop-refdes');
+    dom.propDesc       = document.getElementById('sd-prop-desc');
+    dom.propPinCount   = document.getElementById('sd-prop-pin-count');
+    dom.propBom        = document.getElementById('sd-prop-bom');
+
+    dom.pinSection     = document.getElementById('sd-props-pin-section');
+    dom.pinNumber      = document.getElementById('sd-pin-number');
+    dom.pinName        = document.getElementById('sd-pin-name');
+    dom.pinTypeRadios  = document.querySelectorAll('input[name="sd-pin-type"]');
+    dom.pinSideRadios  = document.querySelectorAll('input[name="sd-pin-side"]');
+
+    dom.shapeSection   = document.getElementById('sd-props-shape-section');
+    dom.shapeRectX     = document.getElementById('sd-shape-rect-x');
+    dom.shapeRectY     = document.getElementById('sd-shape-rect-y');
+    dom.shapeRectW     = document.getElementById('sd-shape-rect-w');
+    dom.shapeRectH     = document.getElementById('sd-shape-rect-h');
+    dom.shapeLineX1    = document.getElementById('sd-shape-line-x1');
+    dom.shapeLineY1    = document.getElementById('sd-shape-line-y1');
+    dom.shapeLineX2    = document.getElementById('sd-shape-line-x2');
+    dom.shapeLineY2    = document.getElementById('sd-shape-line-y2');
+    dom.shapeDelete    = document.getElementById('sd-shape-delete');
+  }
+
+  function wireUi() {
+    // Toolbox
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.sd-tool-btn'),
+      function (btn) {
+        btn.addEventListener('click', function () {
+          setActiveTool(btn.dataset.tool);
+        });
+      }
+    );
+
+    // Library list
+    if (dom.libraryList) {
+      dom.libraryList.addEventListener('click', function (e) {
+        var li = e.target.closest('.sd-library-item');
+        if (!li) return;
+        var id = parseInt(li.dataset.symbolId, 10);
+        if (!isNaN(id)) activateSymbol(id);
+      });
+    }
+    if (dom.libraryNew) {
+      dom.libraryNew.addEventListener('click', function () {
+        createSymbol({
+          name: 'New symbol',
+          ref_des_prefix: 'U',
+          bom_item_id: STATE.initBomItemId,
+        }).catch(function () { /* setSaveStatus already showed error */ });
+      });
+    }
+    if (dom.libraryDuplicate) {
+      dom.libraryDuplicate.addEventListener('click', duplicateActive);
+    }
+    if (dom.libraryDelete) {
+      dom.libraryDelete.addEventListener('click', deleteActive);
+    }
+    if (dom.librarySearch) {
+      dom.librarySearch.addEventListener('input', function () {
+        STATE.librarySearch = dom.librarySearch.value;
+        renderLibraryList();
+      });
+    }
+
+    // Symbol-level fields — autosave on blur, debounced commit on input.
+    if (dom.propName) {
+      dom.propName.addEventListener('input', function () {
+        setActiveSymbolField('name', dom.propName.value || 'Untitled');
+        renderLibraryList();
+      });
+    }
+    if (dom.propRefDes) {
+      dom.propRefDes.addEventListener('input', function () {
+        setActiveSymbolField('ref_des_prefix', (dom.propRefDes.value || 'U').slice(0, 8));
+      });
+    }
+    if (dom.propDesc) {
+      dom.propDesc.addEventListener('input', function () {
+        setActiveSymbolField('description', dom.propDesc.value || null);
+      });
+    }
+    if (dom.propBom) {
+      dom.propBom.addEventListener('change', function () {
+        var v = dom.propBom.value;
+        setActiveSymbolField('bom_item_id', v ? parseInt(v, 10) : null);
+      });
+    }
+
+    // Pin fields
+    if (dom.pinNumber) {
+      dom.pinNumber.addEventListener('input', function () {
+        var pin = STATE.selectedPinId && findPin(STATE.selectedPinId);
+        if (!pin) return;
+        pin.number = dom.pinNumber.value || '';
+        renderCanvas();
+        scheduleAutosave();
+      });
+    }
+    if (dom.pinName) {
+      dom.pinName.addEventListener('input', function () {
+        var pin = STATE.selectedPinId && findPin(STATE.selectedPinId);
+        if (!pin) return;
+        pin.name = dom.pinName.value || '';
+        renderCanvas();
+        scheduleAutosave();
+      });
+    }
+    Array.prototype.forEach.call(dom.pinTypeRadios, function (r) {
+      r.addEventListener('change', function () {
+        var pin = STATE.selectedPinId && findPin(STATE.selectedPinId);
+        if (!pin || !r.checked) return;
+        pin.type = r.value;
+        scheduleAutosave();
+      });
+    });
+    Array.prototype.forEach.call(dom.pinSideRadios, function (r) {
+      r.addEventListener('change', function () {
+        var pin = STATE.selectedPinId && findPin(STATE.selectedPinId);
+        if (!pin || !r.checked) return;
+        pin.side = r.value;
+        // Re-snap the pin to its new side's rail axis.
+        var snapped = snapPinToSide(pin.x, pin.y, r.value);
+        pin.x = snapped.x; pin.y = snapped.y;
+        renderCanvas();
+        scheduleAutosave();
+      });
+    });
+
+    // Shape fields — only edit by typing in the inputs.
+    function wireShapeNumeric(el, prop) {
+      if (!el) return;
+      el.addEventListener('change', function () {
+        var shape = STATE.selectedShapeId && findShape(STATE.selectedShapeId);
+        if (!shape) return;
+        var n = snap(parseInt(el.value, 10) || 0);
+        shape[prop] = n;
+        el.value = n;
+        renderCanvas();
+        scheduleAutosave();
+      });
+    }
+    wireShapeNumeric(dom.shapeRectX, 'x');
+    wireShapeNumeric(dom.shapeRectY, 'y');
+    wireShapeNumeric(dom.shapeRectW, 'w');
+    wireShapeNumeric(dom.shapeRectH, 'h');
+    wireShapeNumeric(dom.shapeLineX1, 'x1');
+    wireShapeNumeric(dom.shapeLineY1, 'y1');
+    wireShapeNumeric(dom.shapeLineX2, 'x2');
+    wireShapeNumeric(dom.shapeLineY2, 'y2');
+
+    if (dom.shapeDelete) {
+      dom.shapeDelete.addEventListener('click', deleteSelected);
+    }
+  }
+
+  // ====================================================================
+  // 19. BOOTSTRAP
+  // ====================================================================
+
+  async function fetchMe() {
+    try {
+      var r = await apiFetch(API + '/api/auth/me');
+      if (!r.ok) return null;
+      return await r.json();
+    } catch (_) { return null; }
+  }
+  async function fetchProject() {
+    var r = await apiFetch(API + '/api/projects/' + STATE.projectId);
+    if (!r.ok) {
+      var err = new Error('Project HTTP ' + r.status);
+      err.status = r.status;
+      throw err;
+    }
+    return r.json();
+  }
+  async function fetchSymbols() {
+    var r = await apiFetch(API + '/api/projects/' + STATE.projectId + '/symbols');
+    if (!r.ok) throw new Error('Symbols HTTP ' + r.status);
+    return r.json();
+  }
+  async function fetchBom() {
+    try {
+      var r = await apiFetch(API + '/api/projects/' + STATE.projectId + '/bom');
+      if (!r.ok) return [];
+      var rows = await r.json();
+      return Array.isArray(rows) ? rows : [];
+    } catch (_) { return []; }
+  }
+
+  async function init() {
+    cacheDom();
+    var params = new URLSearchParams(window.location.search);
+    // Accept both ``project_id`` (the spec's name) and ``id`` (the
+    // shorter form the schematic editor uses) so the C1 / E2 deep
+    // links can hit this page either way.
+    STATE.projectId = params.get('project_id') || params.get('id');
+    STATE.initNew = params.get('new') === 'true';
+    STATE.initBomItemId = params.get('bom_item_id') ? parseInt(params.get('bom_item_id'), 10) : null;
+    STATE.initSymbolId = params.get('symbol_id') ? parseInt(params.get('symbol_id'), 10) : null;
+
+    if (!STATE.projectId) {
+      if (dom.errorDetail) dom.errorDetail.textContent = 'Missing ?project_id=… in the URL.';
+      showOnly(dom.error);
+      return;
+    }
+    if (dom.backLink) {
+      dom.backLink.href = '/projects/instructions/edit.html?id=' +
+        encodeURIComponent(STATE.projectId);
+    }
+    if (dom.openSchematic) {
+      dom.openSchematic.href = '/projects/schematic/edit.html?id=' +
+        encodeURIComponent(STATE.projectId);
+    }
+
+    try {
+      var me = await fetchMe();
+      STATE.me = me;
+      var project = await fetchProject();
+      STATE.project = project;
+      STATE.isOwner = !!(me && project && project.author_username === me.username);
+
+      if (dom.projectTitle) {
+        dom.projectTitle.textContent =
+          'Symbol designer · ' + (project.title || 'Untitled');
+      }
+
+      if (!STATE.isOwner) {
+        showOnly(dom.notOwner);
+        return;
+      }
+
+      var results = await Promise.all([fetchSymbols(), fetchBom()]);
+      STATE.symbols = Array.isArray(results[0]) ? results[0] : [];
+      STATE.bomItems = Array.isArray(results[1]) ? results[1] : [];
+
+      wireUi();
+      initCanvas();
+      renderLibraryList();
+      renderBomDropdown();
+      setSaveStatus('saved');
+
+      // Initial selection:
+      //   - ``?new=true`` (optionally with ``?bom_item_id=…``) → create
+      //     a fresh symbol pre-linked to that BOM row.
+      //   - ``?symbol_id=…`` → open that symbol.
+      //   - Otherwise → open the first symbol in the list, if any.
+      if (STATE.initNew) {
+        await createSymbol({
+          name: 'New symbol',
+          ref_des_prefix: 'U',
+          bom_item_id: STATE.initBomItemId,
+        });
+      } else if (STATE.initSymbolId) {
+        activateSymbol(STATE.initSymbolId);
+      } else if (STATE.symbols.length > 0) {
+        activateSymbol(STATE.symbols[0].id);
+      } else {
+        renderCanvas();
+        renderPropertiesPanel();
+      }
+
+      showOnly(dom.main);
+      setTimeout(syncCanvasDisplaySize, 50);
+    } catch (e) {
+      if (e && e.status === 404 && dom.errorDetail) {
+        dom.errorDetail.textContent = 'Project not found.';
+      }
+      showOnly(dom.error);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/web/projects/symbol/edit.html
+++ b/web/projects/symbol/edit.html
@@ -1,0 +1,285 @@
+---
+title: Symbol Designer
+layout: default
+description: Design schematic symbols for your project
+permalink: /projects/symbol/edit.html
+hide_nibsy: true
+---
+
+{% include nav_projects.html %}
+
+<link rel="stylesheet" href="/assets/css/symbol-designer.css?v={{ site.time | date: '%s' }}">
+
+<!-- Tag the body so site-level CSS rules (footer hide, container reset)
+     scope to this workspace only — same trick as the schematic editor. -->
+<script>document.body.classList.add('symbol-designer-page');</script>
+
+<div class="sd-workspace" id="sd-workspace">
+
+  <!-- ===========================================================
+       Title bar — Back / centred title + save status
+       =========================================================== -->
+  <div class="sd-titlebar" id="sd-titlebar">
+    <div class="sd-titlebar-left">
+      <a id="sd-back-link" href="/projects/instructions/edit.html" class="sd-titlebar-link">
+        <i class="fas fa-arrow-left me-1"></i> Back to project editor
+      </a>
+    </div>
+    <div class="sd-titlebar-center">
+      <span class="sd-project-title" id="sd-project-title">Loading&hellip;</span>
+      <span class="sd-save-status" id="sd-save-status" aria-live="polite"></span>
+    </div>
+    <div class="sd-titlebar-right">
+      <a id="sd-open-schematic" class="sd-titlebar-btn" href="#"
+         title="Open the schematic editor for this project">
+        <i class="fas fa-diagram-project me-1"></i> Open schematic
+      </a>
+    </div>
+  </div>
+
+  <!-- ===========================================================
+       Loading / not-owner / error states
+       =========================================================== -->
+  <div class="sd-loading" id="sd-loading">
+    <i class="fas fa-spinner fa-spin me-2"></i> Loading symbol designer&hellip;
+  </div>
+
+  <div class="sd-not-owner d-none" id="sd-not-owner">
+    <div class="sd-icon"><i class="fas fa-lock"></i></div>
+    <h4><i class="fas fa-lock me-3"></i> You don't own this project</h4>
+    <p class="text-muted">Only the project author can design symbols.</p>
+    <a href="/projects/" class="btn btn-outline-primary mt-2">
+      <i class="fas fa-arrow-left me-1"></i> Back to projects
+    </a>
+  </div>
+
+  <div class="sd-error d-none" id="sd-error">
+    <div class="sd-icon text-danger"><i class="fas fa-exclamation-triangle"></i></div>
+    <h4><i class="fas fa-exclamation-triangle me-3 text-danger"></i> Couldn't load this project</h4>
+    <p class="text-muted" id="sd-error-detail">The project may not exist, or you may need to log in.</p>
+    <a href="/projects/" class="btn btn-outline-primary mt-2">
+      <i class="fas fa-arrow-left me-1"></i> Back to projects
+    </a>
+  </div>
+
+  <!-- ===========================================================
+       Main editor shell — hidden until loader resolves
+       =========================================================== -->
+  <div class="sd-main d-none" id="sd-main">
+
+    <!-- Library list (left, 240px) -->
+    <aside class="sd-library" id="sd-library" aria-label="Symbol library">
+      <header class="sd-library-header">
+        <h6 class="sd-library-title">
+          <i class="fas fa-shapes me-2"></i> Library
+        </h6>
+        <button type="button" class="sd-library-new-btn" id="sd-library-new"
+                title="Create a new symbol">
+          <i class="fas fa-plus me-1"></i> New
+        </button>
+      </header>
+      <div class="sd-library-search">
+        <input type="search" class="form-control form-control-sm" id="sd-library-search"
+               placeholder="Search&hellip;" aria-label="Search symbols">
+      </div>
+      <ul class="sd-library-list" id="sd-library-list" role="listbox"
+          aria-label="Project symbols">
+        <!-- Populated by JS. -->
+      </ul>
+      <footer class="sd-library-footer">
+        <button type="button" class="sd-library-action-btn" id="sd-library-duplicate"
+                disabled title="Duplicate the selected symbol">
+          <i class="fas fa-clone me-1"></i> Duplicate
+        </button>
+        <button type="button" class="sd-library-action-btn sd-library-action-danger"
+                id="sd-library-delete" disabled title="Delete the selected symbol">
+          <i class="fas fa-trash me-1"></i> Delete
+        </button>
+      </footer>
+    </aside>
+
+    <!-- Canvas column -->
+    <main class="sd-canvas-col" id="sd-canvas-col" aria-label="Symbol canvas">
+
+      <!-- Toolbox (above canvas) -->
+      <div class="sd-toolbox" id="sd-toolbox" role="toolbar"
+           aria-label="Drawing tools">
+        <button type="button" class="sd-tool-btn is-active" data-tool="select"
+                title="Select / move">
+          <i class="fas fa-mouse-pointer"></i><span>Select</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="pin"
+                title="Place a pin on a side rail">
+          <i class="fas fa-circle-dot"></i><span>Pin</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="net"
+                title="Net (coming soon)">
+          <i class="fas fa-bolt"></i><span>Net</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="name"
+                title="Name (coming soon)">
+          <i class="fas fa-i-cursor"></i><span>Name</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="label"
+                title="Label (coming soon)">
+          <i class="fas fa-tag"></i><span>Label</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="line"
+                title="Draw a body line (click two endpoints)">
+          <i class="fas fa-slash"></i><span>Line</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="rect"
+                title="Draw a body rectangle (click and drag)">
+          <i class="far fa-square"></i><span>Rect</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="circle"
+                title="Circle (coming soon)">
+          <i class="far fa-circle"></i><span>Circle</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="text"
+                title="Text (coming soon)">
+          <i class="fas fa-font"></i><span>Text</span>
+        </button>
+        <span class="sd-toolbox-sep" aria-hidden="true"></span>
+        <button type="button" class="sd-tool-btn" data-tool="rotate-ccw"
+                title="Rotate -90&deg;">
+          <i class="fas fa-rotate-left"></i><span>-90&deg;</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="rotate-cw"
+                title="Rotate +90&deg;">
+          <i class="fas fa-rotate-right"></i><span>+90&deg;</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="flip-h"
+                title="Flip horizontally">
+          <i class="fas fa-arrows-left-right"></i><span>Flip H</span>
+        </button>
+        <button type="button" class="sd-tool-btn" data-tool="flip-v"
+                title="Flip vertically">
+          <i class="fas fa-arrows-up-down"></i><span>Flip V</span>
+        </button>
+      </div>
+
+      <!-- Canvas wrapper -->
+      <div class="sd-canvas-wrap" id="sd-canvas-wrap">
+        <canvas id="sd-canvas"></canvas>
+        <div class="sd-canvas-empty" id="sd-canvas-empty">
+          <i class="fas fa-shapes fa-3x mb-3"></i>
+          <p>No symbol selected.</p>
+          <p class="text-muted small">Pick one from the library, or click
+            <strong>+ New</strong> to start a fresh symbol.</p>
+        </div>
+        <div class="sd-toast" id="sd-toast" role="status" aria-live="polite"></div>
+      </div>
+    </main>
+
+    <!-- Properties panel (right, 260px) -->
+    <aside class="sd-props" id="sd-props" aria-label="Properties panel">
+      <section class="sd-props-section" id="sd-props-symbol-section">
+        <h6 class="sd-props-section-title">Symbol</h6>
+        <div class="sd-props-field">
+          <label for="sd-prop-name">Name</label>
+          <input type="text" id="sd-prop-name" class="form-control form-control-sm"
+                 maxlength="200" placeholder="MyChip">
+        </div>
+        <div class="sd-props-field">
+          <label for="sd-prop-refdes">RefDes prefix</label>
+          <input type="text" id="sd-prop-refdes" class="form-control form-control-sm"
+                 maxlength="8" placeholder="U">
+        </div>
+        <div class="sd-props-field">
+          <label for="sd-prop-desc">Description</label>
+          <textarea id="sd-prop-desc" class="form-control form-control-sm"
+                    rows="2" placeholder="What is this symbol?"></textarea>
+        </div>
+        <div class="sd-props-field">
+          <label>Pin count</label>
+          <div class="sd-props-readonly" id="sd-prop-pin-count">0</div>
+        </div>
+        <div class="sd-props-field">
+          <label for="sd-prop-bom">Linked BOM part</label>
+          <select id="sd-prop-bom" class="form-select form-select-sm">
+            <option value="">(none)</option>
+          </select>
+          <small class="sd-props-hint">When set, this symbol appears as a
+            <code>&#x2317;</code> chip in that BOM row's asset drawer.</small>
+        </div>
+      </section>
+
+      <section class="sd-props-section d-none" id="sd-props-pin-section">
+        <h6 class="sd-props-section-title">Selected pin</h6>
+        <div class="sd-props-field">
+          <label for="sd-pin-number">Pin number</label>
+          <input type="text" id="sd-pin-number" class="form-control form-control-sm"
+                 maxlength="8">
+        </div>
+        <div class="sd-props-field">
+          <label for="sd-pin-name">Pin name</label>
+          <input type="text" id="sd-pin-name" class="form-control form-control-sm"
+                 maxlength="32">
+        </div>
+        <div class="sd-props-field">
+          <label>Type</label>
+          <div class="sd-props-radio-grid" id="sd-pin-type">
+            <label><input type="radio" name="sd-pin-type" value="IN"><span>IN</span></label>
+            <label><input type="radio" name="sd-pin-type" value="OUT"><span>OUT</span></label>
+            <label><input type="radio" name="sd-pin-type" value="I/O"><span>I/O</span></label>
+            <label><input type="radio" name="sd-pin-type" value="PWR"><span>PWR</span></label>
+            <label><input type="radio" name="sd-pin-type" value="GND"><span>GND</span></label>
+            <label><input type="radio" name="sd-pin-type" value="NC"><span>NC</span></label>
+          </div>
+        </div>
+        <div class="sd-props-field">
+          <label>Side</label>
+          <div class="sd-props-radio-grid sd-props-radio-grid-4" id="sd-pin-side">
+            <label><input type="radio" name="sd-pin-side" value="left"><span>Left</span></label>
+            <label><input type="radio" name="sd-pin-side" value="right"><span>Right</span></label>
+            <label><input type="radio" name="sd-pin-side" value="top"><span>Top</span></label>
+            <label><input type="radio" name="sd-pin-side" value="bottom"><span>Bottom</span></label>
+          </div>
+        </div>
+      </section>
+
+      <section class="sd-props-section d-none" id="sd-props-shape-section">
+        <h6 class="sd-props-section-title">Selected shape</h6>
+        <div class="sd-props-field" data-shape-kind="rect">
+          <label>Rectangle</label>
+          <div class="sd-props-grid-2">
+            <label class="sd-props-inline">x <input type="number" id="sd-shape-rect-x"
+                   class="form-control form-control-sm" step="16"></label>
+            <label class="sd-props-inline">y <input type="number" id="sd-shape-rect-y"
+                   class="form-control form-control-sm" step="16"></label>
+            <label class="sd-props-inline">w <input type="number" id="sd-shape-rect-w"
+                   class="form-control form-control-sm" step="16"></label>
+            <label class="sd-props-inline">h <input type="number" id="sd-shape-rect-h"
+                   class="form-control form-control-sm" step="16"></label>
+          </div>
+        </div>
+        <div class="sd-props-field" data-shape-kind="line">
+          <label>Line</label>
+          <div class="sd-props-grid-2">
+            <label class="sd-props-inline">x1 <input type="number" id="sd-shape-line-x1"
+                   class="form-control form-control-sm" step="16"></label>
+            <label class="sd-props-inline">y1 <input type="number" id="sd-shape-line-y1"
+                   class="form-control form-control-sm" step="16"></label>
+            <label class="sd-props-inline">x2 <input type="number" id="sd-shape-line-x2"
+                   class="form-control form-control-sm" step="16"></label>
+            <label class="sd-props-inline">y2 <input type="number" id="sd-shape-line-y2"
+                   class="form-control form-control-sm" step="16"></label>
+          </div>
+        </div>
+        <button type="button" class="sd-props-delete-btn" id="sd-shape-delete">
+          <i class="fas fa-trash me-1"></i> Delete shape
+        </button>
+      </section>
+    </aside>
+  </div>
+</div>
+
+<!--
+  Fabric.js v6 (UMD build). Pinned to 6.4.0 to match the schematic editor
+  and instruction builder so the three pages share the same engine.
+-->
+<script src="https://cdn.jsdelivr.net/npm/fabric@6.4.0/dist/index.min.js"></script>
+<script src="/assets/js/project-auth.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/terms-gate.js?v={{ site.time | date: '%s' }}"></script>
+<script src="/assets/js/symbol-designer.js?v={{ site.time | date: '%s' }}"></script>


### PR DESCRIPTION
## Summary

- Adds the Symbol Designer page (`/projects/symbol/edit.html?project_id=…`) with three-panel layout (library / canvas / properties), 16px dot-grid Fabric canvas, origin cross at (0,0), and Pin / Rect / Line tools (Net / Label / Circle / Text / Name stubbed in v1).
- Backend: new `project_symbols` table + full CRUD at `/api/projects/{id}/symbols` with idempotent duplicate. Brand-new table — no migration helper needed.
- **E2 integration:** schematic editor merges per-project custom symbols into its hard-coded library at runtime; `+ open Symbol Designer` button enabled and deep-links to the new page.
- **C1 integration:** BOM row `⋮` menu becomes a Bootstrap dropdown with `✎ design symbol…` (deep-links with `bom_item_id` pre-set). Custom symbols linked to a BOM row appear as `⌗` chips in that row's asset drawer; dragging one onto the instruction-builder canvas rasterises the symbol to a PNG via an off-screen canvas.
- 13 new tests; full suite 477/477.

## Test plan

- [ ] Open `/projects/symbol/edit.html?project_id=<owned>` → designer loads. Click **+ New** → blank symbol; canvas shows origin cross + side rails.
- [ ] Pin tool → click near each edge → 4 pins, auto-numbered, `I/O` default.
- [ ] Rect + Line tools build body; everything snaps to 16px grid.
- [ ] Pin selection populates properties pane (number / name / type / side). Edits autosave (~500ms).
- [ ] Symbol fields (name / refDes / description / Linked BOM part) autosave; round-trip on reload.
- [ ] Open the schematic editor on the same project → Place-symbol list shows the custom symbol with a red **Custom** badge. Click → place on canvas → autosaves.
- [ ] `+ open Symbol Designer` (formerly disabled) opens designer pre-filled with `?new=true`.
- [ ] Instruction builder → BOM pane → the row linked to the custom symbol shows a `⌗` chip in its drawer. Drag onto canvas → rasterised symbol image appears.
- [ ] BOM row `⋮` → `✎ design symbol…` → designer opens with `?new=true&bom_item_id=…`.
- [ ] `pytest stacks/projects-api/tests/ -q` → 477 passing.

## Trimming + ambiguity calls

- **Net / Name / Label / Circle / Text** designer tools are stubbed in v1 (button present, "coming soon" toast). Pin / Rect / Line + side rails + Linked-BOM dropdown are enough for a usable symbol. `IMPLEMENTED_TOOLS` allowlist gates re-enabling.
- Rotate ±90° / Flip H/V act on the whole symbol when nothing is selected; per-selection transform is a TODO comment.
- BOM table confirmed `project_bom_items`; FK retargeted.
- Non-existent `bom_item_id` → **422** (spec preferred this over 400).
- `?project_id=` and `?id=` URL params both work for deep links.
- Symbol→Editor coordinate conversion handled by `symbolDefFromCustom()` (pin x/y centred-on-origin → editor's `bodyWidth/Height` + `(side, offset)` model with 8px pad).

Out of scope: footprints, net auto-routing in editor, multi-symbol ops, symbol versioning, multi-author collab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)