### PR TITLE
Add part pages referenced by Snakie's parts library help links

### DIFF
--- a/web/learn/parts/bme280/index.md
+++ b/web/learn/parts/bme280/index.md
@@ -1,0 +1,113 @@
+---
+title: BME280 Environmental Sensor
+description: >-
+  The Bosch BME280 measures temperature, barometric pressure and humidity in
+  one tiny I²C chip. Here's how to wire a BME280 breakout to a Raspberry Pi
+  Pico and read it with MicroPython.
+layout: content
+---
+
+{% include breadcrumbs.html %}
+
+# BME280 Environmental Sensor
+
+The `BME280` is a Bosch sensor that measures **temperature**, **barometric
+pressure** and **relative humidity** in one tiny chip — a complete weather
+station on a breakout board. It talks **I²C** at address **0x76** (or **0x77**,
+selected with the ADDR pin/trace depending on your breakout), so it wires
+straight to a Raspberry Pi Pico, ESP32, micro:bit or Raspberry Pi with just
+four wires.
+
+Breakouts such as Pimoroni's run from **2–6 V** and also offer a Qw/ST
+(Qwiic / STEMMA QT) connector, so you can plug it in with a single cable — no
+soldering.
+
+> Buying tip: the **BMP280** looks almost identical and is often sold in the
+> same listings, but it has **no humidity sensor**. If you want all three
+> readings, check it really is a BME280.
+
+---
+
+## What it measures
+
+| Reading | Unit |
+|---------|------|
+| Temperature | °C |
+| Barometric pressure | hPa (1 hPa = 1 mbar; sea level is ~1013 hPa) |
+| Relative humidity | %RH |
+
+Pressure is the interesting one — because pressure falls as you go up, the
+BME280 is also commonly used as an **altimeter**, and pressure trends are the
+basis of simple weather forecasting.
+
+---
+
+## Wiring
+
+Pin order below is Pimoroni's Breakout Garden header — check the silkscreen on
+your breakout, as other makers order the pins differently:
+
+| Breakout pin | Connect to |
+|--------------|------------|
+| **2-6V** | 3V3 |
+| **SDA** | an I²C SDA pin — Pico I2C0: **GP0** |
+| **SCL** | an I²C SCL pin — Pico I2C0: **GP1** |
+| **INT** | leave unconnected |
+| **GND** | GND |
+
+---
+
+## MicroPython example
+
+First check the sensor is answering on the bus:
+
+```python
+from machine import I2C, Pin
+
+i2c = I2C(0, sda=Pin(0), scl=Pin(1))
+print(i2c.scan())     # expect [118] (0x76) or [119] (0x77)
+```
+
+Then, with the widely-used community `bme280` driver
+([micropython-bme280](https://github.com/robert-hh/BME280)) copied to your
+board:
+
+```python
+from machine import I2C, Pin
+import bme280
+import time
+
+i2c = I2C(0, sda=Pin(0), scl=Pin(1))
+bme = bme280.BME280(i2c=i2c)
+
+while True:
+    temperature, pressure, humidity = bme.values
+    print(temperature, pressure, humidity)
+    time.sleep(1)
+```
+
+If the driver can't find the sensor, it's usually one of: SDA/SCL swapped, the
+sensor on the other address (try `0x77`), or a missing ground connection — run
+`i2c.scan()` again and see what comes back.
+
+The readings are per-unit accurate out of the box: every BME280 is factory
+calibrated, and the driver reads each chip's own calibration constants and
+applies the compensation maths from the Bosch datasheet for you.
+
+---
+
+## Use it in Snakie
+
+The BME280 is in the Standard parts library of
+[Snakie](https://www.snakie.org), my free, open-source MicroPython editor.
+Drag it onto the Board View and Snakie shows you the wiring and copies its
+bundled `bme280` driver to the board — `read()` hands you `(temperature °C,
+pressure hPa, humidity %RH)` as plain floats, ready for the live instruments.
+
+---
+
+## Related learning
+
+- [BME280 Deep Dive — I2C and SPI Explained course](/learn/i2c_spi/06_bme280-deep-dive.html)
+- [I2C and SPI Explained](/learn/i2c_spi/) — the full course
+- [I2C — GPIO Mastery course](/learn/micropython_gpio/12_i2c.html)

--- a/web/learn/parts/icm20948/index.md
+++ b/web/learn/parts/icm20948/index.md
@@ -1,0 +1,123 @@
+---
+title: ICM20948 9-DoF Motion Sensor
+description: >-
+  The TDK InvenSense ICM-20948 packs a 3-axis accelerometer, gyroscope and
+  magnetometer into one I²C chip — nine degrees of freedom. Here's how to wire
+  a breakout to a Raspberry Pi Pico and read it with MicroPython.
+layout: content
+---
+
+{% include breadcrumbs.html %}
+
+# ICM20948 9-DoF Motion Sensor
+
+The `ICM-20948` is a TDK InvenSense motion sensor that packs a **3-axis
+accelerometer**, a **3-axis gyroscope** and a **3-axis magnetometer** (an
+on-board AK09916) into one tiny I²C package — **nine degrees of freedom** in
+total. That's everything you need for tilt sensing, orientation tracking,
+balancing robots and a compass heading.
+
+Breakouts such as Pimoroni's run at **3.3 V or 5 V**, so it's happy on a
+Raspberry Pi Pico, an ESP32 or a Raspberry Pi.
+
+---
+
+## Key specs
+
+| Spec | Value |
+|------|-------|
+| Accelerometer | ±2 / 4 / 8 / 16 g |
+| Gyroscope | ±250 / 500 / 1000 / 2000 °/s |
+| Magnetometer | ±4900 µT (AK09916) |
+| Interface | I²C, address **0x68** (or **0x69** via the address jumper/trace) |
+| Power | 3.3 V or 5 V (breakout-dependent) |
+
+The magnetometer sits on the ICM-20948's internal auxiliary I²C bus — a good
+driver configures the chip's aux-bus master to stream it for you, so there's
+nothing extra to wire.
+
+---
+
+## Wiring
+
+Pin order below is Pimoroni's Breakout Garden header — check the silkscreen on
+your breakout:
+
+| Breakout pin | Connect to |
+|--------------|------------|
+| **3-5V** | 3V3 (or 5 V) |
+| **GND** | GND |
+| **SDA** | an I²C SDA pin — e.g. Pico **GP4** (I2C0) |
+| **SCL** | an I²C SCL pin — e.g. Pico **GP5** (I2C0) |
+| **INT** | *optional* — any GPIO, for the data-ready interrupt |
+
+---
+
+## MicroPython example
+
+First check the sensor is answering on the bus:
+
+```python
+from machine import I2C, Pin
+
+i2c = I2C(0, sda=Pin(4), scl=Pin(5), freq=400_000)
+print(i2c.scan())     # expect [104] (0x68) or [105] (0x69)
+```
+
+Pimoroni's custom MicroPython build includes a driver for their breakout, and
+[Snakie](https://www.snakie.org) bundles a plain-MicroPython `icm20948` driver
+with the part — with that on your board, reading all nine axes looks like this:
+
+```python
+from machine import I2C, Pin
+from icm20948 import ICM20948
+import time
+
+i2c = I2C(0, sda=Pin(4), scl=Pin(5), freq=400_000)
+imu = ICM20948(i2c)                # auto-detects 0x68 / 0x69
+
+while True:
+    ax, ay, az = imu.read_accel()  # g
+    gx, gy, gz = imu.read_gyro()   # degrees / second
+    mx, my, mz = imu.read_mag()    # microtesla (µT)
+    print("accel g   ", ax, ay, az)
+    print("gyro dps  ", gx, gy, gz)
+    print("mag  uT   ", mx, my, mz)
+    print("-")
+    time.sleep(0.5)
+```
+
+A quick sanity check: a flat, still board reads roughly **1 g on the Z axis**
+and about **0 °/s** on all gyro axes — gravity is always there, rotation isn't.
+
+---
+
+## Troubleshooting
+
+- **Nothing in `i2c.scan()`** → check SDA/SCL aren't swapped, and that power
+  and ground are solid. The sensor should show up as `104` (0x68) or `105`
+  (0x69).
+- **It scans but reads fail** → the bus can't clock data reliably: add strong
+  pull-up resistors on SDA and SCL to 3V3, shorten the wires, and check the
+  common ground. On **RP2350** boards use **~2.2 kΩ** pull-ups — erratum
+  RP2350-E9 makes the usual 4.7 kΩ marginal.
+- **Compass heading is off** → keep the sensor away from motors, speakers and
+  magnets, and calibrate for your local environment.
+
+---
+
+## Use it in Snakie
+
+The ICM20948 is in the Standard parts library of
+[Snakie](https://www.snakie.org), my free, open-source MicroPython editor.
+Drag it onto the Board View and Snakie shows you the wiring and copies the
+`icm20948` driver to your board — and the IMU instrument gives you a live 3-D
+attitude view driven straight from the sensor.
+
+---
+
+## Related learning
+
+- [I2C — GPIO Mastery course](/learn/micropython_gpio/12_i2c.html)
+- [I2C and SPI Explained](/learn/i2c_spi/) — scanning, datasheets and debugging
+- [Robotics with MicroPython](/learn/micropython_robotics/)

--- a/web/learn/parts/index.md
+++ b/web/learn/parts/index.md
@@ -1,0 +1,43 @@
+---
+title: Parts
+description: >-
+  Reference guides for common robotics parts — what each part is, how to wire it
+  up, and how to use it from MicroPython.
+layout: content
+---
+
+{% include breadcrumbs.html %}
+
+# Parts
+
+## Quick reference guides for common robotics parts
+
+Each guide covers what the part is, its key specs, how to wire it to a
+Raspberry Pi Pico (or any MicroPython board), and a small example program to
+get you going.
+
+These parts are also in the Standard parts library of
+[Snakie](https://www.snakie.org), my free, open-source MicroPython editor —
+drag a part onto the Board View and Snakie shows you where the wires go and
+hands you the driver and example code.
+
+---
+
+## The parts
+
+| Part | What it does |
+|------|--------------|
+| [SG90 Micro Servo](/learn/parts/sg90/) | 9 g hobby servo with ~180° of travel — pan/tilt rigs, grippers, robot legs |
+| [Potentiometer](/learn/parts/potentiometer/) | A rotary knob that gives you an analog value — the classic ADC input |
+| [BME280](/learn/parts/bme280/) | Bosch environmental sensor — temperature, pressure and humidity over I²C |
+| [ICM20948](/learn/parts/icm20948/) | 9-DoF motion sensor — accelerometer, gyroscope and magnetometer over I²C |
+
+---
+
+## Want to go deeper?
+
+These courses use the parts above:
+
+- [Raspberry Pi Pico with MicroPython — GPIO Mastery](/learn/micropython_gpio/) — PWM, ADC, I²C and more
+- [I2C and SPI Explained](/learn/i2c_spi/) — how the buses these sensors sit on actually work
+- [Learn MicroPython — The basics](/learn/micropython/) — start here if MicroPython is new to you

--- a/web/learn/parts/potentiometer/index.md
+++ b/web/learn/parts/potentiometer/index.md
@@ -1,0 +1,91 @@
+---
+title: Potentiometer
+description: >-
+  A potentiometer is a rotary variable resistor — the classic analog input.
+  Here's how to wire one to a Raspberry Pi Pico and read it with MicroPython's
+  ADC.
+layout: content
+---
+
+{% include breadcrumbs.html %}
+
+# Potentiometer
+
+A `potentiometer` ("pot") is a rotary variable resistor with three terminals.
+Wire the two outer pins to power and ground and the middle **wiper** pin forms
+a variable voltage divider — turning the knob sweeps the wiper voltage smoothly
+from 0 V up to the supply voltage. Read that voltage with an ADC pin and you've
+got a knob your code can react to: volume controls, speed dials, menu
+selectors, servo testers.
+
+The common hobby part is a **10 kΩ** rotary pot, which is a good value for
+microcontroller ADC inputs.
+
+You can learn more about [how potentiometers work here](/resources/how_it_works/pots.html).
+
+---
+
+## Wiring
+
+| Pin | Connect to |
+|-----|------------|
+| VCC (outer) | **3V3** |
+| OUT (middle, the wiper) | an ADC-capable GPIO — Pico: **GP26 / GP27 / GP28** |
+| GND (outer) | GND |
+
+Two things worth knowing on the Pico:
+
+- Only three ADC channels come out on the pins: **GP26 (ADC0)**, **GP27
+  (ADC1)** and **GP28 (ADC2)**.
+- Use **3V3** for the pot, not 5 V — the Pico's ADC inputs are 3.3 V max.
+
+If the value moves the "wrong way" when you turn the knob, just swap the two
+outer wires.
+
+---
+
+## MicroPython example
+
+With the wiper on **GP26**:
+
+```python
+from machine import ADC, Pin
+import time
+
+pot = ADC(Pin(26))                # OUT wired to GP26 (ADC0)
+
+while True:
+    raw = pot.read_u16()          # 0 … 65535
+    pct = raw * 100 // 65535      # 0 … 100 %
+    volts = raw / 65535 * 3.3
+    print(pct, "%", round(volts, 2), "V")
+    time.sleep(0.1)
+```
+
+`read_u16()` always returns a 16-bit value (0–65535), whatever the chip's
+actual ADC resolution — so the maths above works on any MicroPython board.
+
+The reading is always a little noisy. If you need a steadier value, average a
+few samples:
+
+```python
+def read_smooth(adc, samples=16):
+    return sum(adc.read_u16() for _ in range(samples)) // samples
+```
+
+---
+
+## Use it in Snakie
+
+The potentiometer is in the Standard parts library of
+[Snakie](https://www.snakie.org), my free, open-source MicroPython editor.
+Drag it onto the Board View to see the wiring, and the Potentiometer
+instrument — a vintage 0–100 % meter — follows the knob live as you turn it.
+
+---
+
+## Related learning
+
+- [Potentiometers — GPIO Mastery course](/learn/micropython_gpio/09_potentiometers.html)
+- [Analog to Digital Converters (ADC)](/learn/micropython_gpio/08_adc.html)
+- [How potentiometers work](/resources/how_it_works/pots.html)

--- a/web/learn/parts/sg90/index.md
+++ b/web/learn/parts/sg90/index.md
@@ -1,0 +1,126 @@
+---
+title: SG90 Micro Servo
+description: >-
+  The SG90 is a tiny, cheap 9 g hobby servo with around 180° of travel,
+  controlled by a 50 Hz PWM signal. Here's how to wire one to a Raspberry Pi
+  Pico and drive it from MicroPython.
+layout: content
+---
+
+{% include breadcrumbs.html %}
+
+# SG90 Micro Servo
+
+The `SG90` is the classic 9 g hobby servo — small, light, cheap, and
+everywhere. It gives you around 180° of controlled rotation from a single PWM
+signal, which makes it perfect for pan/tilt rigs, robot arms, grippers,
+walking robots and RC projects.
+
+You can learn more about [how servos work here](/resources/how_it_works/servos.html).
+
+---
+
+## Key specs
+
+| Spec | Value |
+|------|-------|
+| Weight | ~9 g |
+| Torque | ~1.8 kg·cm @ 4.8 V |
+| Speed | ~0.1 s / 60° |
+| Rotation | ~180° |
+| Operating voltage | 4.8–6 V |
+| Control signal | 50 Hz PWM, ~1–2 ms pulse width |
+
+---
+
+## Wiring
+
+The SG90 has three flying leads:
+
+| Wire | Signal | Connect to |
+|------|--------|-----------|
+| **Orange** | Signal (PWM) | any GPIO (e.g. Pico **GP16**) |
+| **Red** | VCC (+5 V) | a **5 V** supply (4.8–6 V) |
+| **Brown** | GND | GND — **shared** with your supply |
+
+> ⚠️ Don't power a servo from the Pico's **3V3** pin — servos draw big current
+> spikes under load and will brown the board out. Use the **VBUS** pin (5 V
+> from USB) or a separate 4.8–6 V supply, and make sure the grounds are
+> connected together.
+
+---
+
+## How the control signal works
+
+The servo expects a **50 Hz** signal — one pulse every 20 ms. The **width** of
+that pulse sets the angle:
+
+- **1.0 ms** → 0°
+- **1.5 ms** → 90° (centre)
+- **2.0 ms** → 180°
+
+Many SG90s accept a wider **0.5–2.5 ms** range for a fuller sweep — if your
+servo doesn't reach its end stops, widen the pulse range a little at a time.
+
+---
+
+## MicroPython example
+
+Using just the built-in `machine` module — signal wire on **GP16**:
+
+```python
+from machine import Pin, PWM
+import time
+
+servo = PWM(Pin(16))
+servo.freq(50)                      # 50 Hz — one pulse every 20 ms
+
+def angle(degrees):
+    # 0° = 500 µs, 180° = 2500 µs
+    pulse_us = 500 + (degrees / 180) * 2000
+    servo.duty_ns(int(pulse_us * 1000))
+
+angle(90)                           # centre
+time.sleep(1)
+angle(0)                            # one end
+time.sleep(1)
+angle(180)                          # the other end
+```
+
+If the servo buzzes when it's holding position at an end stop, stop sending
+pulses with `servo.deinit()` — it releases the holding torque and the buzzing
+stops.
+
+---
+
+## Dimensions
+
+![Dimensioned drawing of the SG90 micro servo](/assets/img/design/sg90.png){:class="img-fluid" loading="lazy"}
+
+The body is roughly **23 × 12 × 29 mm** with two mounting tabs (32.2 mm across
+the tabs), and the output shaft takes the usual push-fit horns.
+
+---
+
+## Troubleshooting
+
+- **Jitter / twitching** → shared ground plus a dedicated 5 V supply (not 3V3).
+- **Buzzing at rest** → `servo.deinit()` once it reaches the target.
+- **Limited range** → widen the pulse range (try 500–2500 µs) a little at a time.
+
+---
+
+## Use it in Snakie
+
+The SG90 is in the Standard parts library of [Snakie](https://www.snakie.org),
+my free, open-source MicroPython editor. Drag it onto the Board View and Snakie
+shows you the wiring, copies a ready-made `servo` driver to your board, and the
+Servo instrument gives you a dial you can drag to move the real servo live.
+
+---
+
+## Related learning
+
+- [Servos — GPIO Mastery course](/learn/micropython_gpio/14_servos.html)
+- [How servos work](/resources/how_it_works/servos.html)
+- [Robotics with MicroPython](/learn/micropython_robotics/)


### PR DESCRIPTION
Snakie's Standard parts library help panels cross-link to `https://www.kevsrobots.com/learn/parts/<part>/` (kevinmcaleer/Snakie#366). All four of those URLs currently return **404**. This PR adds the missing pages as hand-authored Jekyll pages under `web/learn/parts/` (plain pages, so `build.py`'s course build doesn't touch them), plus a small index page.

## Pages

| Page | URL | Contents |
|------|-----|----------|
| `web/learn/parts/index.md` | `/learn/parts/` | Index of the part guides, links to related courses, Snakie mention |
| `web/learn/parts/sg90/index.md` | `/learn/parts/sg90/` | SG90 specs, wire-colour table, 5 V power warning, PWM signal explainer, raw `machine.PWM` example, the existing dimensioned drawing (`/assets/img/design/sg90.png`), troubleshooting |
| `web/learn/parts/potentiometer/index.md` | `/learn/parts/potentiometer/` | Voltage-divider explainer, Pico ADC wiring (GP26–28), `read_u16()` example + smoothing snippet |
| `web/learn/parts/bme280/index.md` | `/learn/parts/bme280/` | What it measures, I²C addresses 0x76/0x77, BMP280 buying tip, Pico wiring, `i2c.scan()` + community `bme280` driver example |
| `web/learn/parts/icm20948/index.md` | `/learn/parts/icm20948/` | 9-DoF specs table, Breakout Garden pinout, `i2c.scan()` + driver example, troubleshooting (incl. RP2350-E9 pull-up note) |

## Notes

- Front matter follows the site's hand-authored pages (`layout: content` + `{% include breadcrumbs.html %}`), like `courses.md` / `discover.md`.
- Each page cross-links existing content: GPIO Mastery lessons (servos, potentiometers, ADC, I²C), the I2C & SPI Explained course's BME280 deep dive, and the pots/servos how-it-works pages — and mentions the part is in Snakie's parts library (snakie.org).
- **No new images**: only the already-existing SG90 dimensioned drawing is referenced.
- Part facts were taken from Snakie's part definitions and the sensors' well-established public specs; nothing speculative was included.

> **Please review before merging** — this is Kev's personal website, so I've deliberately left this PR unmerged for his review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)