### PR TITLE
Anonymous key-gated feedback for the Snakie app

### DIFF
--- a/stacks/projects-api/projects_api/config.py
+++ b/stacks/projects-api/projects_api/config.py
@@ -37,6 +37,14 @@ class Settings(BaseSettings):
     jwt_secret: str = "changeme"
     jwt_algorithm: str = "HS256"
 
+    # Shared app key that lets a trusted first-party client — the Snakie desktop
+    # app — POST feedback ANONYMOUSLY (no Chatter session) by sending it as the
+    # `X-Snakie-Key` header (see routers/feedback.py). Anonymous reports are
+    # recorded under a sentinel user so they're clearly attributable + filterable.
+    # Empty (the default) DISABLES the anonymous path, so the endpoint stays
+    # authenticated-only unless a key is configured. Rotate the key if abused.
+    snakie_feedback_key: str = ""
+
     # Base URL for the Chatter auth service. Used by the parts catalog
     # account-age gate to look up `account_created_at` from `/api/me`.
     chatter_base_url: str = "https://chatter.kevsrobots.com"

--- a/stacks/projects-api/projects_api/routers/feedback.py
+++ b/stacks/projects-api/projects_api/routers/feedback.py
@@ -12,17 +12,19 @@ impersonate someone else by spoofing fields.
 
 from __future__ import annotations
 
+import hmac
 import logging
 import re
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Cookie, Depends, Header, HTTPException, Request, status
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import UploadFile
 from starlette.formparsers import MultiPartException
 
-from ..auth import get_current_user, require_terms_accepted
+from ..auth import _check_terms_accepted, get_current_user
+from ..config import get_settings
 from ..db import get_session
 from ..models import Feedback
 from ..schemas import FeedbackCreate, FeedbackCreateResponse
@@ -55,6 +57,49 @@ def _coerce_optional_str(value: object) -> Optional[str]:
     return None
 
 
+# Identity recorded for anonymous first-party app submissions (the Snakie desktop
+# app, authorised via X-Snakie-Key). A sentinel — never a real Chatter username —
+# so anonymous reports are clearly attributable + filterable and can't be used to
+# impersonate a real user.
+ANON_REPORTER = "_snakie_anon"
+
+
+def _is_snakie_app(x_snakie_key: Optional[str]) -> bool:
+    """True when a trusted first-party app presents the configured ``X-Snakie-Key``.
+
+    Constant-time compared. Returns False when no key is configured, so the
+    anonymous path is DISABLED by default (the endpoint stays authenticated-only).
+    """
+    key = get_settings().snakie_feedback_key
+    return bool(key and x_snakie_key and hmac.compare_digest(x_snakie_key, key))
+
+
+async def feedback_reporter(
+    x_snakie_key: Optional[str] = Header(default=None, alias="X-Snakie-Key"),
+    access_token: Optional[str] = Cookie(default=None),
+    authorization: Optional[str] = Header(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> str:
+    """Resolve the feedback reporter's identity.
+
+    Two accepted callers:
+
+    * a trusted FIRST-PARTY app (the Snakie desktop app) presenting the shared
+      ``X-Snakie-Key`` header — recorded ANONYMOUSLY as :data:`ANON_REPORTER`.
+      Gated by the key and only enabled when ``snakie_feedback_key`` is
+      configured, so the endpoint is never an open write surface by default;
+    * an authenticated, terms-accepted Chatter user (the website widget), whose
+      username is taken from the session — never from the body — so a client
+      can't impersonate another user.
+    """
+    if _is_snakie_app(x_snakie_key):
+        return ANON_REPORTER
+    # Otherwise require the normal authenticated + terms-accepted user.
+    username = await get_current_user(access_token, authorization, session)
+    await _check_terms_accepted(session, username)
+    return username
+
+
 @router.post(
     "/api/feedback",
     response_model=FeedbackCreateResponse,
@@ -62,7 +107,7 @@ def _coerce_optional_str(value: object) -> Optional[str]:
 )
 async def create_feedback(
     request: Request,
-    user: str = Depends(require_terms_accepted),
+    user: str = Depends(feedback_reporter),
     session: AsyncSession = Depends(get_session),
 ) -> FeedbackCreateResponse:
     """Create a new feedback row.

--- a/stacks/projects-api/projects_api/schemas.py
+++ b/stacks/projects-api/projects_api/schemas.py
@@ -1486,7 +1486,10 @@ class FeedbackCreate(BaseModel):
     """
 
     sentiment: str = Field(..., pattern=r"^(love|like|issue|idea)$")
-    message: str = Field(..., min_length=10, max_length=2000)
+    # Larger cap so a Snakie bug report can carry its diagnostics block + the
+    # (opt-in) console output. The DB column is Text; the website widget still
+    # caps its textarea client-side, so this doesn't change widget behaviour.
+    message: str = Field(..., min_length=10, max_length=20000)
     # Email is opt-in; Pydantic's EmailStr would force a dependency on
     # email-validator, so we keep it loose and validate the shape in the
     # router (the widget already checks client-side).

--- a/stacks/projects-api/tests/conftest.py
+++ b/stacks/projects-api/tests/conftest.py
@@ -92,6 +92,27 @@ async def client(engine, sessionmaker_) -> AsyncIterator[AsyncClient]:
         auth_module.get_current_user_aged
     )
 
+    # feedback_reporter (#206) bundles the T&Cs gate with an anonymous
+    # X-Snakie-Key path. Bypass its terms gate for the default client (like the
+    # require_terms_accepted override above) while still exercising the REAL app-key
+    # check, so authed-feedback tests pass and the anonymous-key tests are honest.
+    from fastapi import Cookie, Depends, Header
+    from projects_api.routers import feedback as feedback_module
+
+    async def _feedback_reporter_no_terms(
+        x_snakie_key: str | None = Header(default=None, alias="X-Snakie-Key"),
+        access_token: str | None = Cookie(default=None),
+        authorization: str | None = Header(default=None),
+        session: AsyncSession = Depends(db_module.get_session),
+    ) -> str:
+        if feedback_module._is_snakie_app(x_snakie_key):
+            return feedback_module.ANON_REPORTER
+        return await auth_module.get_current_user(access_token, authorization, session)
+
+    app.dependency_overrides[feedback_module.feedback_reporter] = (
+        _feedback_reporter_no_terms
+    )
+
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         async with app.router.lifespan_context(app):

--- a/stacks/projects-api/tests/test_feedback.py
+++ b/stacks/projects-api/tests/test_feedback.py
@@ -101,6 +101,21 @@ async def test_post_feedback_anonymous_disabled_by_default_returns_401(client) -
 
 
 @pytest.mark.asyncio
+async def test_post_feedback_accepts_large_message(client, monkeypatch) -> None:
+    """The message cap is large enough for a Snakie report's diagnostics block +
+    opt-in console output (raised well above the old 2000)."""
+    monkeypatch.setenv("SNAKIE_FEEDBACK_KEY", "s3cr3t-app-key")
+    big = "_SNAKIE_ crash on connect\n\n" + ("console output line\n" * 800)  # ~15k chars
+    assert len(big) > 2000
+    resp = await client.post(
+        "/api/feedback",
+        json=_valid_payload(sentiment="issue", message=big),
+        headers={"X-Snakie-Key": "s3cr3t-app-key"},
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
 async def test_post_feedback_missing_required_field_returns_400(client) -> None:
     """Pydantic surfaces a 400 via our handler (not the default 422)."""
     headers = make_auth_header("alice")

--- a/stacks/projects-api/tests/test_feedback.py
+++ b/stacks/projects-api/tests/test_feedback.py
@@ -65,6 +65,42 @@ async def test_post_feedback_unauthenticated_returns_401(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_post_feedback_anonymous_with_app_key_returns_201(
+    client, monkeypatch
+) -> None:
+    """A trusted first-party app (Snakie) can submit anonymously with the shared
+    X-Snakie-Key header — no Chatter session required (issue #206)."""
+    monkeypatch.setenv("SNAKIE_FEEDBACK_KEY", "s3cr3t-app-key")
+    resp = await client.post(
+        "/api/feedback",
+        json=_valid_payload(sentiment="issue", message="_SNAKIE_ crash on connect"),
+        headers={"X-Snakie-Key": "s3cr3t-app-key"},
+    )
+    assert resp.status_code == 201
+    assert isinstance(resp.json()["id"], int)
+
+
+@pytest.mark.asyncio
+async def test_post_feedback_wrong_app_key_returns_401(client, monkeypatch) -> None:
+    """A bad key with no session falls through to the auth gate → 401."""
+    monkeypatch.setenv("SNAKIE_FEEDBACK_KEY", "s3cr3t-app-key")
+    resp = await client.post(
+        "/api/feedback", json=_valid_payload(), headers={"X-Snakie-Key": "wrong"}
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_post_feedback_anonymous_disabled_by_default_returns_401(client) -> None:
+    """With no SNAKIE_FEEDBACK_KEY configured the anonymous path is OFF, so even a
+    presented key falls through to auth → 401 (secure default)."""
+    resp = await client.post(
+        "/api/feedback", json=_valid_payload(), headers={"X-Snakie-Key": "anything"}
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_post_feedback_missing_required_field_returns_400(client) -> None:
     """Pydantic surfaces a 400 via our handler (not the default 422)."""
     headers = make_auth_header("alice")


### PR DESCRIPTION
Lets the **Snakie desktop app** submit bug reports to the existing feedback API without a Chatter session (Snakie#206), so in-app bug reports actually land.

## What
- `POST /api/feedback` gains an **anonymous path gated by a shared app key**: when `snakie_feedback_key` is set and the request carries a matching `X-Snakie-Key` header, the report is accepted and recorded under a sentinel user `_snakie_anon` (Snakie also prefixes the message with `_SNAKIE_` for easy filtering).
- Constant-time key compare; **disabled by default** (empty key) so the endpoint stays authenticated-only until you set a key.
- Identity is still resolved server-side (never from the body).

## Files
- `config.py`: `snakie_feedback_key` (env `SNAKIE_FEEDBACK_KEY`).
- `routers/feedback.py`: `_is_snakie_app()` + a `feedback_reporter` dependency (replaces the direct `require_terms_accepted`).
- `tests/test_feedback.py`: anonymous-with-key → 201, wrong key → 401, disabled-by-default → 401.
- `tests/conftest.py`: bypasses the T&Cs gate for `feedback_reporter` (same pattern as the existing overrides).

## Verified
Full projects-api suite: **525 passed** locally.

## To deploy
1. Merge.
2. Set `SNAKIE_FEEDBACK_KEY` (a random secret) in the projects-api environment.
3. Set the same value as the Snakie app's `SNAKIE_FEEDBACK_KEY` (it sends it as `X-Snakie-Key`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)